### PR TITLE
Remove mixed use of named and non-named return parameters

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -355,18 +355,17 @@ func curveInSlice(i certificate.EllipticCurve, s []certificate.EllipticCurve) bo
 	return false
 }
 
-func checkStringByRegexp(s string, regexs []string) (matched bool) {
-	var err error
+func checkStringByRegexp(s string, regexs []string) bool {
 	for _, r := range regexs {
-		matched, err = regexp.MatchString(r, s)
+		matched, err := regexp.MatchString(r, s)
 		if err == nil && matched {
 			return true
 		}
 	}
-	return
+	return false
 }
 
-func isComponentValid(ss []string, regexs []string, optional bool) (matched bool) {
+func isComponentValid(ss []string, regexs []string, optional bool) bool {
 	if optional && len(ss) == 0 {
 		return true
 	}


### PR DESCRIPTION
While debugging my tests I found the `checkStringByRegexp` and `isComponentValid` had named return parameters but then used a `return true` which specifically set the return value.
I have removed the name from the return parameters to have more consistent returns.