### PR TITLE
Metadata192 lower

### DIFF
--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -258,6 +258,95 @@ func wrapAltNames(req *certificate.Request) (items []sanItem) {
 	return items
 }
 
+func prepareLegacyMetadata(c *Connector, metaItems []customField, dn string) (items []guidData, err error) {
+	metadataItems, err := c.RequestAllMetadataItems(dn)
+	if nil != err {
+		return nil, err
+	}
+	customFieldsGUIDMap := make(map[string]string)
+	for _, item := range metadataItems {
+		customFieldsGUIDMap[item.Label] = item.Guid
+	}
+
+	requestGUIDData := []guidData{}
+	for _, item := range metaItems {
+		guid := customFieldsGUIDMap[item.Name]
+		if len(guid) > 0 {
+			requestGUIDData = append(requestGUIDData, guidData{guid, item.Values})
+		}
+	}
+	return requestGUIDData, nil
+}
+
+//RequestAllMetadataItems returns all possible metadata items for a DN
+func (c *Connector) RequestAllMetadataItems(dn string) (items []metadataItem, err error) {
+	statusCode, status, body, err := c.request("POST", urlResourceMetadataGet, metadataGetItemsRequest{dn})
+	if err != nil {
+		return nil, err
+	}
+	if statusCode != http.StatusOK {
+		return nil, fmt.Errorf("Unexpected http status code while fetching metadata items. %d-%s", statusCode, status)
+	}
+
+	response := metadataGetItemsResponse{}
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return nil, fmt.Errorf("%s", err)
+	}
+	return response.Items, nil
+}
+
+//RequestSystemVersion returns the TPP system version of the connector context
+func (c *Connector) RequestSystemVersion() (ver string, err error) {
+	statusCode, status, body, err := c.request("GET", urlResourceSystemStatusVersion, "")
+	if err != nil {
+		return "", fmt.Errorf("%s", err)
+	}
+	//Put in hint for authentication scope 'configuration'
+	switch statusCode {
+	case 200:
+		break
+	case 401:
+		return "", fmt.Errorf("http status code '%s' was returned by the server. Hint: OAuth scope 'configuration' is required when using custom fields", status)
+	default:
+		return "", fmt.Errorf("Unexpected http status code while fetching TPP version. %s", status)
+	}
+	type responseType struct{ Version string }
+	response := responseType{}
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return "", fmt.Errorf("%s", err)
+	}
+	return response.Version, nil
+}
+
+//SetCertificateMetadata submits the metadata to TPP for storage returning the lock status of the metadata stored
+func (c *Connector) SetCertificateMetadata(metadataRequest metadataSetRequest) (locked bool, err error) {
+	statusCode, status, body, err := c.request("POST", urlResourceMetadataSet, metadataRequest)
+	if err != nil {
+		return false, fmt.Errorf("%s", err)
+	}
+	if statusCode != http.StatusOK {
+		return false, fmt.Errorf("Unexpected http status code while setting metadata items. %d-%s", statusCode, status)
+	}
+
+	var result = metadataSetResponse{}
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return false, fmt.Errorf("%s", err)
+	}
+
+	switch result.Result {
+	case 0:
+		break
+	case 17:
+		return false, fmt.Errorf("custom field value not a valid list item. Server returned error %d", result.Result)
+	default:
+		return false, fmt.Errorf("return code %d was returned while adding metadata to %s. Please refer to the Metadata Result Codes in the TPP WebSDK API documentation to determine if further action is needed", result.Result, metadataRequest.DN)
+	}
+	return result.Locked, nil
+}
+
 func prepareRequest(req *certificate.Request, zone string) (tppReq certificateRequest, err error) {
 	switch req.CsrOrigin {
 	case certificate.LocalGeneratedCSR, certificate.UserProvidedCSR:
@@ -395,6 +484,28 @@ func (c *Connector) RequestCertificate(req *certificate.Request) (requestID stri
 		return "", fmt.Errorf("%s", err)
 	}
 
+	//Handle legacy TPP custom field API
+	if len(req.CustomFields) > 0 {
+		//Check to see if this is 19.2 or lower
+		tppVersion, err := c.RequestSystemVersion()
+		if err != nil {
+			return "", fmt.Errorf("%s", err)
+		}
+
+		if "19.2.999" > tppVersion {
+			//Create a metadata/set command with the metadata from tppCertificateRequest
+			guidItems, err := prepareLegacyMetadata(c, tppCertificateRequest.CustomFields, requestID)
+			if err != nil {
+				return "", fmt.Errorf("%s", err)
+			}
+			requestData := metadataSetRequest{requestID, guidItems, true}
+			//c.request with the metadata request
+			_, err = c.SetCertificateMetadata(requestData)
+			if err != nil {
+				return "", fmt.Errorf("%s", err)
+			}
+		}
+	}
 	req.PickupID = requestID
 	return requestID, nil
 }

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -24,9 +24,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"github.com/Venafi/vcert/pkg/certificate"
-	"github.com/Venafi/vcert/pkg/endpoint"
-	"github.com/Venafi/vcert/test"
 	"net/http"
 	"net/url"
 	"os"
@@ -34,6 +31,10 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Venafi/vcert/pkg/certificate"
+	"github.com/Venafi/vcert/pkg/endpoint"
+	"github.com/Venafi/vcert/test"
 )
 
 var ctx *test.Context
