### PR TITLE
Add http.Client as an option for construction of a new client

### DIFF
--- a/client.go
+++ b/client.go
@@ -19,6 +19,7 @@ package vcert
 import (
 	"crypto/x509"
 	"fmt"
+
 	"github.com/Venafi/vcert/pkg/endpoint"
 	"github.com/Venafi/vcert/pkg/venafi/cloud"
 	"github.com/Venafi/vcert/pkg/venafi/fake"
@@ -29,9 +30,7 @@ import (
 // Config should have Credentials compatible with the selected ConnectorType.
 // Returned connector is a concurrency-safe interface to TPP or Venafi Cloud that can be reused without restriction.
 // Connector can also be of type "fake" for local tests, which doesn`t connect to any backend and all certificates enroll locally.
-func NewClient(cfg *Config) (endpoint.Connector, error) {
-	var err error
-
+func (cfg *Config) NewClient() (connector endpoint.Connector, err error) {
 	var connectionTrustBundle *x509.CertPool
 	if cfg.ConnectionTrust != "" {
 		fmt.Println("You specified a trust bundle.")
@@ -41,29 +40,31 @@ func NewClient(cfg *Config) (endpoint.Connector, error) {
 		}
 	}
 
-	var connector endpoint.Connector
 	switch cfg.ConnectorType {
 	case endpoint.ConnectorTypeCloud:
 		connector, err = cloud.NewConnector(cfg.BaseUrl, cfg.Zone, cfg.LogVerbose, connectionTrustBundle)
-		if err != nil {
-			return nil, err
-		}
 	case endpoint.ConnectorTypeTPP:
 		connector, err = tpp.NewConnector(cfg.BaseUrl, cfg.Zone, cfg.LogVerbose, connectionTrustBundle)
-		if err != nil {
-			return nil, err
-		}
 	case endpoint.ConnectorTypeFake:
 		connector = fake.NewConnector(cfg.LogVerbose, connectionTrustBundle)
 	default:
-		return nil, fmt.Errorf("ConnectorType is not defined")
+		err = fmt.Errorf("ConnectorType is not defined")
+	}
+	if err != nil {
+		return
 	}
 
 	connector.SetZone(cfg.Zone)
+	connector.SetHTTPClient(cfg.Client)
 
 	err = connector.Authenticate(cfg.Credentials)
-	if err != nil {
-		return nil, err
-	}
-	return connector, nil
+	return
+}
+
+// NewClient returns a connector for either Trust Protection Platform (TPP) or Venafi Cloud based on provided configuration.
+// Config should have Credentials compatible with the selected ConnectorType.
+// Returned connector is a concurrency-safe interface to TPP or Venafi Cloud that can be reused without restriction.
+// Connector can also be of type "fake" for local tests, which doesn`t connect to any backend and all certificates enroll locally.
+func NewClient(cfg *Config) (endpoint.Connector, error) {
+	return cfg.NewClient()
 }

--- a/config.go
+++ b/config.go
@@ -18,12 +18,14 @@ package vcert
 
 import (
 	"fmt"
-	"github.com/Venafi/vcert/pkg/endpoint"
-	"gopkg.in/ini.v1"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"os/user"
 	"path/filepath"
+
+	"github.com/Venafi/vcert/pkg/endpoint"
+	"gopkg.in/ini.v1"
 )
 
 // Config is a basic structure for high level initiating connector to Trust Platform (TPP)/Venafi Cloud
@@ -39,9 +41,11 @@ type Config struct {
 	// ConnectionTrust  may contain a trusted CA or certificate of server if you use self-signed certificate.
 	ConnectionTrust string // *x509.CertPool
 	LogVerbose      bool
+	// http.Client to use durring construction
+	Client *http.Client
 }
 
-// LoadFromFile is deprecated. In the future will be rewrited.
+// LoadConfigFromFile is deprecated. In the future will be rewrited.
 func LoadConfigFromFile(path, section string) (cfg Config, err error) {
 
 	if section == "" {


### PR DESCRIPTION
When using custom clients we still ran into authentication failures when using the Client from config feature. This can be recreated by putting VCert TPP behind anything that will require a custom client. Or in the case that we use a test instance with a certificate that doesn't validate and disable certificate verification for our TPP instance.

This just adds the ability to set a client in the config so it is set before the call to `connector.Authenticate`