### PR TITLE
Set policy on fake ReadZoneConfiguration()

### DIFF
--- a/pkg/venafi/fake/connector.go
+++ b/pkg/venafi/fake/connector.go
@@ -229,7 +229,10 @@ func (c *Connector) RevokeCertificate(revReq *certificate.RevocationRequest) (er
 }
 
 func (c *Connector) ReadZoneConfiguration() (config *endpoint.ZoneConfiguration, err error) {
-	return endpoint.NewZoneConfiguration(), nil
+	config = endpoint.NewZoneConfiguration()
+	policy, err := c.ReadPolicyConfiguration()
+	config.Policy = *policy
+	return
 }
 
 // RenewCertificate attempts to renew the certificate


### PR DESCRIPTION
Currently there is no policy set in the zone configuration in fake which will fail validation later on.

When updating the module i found our tests to be failing on validating the CSR.
We use the fake connector as client in our tests
https://github.com/jetstack/cert-manager/blob/master/pkg/internal/venafi/sign_test.go#L197 
From which we use `client.ReadZoneConfiguration()` to get the zone configuration and then validate the CSR, however in the fake package it seems to not pass through the fake policy to the zone configuration.
I added this to `ReadZoneConfiguration` and everything works fine again.

Feedback welcome, hope I understood why this failed correct :smiley: 