@@ -54,7 +55,7 @@ func init() {
 
 	resp, err := tpp.GetRefreshToken(&endpoint.Authentication{
 		User: ctx.TPPuser, Password: ctx.TPPPassword,
-		Scope: "certificate:approve,delete,discover,manage,revoke;"})
+		Scope: "certificate:approve,delete,discover,manage,revoke;configuration"})
 	if err != nil {
 		panic(err)
 	}
@@ -439,7 +440,10 @@ func TestRequestCertificateServiceGenerated(t *testing.T) {
 	req.CsrOrigin = certificate.ServiceGeneratedCSR
 	req.FetchPrivateKey = true
 	req.KeyPassword = "newPassw0rd!"
-
+	req.CustomFields = []certificate.CustomField{
+		certificate.CustomField{Type: certificate.CustomFieldPlain, Name: "TestField", Value: "Value 1"},
+		certificate.CustomField{Type: certificate.CustomFieldPlain, Name: "TestField2", Value: "TRUE"},
+	}
 	config.UpdateCertificateRequest(req)
 
 	pickupId, err := tpp.RequestCertificate(req)

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -55,7 +55,7 @@ func init() {
 
 	resp, err := tpp.GetRefreshToken(&endpoint.Authentication{
 		User: ctx.TPPuser, Password: ctx.TPPPassword,
-		Scope: "certificate:approve,delete,discover,manage,revoke;configuration"})
+		Scope: "certificate:approve,delete,discover,manage,revoke;"})
 	if err != nil {
 		panic(err)
 	}
