### PR TITLE
TLS renegotiation

### DIFF
--- a/client.go
+++ b/client.go
@@ -41,7 +41,7 @@ func NewClient(cfg *Config) (endpoint.Connector, error) {
 	case endpoint.ConnectorTypeCloud:
 		connector = cloud.NewConnector(cfg.LogVerbose, connectionTrustBundle)
 	case endpoint.ConnectorTypeTPP:
-		connector = tpp.NewConnector(cfg.LogVerbose, connectionTrustBundle)
+		connector = tpp.NewConnector(cfg.LogVerbose, connectionTrustBundle, cfg.Renegotiate)
 	case endpoint.ConnectorTypeFake:
 		connector = fake.NewConnector(cfg.LogVerbose, connectionTrustBundle)
 	default:

--- a/config.go
+++ b/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	Zone            string
 	Credentials     *endpoint.Authentication
 	ConnectionTrust string // *x509.CertPool
+	Renegotiate     string
 	LogVerbose      bool
 	ConfigFile      string
 	ConfigSection   string

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -33,16 +33,17 @@ import (
 
 // Connector contains the base data needed to communicate with a TPP Server
 type Connector struct {
-	baseURL string
-	apiKey  string
-	verbose bool
-	trust   *x509.CertPool
-	zone    string
+	baseURL     string
+	apiKey      string
+	verbose     bool
+	trust       *x509.CertPool
+	zone        string
+	renegotiate string
 }
 
 // NewConnector creates a new TPP Connector object used to communicate with TPP
-func NewConnector(verbose bool, trust *x509.CertPool) *Connector {
-	c := Connector{trust: trust, verbose: verbose}
+func NewConnector(verbose bool, trust *x509.CertPool, renegotiate string) *Connector {
+	c := Connector{trust: trust, verbose: verbose, renegotiate: renegotiate}
 	return &c
 }
 

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"github.com/Venafi/vcert/pkg/certificate"
 	"github.com/Venafi/vcert/pkg/endpoint"
+	"log"
 	"net/http"
 	"regexp"
 	"strings"
@@ -243,8 +244,10 @@ func (c *Connector) getHTTPClient() *http.Client {
 	switch c.renegotiate {
 	case "always":
 		tlsConf.Renegotiation = tls.RenegotiateFreelyAsClient
+		log.Printf("Using renegotiation option %s", tlsConf.Renegotiation)
 	case "once":
 		tlsConf.Renegotiation = tls.RenegotiateOnceAsClient
+		log.Printf("Using renegotiation option %s", tlsConf.Renegotiation)
 	default:
 		tlsConf.Renegotiation = tls.RenegotiateNever
 	}

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -239,12 +239,22 @@ func (c *Connector) getURL(resource urlResource) (string, error) {
 }
 
 func (c *Connector) getHTTPClient() *http.Client {
-	if c.trust != nil {
-		tr := &http.Transport{TLSClientConfig: &tls.Config{RootCAs: c.trust}}
-		return &http.Client{Transport: tr}
+	tlsConf := &tls.Config{}
+	switch c.renegotiate {
+	case "always":
+		tlsConf.Renegotiation = tls.RenegotiateFreelyAsClient
+	case "once":
+		tlsConf.Renegotiation = tls.RenegotiateOnceAsClient
+	default:
+		tlsConf.Renegotiation = tls.RenegotiateNever
 	}
 
-	return http.DefaultClient
+	if c.trust != nil {
+		tlsConf.RootCAs = c.trust
+	}
+
+	tr := &http.Transport{TLSClientConfig: tlsConf}
+	return &http.Client{Transport: tr}
 }
 
 //GenerateRequest creates a new certificate request, based on the zone/policy configuration and the user data


### PR DESCRIPTION
Adding optional TLS renegotiation for vCert client
Options:
always = RenegotiateFreelyAsClient
once = RenegotiateOnceAsClient
empty or other = RenegotiateNever

See https://golang.org/pkg/crypto/tls/#RenegotiationSupport