### PR TITLE
Add metadata save to tpp19.2 and lower

### DIFF
--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -259,7 +259,7 @@ func wrapAltNames(req *certificate.Request) (items []sanItem) {
 }
 
 func prepareLegacyMetadata(c *Connector, metaItems []customField, dn string) (items []guidData, err error) {
-	metadataItems, err := c.RequestAllMetadataItems(dn)
+	metadataItems, err := c.requestAllMetadataItems(dn)
 	if nil != err {
 		return nil, err
 	}
@@ -279,8 +279,8 @@ func prepareLegacyMetadata(c *Connector, metaItems []customField, dn string) (it
 }
 
 //RequestAllMetadataItems returns all possible metadata items for a DN
-func (c *Connector) RequestAllMetadataItems(dn string) (items []metadataItem, err error) {
-	statusCode, status, body, err := c.request("POST", urlResourceMetadataGet, metadataGetItemsRequest{dn})
+func (c *Connector) requestAllMetadataItems(dn string) (items []metadataItem, err error) {
+	statusCode, status, body, err := c.request("POST", urlResourceAllMetadataGet, metadataGetItemsRequest{dn})
 	if err != nil {
 		return nil, err
 	}
@@ -296,8 +296,26 @@ func (c *Connector) RequestAllMetadataItems(dn string) (items []metadataItem, er
 	return response.Items, nil
 }
 
+//RequestMetadataItems returns metadata items for a DN that have a value stored
+func (c *Connector) requestMetadataItems(dn string) (items []metadataKeyValueSet, err error) {
+	statusCode, status, body, err := c.request("POST", urlResourceMetadataGet, metadataGetItemsRequest{dn})
+	if err != nil {
+		return nil, err
+	}
+	if statusCode != http.StatusOK {
+		return nil, fmt.Errorf("Unexpected http status code while fetching certificate metadata items. %d-%s", statusCode, status)
+	}
+
+	response := metadataGetResponse{}
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return nil, fmt.Errorf("%s", err)
+	}
+	return response.Data, nil
+}
+
 //RequestSystemVersion returns the TPP system version of the connector context
-func (c *Connector) RequestSystemVersion() (ver string, err error) {
+func (c *Connector) requestSystemVersion() (ver string, err error) {
 	statusCode, status, body, err := c.request("GET", urlResourceSystemStatusVersion, "")
 	if err != nil {
 		return "", fmt.Errorf("%s", err)
@@ -321,7 +339,14 @@ func (c *Connector) RequestSystemVersion() (ver string, err error) {
 }
 
 //SetCertificateMetadata submits the metadata to TPP for storage returning the lock status of the metadata stored
-func (c *Connector) SetCertificateMetadata(metadataRequest metadataSetRequest) (locked bool, err error) {
+func (c *Connector) setCertificateMetadata(metadataRequest metadataSetRequest) (locked bool, err error) {
+	if len(metadataRequest.DN) < 1 {
+		return false, fmt.Errorf("DN must be provided to setCertificateMetaData")
+	}
+	if len(metadataRequest.GuidData) < 1 && metadataRequest.KeepExisting {
+		return false, nil
+	} //Not an error, but there is nothing to do
+
 	statusCode, status, body, err := c.request("POST", urlResourceMetadataSet, metadataRequest)
 	if err != nil {
 		return false, fmt.Errorf("%s", err)
@@ -399,12 +424,13 @@ func (c *Connector) RequestCertificate(req *certificate.Request) (requestID stri
 	//Handle legacy TPP custom field API
 	if len(req.CustomFields) > 0 {
 		//Check to see if this is 19.2 or lower
-		tppVersion, err := c.RequestSystemVersion()
+		//If the call returns metatdata items then the system version must be 19.3 or above,
+		//if not, try to use the 19.2 metadata save method
+		metadataItems, err := c.requestMetadataItems(requestID)
 		if err != nil {
 			return "", fmt.Errorf("%s", err)
 		}
-
-		if "19.2.999" > tppVersion {
+		if len(metadataItems) < 1 {
 			//Create a metadata/set command with the metadata from tppCertificateRequest
 			guidItems, err := prepareLegacyMetadata(c, tppCertificateRequest.CustomFields, requestID)
 			if err != nil {
@@ -412,7 +438,7 @@ func (c *Connector) RequestCertificate(req *certificate.Request) (requestID stri
 			}
 			requestData := metadataSetRequest{requestID, guidItems, true}
 			//c.request with the metadata request
-			_, err = c.SetCertificateMetadata(requestData)
+			_, err = c.setCertificateMetadata(requestData)
 			if err != nil {
 				return "", fmt.Errorf("%s", err)
 			}

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -24,9 +24,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"github.com/Venafi/vcert/pkg/certificate"
-	"github.com/Venafi/vcert/pkg/endpoint"
-	"github.com/Venafi/vcert/test"
 	"net/http"
 	"net/url"
 	"os"
@@ -34,6 +31,10 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Venafi/vcert/pkg/certificate"
+	"github.com/Venafi/vcert/pkg/endpoint"
+	"github.com/Venafi/vcert/test"
 )
 
 var ctx *test.Context
@@ -54,7 +55,7 @@ func init() {
 
 	resp, err := tpp.GetRefreshToken(&endpoint.Authentication{
 		User: ctx.TPPuser, Password: ctx.TPPPassword,
-		Scope: "certificate:approve,delete,discover,manage,revoke;"})
+		Scope: "certificate:approve,delete,discover,manage,revoke;configuration"})
 	if err != nil {
 		panic(err)
 	}
@@ -439,7 +440,10 @@ func TestRequestCertificateServiceGenerated(t *testing.T) {
 	req.CsrOrigin = certificate.ServiceGeneratedCSR
 	req.FetchPrivateKey = true
 	req.KeyPassword = "newPassw0rd!"
-
+	req.CustomFields = []certificate.CustomField{
+		certificate.CustomField{Type: certificate.CustomFieldPlain, Name: "TestField", Value: "Value 1"},
+		certificate.CustomField{Type: certificate.CustomFieldPlain, Name: "TestField2", Value: "TRUE"},
+	}
 	config.UpdateCertificateRequest(req)
 
 	pickupId, err := tpp.RequestCertificate(req)

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -55,7 +55,7 @@ func init() {
 
 	resp, err := tpp.GetRefreshToken(&endpoint.Authentication{
 		User: ctx.TPPuser, Password: ctx.TPPPassword,
-		Scope: "certificate:approve,delete,discover,manage,revoke;configuration"})
+		Scope: "certificate:approve,delete,discover,manage,revoke;"})
 	if err != nil {
 		panic(err)
 	}
@@ -440,10 +440,6 @@ func TestRequestCertificateServiceGenerated(t *testing.T) {
 	req.CsrOrigin = certificate.ServiceGeneratedCSR
 	req.FetchPrivateKey = true
 	req.KeyPassword = "newPassw0rd!"
-	req.CustomFields = []certificate.CustomField{
-		certificate.CustomField{Type: certificate.CustomFieldPlain, Name: "TestField", Value: "Value 1"},
-		certificate.CustomField{Type: certificate.CustomFieldPlain, Name: "TestField2", Value: "TRUE"},
-	}
 	config.UpdateCertificateRequest(req)
 
 	pickupId, err := tpp.RequestCertificate(req)

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -208,9 +208,13 @@ type metadataItem struct {
 	RenderReadOnly    bool     `json:",omitempty"`
 	Type              int      `json:",omitempty"`
 }
+type metadataKeyValueSet struct {
+	Key   metadataItem `json:",omitempty"`
+	Value []string     `json:",omitempty"`
+}
 type metadataResultCode int
 
-var MetadataResultCodesMap = map[string]metadataResultCode{
+var metadataResultCodesMap = map[string]metadataResultCode{
 	"":                         0,  //Empty is assumed success
 	"Success":                  0,  //(Indicates the API call was successful.)
 	"InvalidConfigObject":      1,  //Config object is invalid. + [Error].
@@ -248,6 +252,11 @@ type metadataGetItemsResponse struct {
 	Locked bool               `json:",omitempty"`
 	Result metadataResultCode `json:",omitempty"`
 }
+type metadataGetResponse struct {
+	Data   []metadataKeyValueSet
+	Locked bool               `json:",omitempty"`
+	Result metadataResultCode `json:",omitempty"`
+}
 type guidData struct {
 	ItemGuid string   `json:",omitempty"`
 	List     []string `json:",omitempty"`
@@ -280,7 +289,8 @@ const (
 	urlResourceCertificatePolicy    urlResource = "vedsdk/certificates/checkpolicy"
 	urlResourceCertificatesList     urlResource = "vedsdk/certificates/"
 	urlResourceMetadataSet          urlResource = "vedsdk/metadata/set"
-	urlResourceMetadataGet          urlResource = "vedsdk/metadata/getitems"
+	urlResourceAllMetadataGet       urlResource = "vedsdk/metadata/getitems"
+	urlResourceMetadataGet          urlResource = "vedsdk/metadata/get"
 	urlResourceSystemStatusVersion  urlResource = "vedsdk/SystemStatus/Version"
 )
 

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -191,6 +191,77 @@ type policyRequest struct {
 	Class         string `json:",omitempty"`
 	AttributeName string `json:",omitempty"`
 }
+type metadataItem struct {
+	AllowedValues     []string `json:",omitempty"`
+	Classes           []string `json:",omitempty"`
+	ConfigAttribute   string   `json:",omitempty"`
+	DefaultValues     []string `json:",omitempty"`
+	DN                string   `json:",omitempty"`
+	ErrorMessage      string   `json:",omitempty"`
+	Guid              string   `json:",omitempty"`
+	Help              string   `json:",omitempty"`
+	Label             string   `json:",omitempty"`
+	Name              string   `json:",omitempty"`
+	Policyable        bool     `json:",omitempty"`
+	RegularExpression string   `json:",omitempty"`
+	RenderHidden      bool     `json:",omitempty"`
+	RenderReadOnly    bool     `json:",omitempty"`
+	Type              int      `json:",omitempty"`
+}
+type metadataResultCode int
+
+var MetadataResultCodesMap = map[string]metadataResultCode{
+	"":                         0,  //Empty is assumed success
+	"Success":                  0,  //(Indicates the API call was successful.)
+	"InvalidConfigObject":      1,  //Config object is invalid. + [Error].
+	"InvalidDN":                2,  //DN is invalid. + [Error].
+	"InvalidName":              3,  //Metadata object name is invalid.
+	"InvalidItem":              4,  //Item is invalid. + [Error].
+	"InvalidClass":             5,  //Class is invalid. + [Error].
+	"InvalidMetadataObject":    6,  //Metadata object is invalid.
+	"InvalidRights":            7,  //Object rights are invalid.+ [Error].
+	"ItemIsNull":               8,  //Item is missing or empty. + [Error].
+	"ItemAlreadyExists":        9,  //Duplicate item. + [Error].
+	"ItemTypeUnknown":          10, //Item type is unknown. + [Error].
+	"ConfigCreateFailed":       11, //Config object failed to create. + [Error].
+	"ConfigWriteFailed":        12, //Config object failed to write. + [Error].
+	"ConfigDeleteFailed":       13, //Config object failed to delete.
+	"MetadataInUse":            14, //Metadata item is in use. + [Error].
+	"NoAllowedValues":          15, //Metadata item has invalid values.
+	"AllowedValueDoesNotExist": 16, //The required object does not exist or you do not have rights to read it.
+	"ValueNotInAllowedList":    17, //Value is invalid.
+	"ItemNotValidForClass":     18, //Item is not valid for class. + [Error].
+	"NameTooLong":              19, //Metadata item name is too long. + [Error].
+	"TooManyContainers":        20, //Nesting is too deep. + [Error].
+	"ConfigDnNotContainer":     21, //DN is invalid.+ [Error].
+	"InvalidPolicyState":       22, //Policy state is invalid.
+	"ConfigLockFailed":         23, //Config lock failed.
+	"ConfigReadFailed":         24, //Config object failed to read.+ [Error].
+	"RemoteError":              25, //Remote request failed.
+}
+
+type metadataGetItemsRequest struct {
+	ObjectDN string `json:"DN"`
+}
+type metadataGetItemsResponse struct {
+	Items  []metadataItem     `json:",omitempty"`
+	Locked bool               `json:",omitempty"`
+	Result metadataResultCode `json:",omitempty"`
+}
+type guidData struct {
+	ItemGuid string   `json:",omitempty"`
+	List     []string `json:",omitempty"`
+}
+type metadataSetRequest struct {
+	DN           string     `json:"DN"`
+	GuidData     []guidData `json:"GuidData"`
+	KeepExisting bool       `json:"KeepExisting"`
+}
+type metadataSetResponse struct {
+	Locked bool               `json:",omitempty"`
+	Result metadataResultCode `json:",omitempty"`
+}
+type systemStatusVersionResponse string
 
 type urlResource string
 
@@ -208,6 +279,9 @@ const (
 	urlResourceCertificateImport    urlResource = "vedsdk/certificates/import"
 	urlResourceCertificatePolicy    urlResource = "vedsdk/certificates/checkpolicy"
 	urlResourceCertificatesList     urlResource = "vedsdk/certificates/"
+	urlResourceMetadataSet          urlResource = "vedsdk/metadata/set"
+	urlResourceMetadataGet          urlResource = "vedsdk/metadata/getitems"
+	urlResourceSystemStatusVersion  urlResource = "vedsdk/SystemStatus/Version"
 )
 
 const (
@@ -487,6 +561,19 @@ func parseRenewResult(httpStatusCode int, httpStatus string, body []byte) (resp 
 }
 
 func parseRenewData(b []byte) (data certificateRenewResponse, err error) {
+	err = json.Unmarshal(b, &data)
+	return
+}
+
+//SystemStatus/Version
+func parseSystemStatusVersionResult(httpStatusCode int, httpStatus string, body []byte) (resp systemStatusVersionResponse, err error) {
+	resp, err = parseSystemStatusVersionData(body)
+	if err != nil {
+		return resp, fmt.Errorf("failed to parse SystemStatus Version response. status: %s", httpStatus)
+	}
+	return resp, nil
+}
+func parseSystemStatusVersionData(b []byte) (data systemStatusVersionResponse, err error) {
 	err = json.Unmarshal(b, &data)
 	return
 }


### PR DESCRIPTION
Added metadata to the TestRequestCertificateServiceGenerated test. 

- In order for the tests to pass, the test TPP servers must have metadata fields "TestField" and "TestField2" both of type string and enabled for certificates.

- I changed the tests to include the 'configuration' OAuth scope. This is needed as the code calls to /SystemStatus/Version that needs this privilege. **It will break users who are currently using metadata in 19.3 as they will need to include this scope by default in any enroll call that includes metadata.**

I tested against TPP 19.2.1.7205 and 19.3.0.4463 which represented the edge cases for the added logic.
 