@@ -440,10 +440,6 @@ func TestRequestCertificateServiceGenerated(t *testing.T) {
 	req.CsrOrigin = certificate.ServiceGeneratedCSR
 	req.FetchPrivateKey = true
 	req.KeyPassword = "newPassw0rd!"
-	req.CustomFields = []certificate.CustomField{
-		certificate.CustomField{Type: certificate.CustomFieldPlain, Name: "TestField", Value: "Value 1"},
-		certificate.CustomField{Type: certificate.CustomFieldPlain, Name: "TestField2", Value: "TRUE"},
-	}
 	config.UpdateCertificateRequest(req)
 
 	pickupId, err := tpp.RequestCertificate(req)

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -230,37 +230,8 @@ type metadataKeyValueSet struct {
 	Key   metadataItem `json:",omitempty"`
 	Value []string     `json:",omitempty"`
 }
-type metadataResultCode int
 
-var metadataResultCodesMap = map[string]metadataResultCode{
-	"":                         0,  //Empty is assumed success
-	"Success":                  0,  //(Indicates the API call was successful.)
-	"InvalidConfigObject":      1,  //Config object is invalid. + [Error].
-	"InvalidDN":                2,  //DN is invalid. + [Error].
-	"InvalidName":              3,  //Metadata object name is invalid.
-	"InvalidItem":              4,  //Item is invalid. + [Error].
-	"InvalidClass":             5,  //Class is invalid. + [Error].
-	"InvalidMetadataObject":    6,  //Metadata object is invalid.
-	"InvalidRights":            7,  //Object rights are invalid.+ [Error].
-	"ItemIsNull":               8,  //Item is missing or empty. + [Error].
-	"ItemAlreadyExists":        9,  //Duplicate item. + [Error].
-	"ItemTypeUnknown":          10, //Item type is unknown. + [Error].
-	"ConfigCreateFailed":       11, //Config object failed to create. + [Error].
-	"ConfigWriteFailed":        12, //Config object failed to write. + [Error].
-	"ConfigDeleteFailed":       13, //Config object failed to delete.
-	"MetadataInUse":            14, //Metadata item is in use. + [Error].
-	"NoAllowedValues":          15, //Metadata item has invalid values.
-	"AllowedValueDoesNotExist": 16, //The required object does not exist or you do not have rights to read it.
-	"ValueNotInAllowedList":    17, //Value is invalid.
-	"ItemNotValidForClass":     18, //Item is not valid for class. + [Error].
-	"NameTooLong":              19, //Metadata item name is too long. + [Error].
-	"TooManyContainers":        20, //Nesting is too deep. + [Error].
-	"ConfigDnNotContainer":     21, //DN is invalid.+ [Error].
-	"InvalidPolicyState":       22, //Policy state is invalid.
-	"ConfigLockFailed":         23, //Config lock failed.
-	"ConfigReadFailed":         24, //Config object failed to read.+ [Error].
-	"RemoteError":              25, //Remote request failed.
-}
+type metadataResultCode int
 
 type metadataGetItemsRequest struct {
 	ObjectDN string `json:"DN"`
@@ -311,10 +282,10 @@ const (
 	urlResourceConfigReadDn           urlResource = "vedsdk/Config/ReadDn"
 	urlResourceFindPolicy             urlResource = "vedsdk/config/findpolicy"
 	urlResourceRefreshAccessToken     urlResource = "vedauth/authorize/token"
-	urlResourceMetadataSet          urlResource = "vedsdk/metadata/set"
-	urlResourceAllMetadataGet       urlResource = "vedsdk/metadata/getitems"
-	urlResourceMetadataGet          urlResource = "vedsdk/metadata/get"
-	urlResourceSystemStatusVersion  urlResource = "vedsdk/SystemStatus/Version"
+	urlResourceMetadataSet            urlResource = "vedsdk/metadata/set"
+	urlResourceAllMetadataGet         urlResource = "vedsdk/metadata/getitems"
+	urlResourceMetadataGet            urlResource = "vedsdk/metadata/get"
+	urlResourceSystemStatusVersion    urlResource = "vedsdk/SystemStatus/Version"
 )
 
 const (

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -226,9 +226,13 @@ type metadataItem struct {
 	RenderReadOnly    bool     `json:",omitempty"`
 	Type              int      `json:",omitempty"`
 }
+type metadataKeyValueSet struct {
+	Key   metadataItem `json:",omitempty"`
+	Value []string     `json:",omitempty"`
+}
 type metadataResultCode int
 
-var MetadataResultCodesMap = map[string]metadataResultCode{
+var metadataResultCodesMap = map[string]metadataResultCode{
 	"":                         0,  //Empty is assumed success
 	"Success":                  0,  //(Indicates the API call was successful.)
 	"InvalidConfigObject":      1,  //Config object is invalid. + [Error].
@@ -263,6 +267,11 @@ type metadataGetItemsRequest struct {
 }
 type metadataGetItemsResponse struct {
 	Items  []metadataItem     `json:",omitempty"`
+	Locked bool               `json:",omitempty"`
+	Result metadataResultCode `json:",omitempty"`
+}
+type metadataGetResponse struct {
+	Data   []metadataKeyValueSet
 	Locked bool               `json:",omitempty"`
 	Result metadataResultCode `json:",omitempty"`
 }
@@ -303,7 +312,8 @@ const (
 	urlResourceFindPolicy             urlResource = "vedsdk/config/findpolicy"
 	urlResourceRefreshAccessToken     urlResource = "vedauth/authorize/token"
 	urlResourceMetadataSet          urlResource = "vedsdk/metadata/set"
-	urlResourceMetadataGet          urlResource = "vedsdk/metadata/getitems"
+	urlResourceAllMetadataGet       urlResource = "vedsdk/metadata/getitems"
+	urlResourceMetadataGet          urlResource = "vedsdk/metadata/get"
 	urlResourceSystemStatusVersion  urlResource = "vedsdk/SystemStatus/Version"
 )
 

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -209,6 +209,77 @@ type policyRequest struct {
 	Class         string `json:",omitempty"`
 	AttributeName string `json:",omitempty"`
 }
+type metadataItem struct {
+	AllowedValues     []string `json:",omitempty"`
+	Classes           []string `json:",omitempty"`
+	ConfigAttribute   string   `json:",omitempty"`
+	DefaultValues     []string `json:",omitempty"`
+	DN                string   `json:",omitempty"`
+	ErrorMessage      string   `json:",omitempty"`
+	Guid              string   `json:",omitempty"`
+	Help              string   `json:",omitempty"`
+	Label             string   `json:",omitempty"`
+	Name              string   `json:",omitempty"`
+	Policyable        bool     `json:",omitempty"`
+	RegularExpression string   `json:",omitempty"`
+	RenderHidden      bool     `json:",omitempty"`
+	RenderReadOnly    bool     `json:",omitempty"`
+	Type              int      `json:",omitempty"`
+}
+type metadataResultCode int
+
+var MetadataResultCodesMap = map[string]metadataResultCode{
+	"":                         0,  //Empty is assumed success
+	"Success":                  0,  //(Indicates the API call was successful.)
+	"InvalidConfigObject":      1,  //Config object is invalid. + [Error].
+	"InvalidDN":                2,  //DN is invalid. + [Error].
+	"InvalidName":              3,  //Metadata object name is invalid.
+	"InvalidItem":              4,  //Item is invalid. + [Error].
+	"InvalidClass":             5,  //Class is invalid. + [Error].
+	"InvalidMetadataObject":    6,  //Metadata object is invalid.
+	"InvalidRights":            7,  //Object rights are invalid.+ [Error].
+	"ItemIsNull":               8,  //Item is missing or empty. + [Error].
+	"ItemAlreadyExists":        9,  //Duplicate item. + [Error].
+	"ItemTypeUnknown":          10, //Item type is unknown. + [Error].
+	"ConfigCreateFailed":       11, //Config object failed to create. + [Error].
+	"ConfigWriteFailed":        12, //Config object failed to write. + [Error].
+	"ConfigDeleteFailed":       13, //Config object failed to delete.
+	"MetadataInUse":            14, //Metadata item is in use. + [Error].
+	"NoAllowedValues":          15, //Metadata item has invalid values.
+	"AllowedValueDoesNotExist": 16, //The required object does not exist or you do not have rights to read it.
+	"ValueNotInAllowedList":    17, //Value is invalid.
+	"ItemNotValidForClass":     18, //Item is not valid for class. + [Error].
+	"NameTooLong":              19, //Metadata item name is too long. + [Error].
+	"TooManyContainers":        20, //Nesting is too deep. + [Error].
+	"ConfigDnNotContainer":     21, //DN is invalid.+ [Error].
+	"InvalidPolicyState":       22, //Policy state is invalid.
+	"ConfigLockFailed":         23, //Config lock failed.
+	"ConfigReadFailed":         24, //Config object failed to read.+ [Error].
+	"RemoteError":              25, //Remote request failed.
+}
+
+type metadataGetItemsRequest struct {
+	ObjectDN string `json:"DN"`
+}
+type metadataGetItemsResponse struct {
+	Items  []metadataItem     `json:",omitempty"`
+	Locked bool               `json:",omitempty"`
+	Result metadataResultCode `json:",omitempty"`
+}
+type guidData struct {
+	ItemGuid string   `json:",omitempty"`
+	List     []string `json:",omitempty"`
+}
+type metadataSetRequest struct {
+	DN           string     `json:"DN"`
+	GuidData     []guidData `json:"GuidData"`
+	KeepExisting bool       `json:"KeepExisting"`
+}
+type metadataSetResponse struct {
+	Locked bool               `json:",omitempty"`
+	Result metadataResultCode `json:",omitempty"`
+}
+type systemStatusVersionResponse string
 
 type urlResource string
 
@@ -231,6 +302,9 @@ const (
 	urlResourceConfigReadDn           urlResource = "vedsdk/Config/ReadDn"
 	urlResourceFindPolicy             urlResource = "vedsdk/config/findpolicy"
 	urlResourceRefreshAccessToken     urlResource = "vedauth/authorize/token"
+	urlResourceMetadataSet          urlResource = "vedsdk/metadata/set"
+	urlResourceMetadataGet          urlResource = "vedsdk/metadata/getitems"
+	urlResourceSystemStatusVersion  urlResource = "vedsdk/SystemStatus/Version"
 )
 
 const (
@@ -530,6 +604,19 @@ func parseRenewResult(httpStatusCode int, httpStatus string, body []byte) (resp 
 }
 
 func parseRenewData(b []byte) (data certificateRenewResponse, err error) {
+	err = json.Unmarshal(b, &data)
+	return
+}
+
+//SystemStatus/Version
+func parseSystemStatusVersionResult(httpStatusCode int, httpStatus string, body []byte) (resp systemStatusVersionResponse, err error) {
+	resp, err = parseSystemStatusVersionData(body)
+	if err != nil {
+		return resp, fmt.Errorf("failed to parse SystemStatus Version response. status: %s", httpStatus)
+	}
+	return resp, nil
+}
+func parseSystemStatusVersionData(b []byte) (data systemStatusVersionResponse, err error) {
 	err = json.Unmarshal(b, &data)
 	return
 }


### PR DESCRIPTION
Does a deep compare of metadata to determine if the metadata was saved by 19.3 on the first call. If the compare fails, it will try to save the metadata using the 19.2 method. 
I left in the requestSystemVersion() method for later use.