### PR TITLE
Source Application Tagging for Venafi Cloud

### DIFF
--- a/cmd/vcert/validators.go
+++ b/cmd/vcert/validators.go
@@ -237,11 +237,11 @@ func validateEnrollFlags(commandName string) error {
 	}
 
 	if flags.tlsAddress != "" && flags.instance == "" {
-		return fmt.Errorf("-tls-address can't be specified without -instance flag")
+		return fmt.Errorf("--tls-address cannot be used without --instance")
 	}
 
-	if (flags.appInfo != "" || flags.tlsAddress != "" || flags.instance != "") && flags.apiKey != "" {
-		return fmt.Errorf("-tls-address or -instance or -app-info can be used only with TPP and can not be used for the Cloud")
+	if (flags.tlsAddress != "" || flags.instance != "") && flags.apiKey != "" {
+		return fmt.Errorf("--instance and --tls-address are not applicable to Venafi Cloud")
 	}
 
 	return nil

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -31,6 +31,8 @@ import (
 
 const SDKName = "Venafi VCert-Go"
 
+var InstanceIP string
+
 // ConnectorType represents the available connectors
 type ConnectorType int
 
@@ -46,6 +48,7 @@ const (
 
 func init() {
 	log.SetPrefix("vCert: ")
+	InstanceIP = getPrimaryNetAddr()
 }
 
 func (t ConnectorType) String() string {
@@ -432,12 +435,11 @@ func (z *ZoneConfiguration) UpdateCertificateRequest(request *certificate.Reques
 	}
 }
 
-func GetPrimaryNetAddr() (ip string, err error) {
+func getPrimaryNetAddr() string {
 	conn, err := net.Dial("udp", "venafi.com:1")
 	if err != nil {
-		return "", fmt.Errorf("failed to get primary network address: %s", err)
+		return "0.0.0.0"
 	}
 	defer conn.Close()
-	ip = conn.LocalAddr().(*net.UDPAddr).IP.String()
-	return
+	return conn.LocalAddr().(*net.UDPAddr).IP.String()
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -22,16 +22,17 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"github.com/Venafi/vcert/pkg/certificate"
 	"log"
 	"net"
 	"net/http"
 	"regexp"
+
+	"github.com/Venafi/vcert/pkg/certificate"
 )
 
 const SDKName = "Venafi VCert-Go"
 
-var InstanceIP string
+var LocalIP string
 
 // ConnectorType represents the available connectors
 type ConnectorType int
@@ -48,7 +49,7 @@ const (
 
 func init() {
 	log.SetPrefix("vCert: ")
-	InstanceIP = getPrimaryNetAddr()
+	LocalIP = getPrimaryNetAddr()
 }
 
 func (t ConnectorType) String() string {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"github.com/Venafi/vcert/pkg/certificate"
 	"log"
+	"net"
 	"net/http"
 	"regexp"
 )
@@ -429,4 +430,14 @@ func (z *ZoneConfiguration) UpdateCertificateRequest(request *certificate.Reques
 			request.KeyLength = 2048
 		}
 	}
+}
+
+func GetPrimaryNetAddr() (ip string, err error) {
+	conn, err := net.Dial("udp", "venafi.com:1")
+	if err != nil {
+		return "", fmt.Errorf("failed to get primary network address: %s", err)
+	}
+	defer conn.Close()
+	ip = conn.LocalAddr().(*net.UDPAddr).IP.String()
+	return
 }

--- a/pkg/venafi/cloud/cloud.go
+++ b/pkg/venafi/cloud/cloud.go
@@ -72,13 +72,17 @@ type certificateRequestResponseData struct {
 	DER                    string    `json:"der,omitempty"`
 }
 
+type certificateRequestClientInfo struct {
+	Type       string `json:"type"`
+	Identifier string `json:"identifier"`
+}
+
 type certificateRequest struct {
-	//CompanyID      string `json:"companyId,omitempty"`
-	CSR                          string `json:"certificateSigningRequest,omitempty"`
-	ZoneID                       string `json:"zoneId,omitempty"`
-	ExistingManagedCertificateId string `json:"existingManagedCertificateId,omitempty"`
-	ReuseCSR                     bool   `json:"reuseCSR,omitempty"`
-	//DownloadFormat string `json:"downloadFormat,omitempty"`
+	CSR                          string                       `json:"certificateSigningRequest,omitempty"`
+	ZoneID                       string                       `json:"zoneId,omitempty"`
+	ExistingManagedCertificateId string                       `json:"existingManagedCertificateId,omitempty"`
+	ReuseCSR                     bool                         `json:"reuseCSR,omitempty"`
+	ApiClientInformation         certificateRequestClientInfo `json:"apiClientInformation,omitempty"`
 }
 
 type certificateStatus struct {
@@ -100,41 +104,32 @@ type CertificateStatusErrorInformation struct {
 	Args    []string `json:"args,omitempty"`
 }
 
-type importRequestEndpointCert struct {
-	Certificate string `json:"certificate"`
-	Fingerprint string `json:"fingerprint"`
-}
-
-type importRequestEndpointProtocol struct {
-	Certificates []string      `json:"certificates"`
-	Ciphers      []interface{} `json:"ciphers"` //todo: check type
-	Protocol     string        `json:"protocol"`
-}
-
-type importRequestEndpoint struct {
-	Alpn                bool                            `json:"alpn"`
-	Certificates        []importRequestEndpointCert     `json:"certificates"`
-	ClientRenegotiation bool                            `json:"clientRenegotiation"`
-	Drown               bool                            `json:"drown"`
-	Heartbleed          bool                            `json:"heartbleed"`
-	Host                string                          `json:"host"`
-	HSTS                bool                            `json:"hsts"`
-	IP                  string                          `json:"ip"`
-	LogJam              int                             `json:"logJam"`
-	Npn                 bool                            `json:"npn"`
-	OCSP                int                             `json:"ocsp"` //default 1
-	Poodle              bool                            `json:"poodle"`
-	PoodleTls           bool                            `json:"poodleTls"`
-	Port                int                             `json:"port"`
-	Protocols           []importRequestEndpointProtocol `json:"protocols"`
-	SecureRenegotiation bool                            `json:"secureRenegotiation"`
-	Sloth               bool                            `json:"sloth"`
+type importRequestClientInfo struct {
+	Type       string `json:"type"`
+	Identifier string `json:"identifier"`
 }
 
 type importRequest struct {
-	ZoneName  string                  `json:"zoneName"`
-	NetworkID string                  `json:"networkId"`
-	Endpoints []importRequestEndpoint `json:"endpoints"`
+	Certificate          string                  `json:"certificate"`
+	ZoneId               string                  `json:"zoneId"`
+	CertificateName      string                  `json:"certificateName"`
+	ApiClientInformation importRequestClientInfo `json:"apiClientInformation"`
+}
+
+type importResponseCertInfo struct {
+	Id                   string    `json:"id"`
+	ManagedCertificateId string    `json:"managedCertificateId"`
+	CompanyId            string    `json:"companyId"`
+	Fingerprint          string    `json:"fingerprint"`
+	CertificateSource    string    `json:"certificateSource"`
+	OwnerUserId          string    `json:"ownerUserId"`
+	IssuanceZoneId       string    `json:"issuanceZoneId"`
+	ValidityStartDate    time.Time `json:"validityStartDate"`
+	ValidityEndDate      time.Time `json:"validityEndDate"`
+}
+
+type importResponse struct {
+	CertificateInformations []importResponseCertInfo `json:"certificateInformations"`
 }
 
 //GenerateRequest generates a CertificateRequest based on the zone configuration, and returns the request along with the private key.

--- a/pkg/venafi/cloud/cloud.go
+++ b/pkg/venafi/cloud/cloud.go
@@ -109,23 +109,37 @@ type importRequestClientInfo struct {
 	Identifier string `json:"identifier"`
 }
 
+type importRequestInstanceInfo struct {
+	AppName            string `json:"appName,omitempty"`
+	NodeName           string `json:"nodeName,omitempty"`
+	AutomationMetadata string `json:"automationMetadata,omitempty"`
+}
+
 type importRequest struct {
-	Certificate          string                  `json:"certificate"`
-	ZoneId               string                  `json:"zoneId"`
-	CertificateName      string                  `json:"certificateName"`
-	ApiClientInformation importRequestClientInfo `json:"apiClientInformation"`
+	Certificate              string                      `json:"certificate"`
+	IssuerCertificates       []string                    `json:"issuerCertificates,omitempty"`
+	ZoneId                   string                      `json:"zoneId"`
+	CertificateName          string                      `json:"certificateName"`
+	ApiClientInformation     importRequestClientInfo     `json:"apiClientInformation,omitempty"`
+	CertificateUsageMetadata []importRequestInstanceInfo `json:"certificateUsageMetadata,omitempty"`
+}
+
+type importResponseClientInfo struct {
+	Type       string `json:"type"`
+	Identifier string `json:"identifier"`
 }
 
 type importResponseCertInfo struct {
-	Id                   string    `json:"id"`
-	ManagedCertificateId string    `json:"managedCertificateId"`
-	CompanyId            string    `json:"companyId"`
-	Fingerprint          string    `json:"fingerprint"`
-	CertificateSource    string    `json:"certificateSource"`
-	OwnerUserId          string    `json:"ownerUserId"`
-	IssuanceZoneId       string    `json:"issuanceZoneId"`
-	ValidityStartDate    time.Time `json:"validityStartDate"`
-	ValidityEndDate      time.Time `json:"validityEndDate"`
+	Id                   string                   `json:"id"`
+	ManagedCertificateId string                   `json:"managedCertificateId"`
+	CompanyId            string                   `json:"companyId"`
+	Fingerprint          string                   `json:"fingerprint"`
+	CertificateSource    string                   `json:"certificateSource"`
+	OwnerUserId          string                   `json:"ownerUserId"`
+	IssuanceZoneId       string                   `json:"issuanceZoneId"`
+	ValidityStartDate    time.Time                `json:"validityStartDate"`
+	ValidityEndDate      time.Time                `json:"validityEndDate"`
+	ApiClientInformation importResponseClientInfo `json:"apiClientInformation,omitempty"`
 }
 
 type importResponse struct {

--- a/pkg/venafi/cloud/cloud.go
+++ b/pkg/venafi/cloud/cloud.go
@@ -22,7 +22,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/Venafi/vcert/pkg/verror"
 	"io"
 	"io/ioutil"
 	"log"
@@ -30,6 +29,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/Venafi/vcert/pkg/verror"
 
 	"github.com/Venafi/vcert/pkg/certificate"
 	"github.com/Venafi/vcert/pkg/endpoint"
@@ -130,16 +131,18 @@ type importResponseClientInfo struct {
 }
 
 type importResponseCertInfo struct {
-	Id                   string                   `json:"id"`
-	ManagedCertificateId string                   `json:"managedCertificateId"`
-	CompanyId            string                   `json:"companyId"`
-	Fingerprint          string                   `json:"fingerprint"`
-	CertificateSource    string                   `json:"certificateSource"`
-	OwnerUserId          string                   `json:"ownerUserId"`
-	IssuanceZoneId       string                   `json:"issuanceZoneId"`
-	ValidityStartDate    time.Time                `json:"validityStartDate"`
-	ValidityEndDate      time.Time                `json:"validityEndDate"`
-	ApiClientInformation importResponseClientInfo `json:"apiClientInformation,omitempty"`
+	Id                      string                   `json:"id"`
+	ManagedCertificateId    string                   `json:"managedCertificateId"`
+	CompanyId               string                   `json:"companyId"`
+	Fingerprint             string                   `json:"fingerprint"`
+	CertificateSource       string                   `json:"certificateSource"`
+	OwnerUserId             string                   `json:"ownerUserId"`
+	IssuanceZoneId          string                   `json:"issuanceZoneId"`
+	ValidityStartDateString string                   `json:"validityStartDate"`
+	ValidityStartDate       time.Time                `json:"-"`
+	ValidityEndDateString   string                   `json:"validityEndDate"`
+	ValidityEndDate         time.Time                `json:"-"`
+	ApiClientInformation    importResponseClientInfo `json:"apiClientInformation,omitempty"`
 }
 
 type importResponse struct {
@@ -207,7 +210,7 @@ func (c *Connector) getHTTPClient() *http.Client {
 	}
 	netTransport.TLSClientConfig = tlsConfig
 	c.client = &http.Client{
-		Timeout:   time.Second * 10,
+		Timeout:   time.Second * 30,
 		Transport: netTransport,
 	}
 	return c.client

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -22,11 +22,12 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"github.com/Venafi/vcert/pkg/verror"
 	"net/http"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/Venafi/vcert/pkg/verror"
 
 	"github.com/Venafi/vcert/pkg/certificate"
 	"github.com/Venafi/vcert/pkg/endpoint"
@@ -181,7 +182,7 @@ func (c *Connector) RequestCertificate(req *certificate.Request) (requestID stri
 		return "", fmt.Errorf("Must be autheticated to request a certificate")
 	}
 
-	ipAddr := endpoint.InstanceIP
+	ipAddr := endpoint.LocalIP
 	origin := endpoint.SDKName
 	for _, f := range req.CustomFields {
 		if f.Type == certificate.CustomFieldOrigin {
@@ -577,7 +578,7 @@ func (c *Connector) ImportCertificate(req *certificate.ImportRequest) (*certific
 	if zone == "" {
 		zone = c.zone
 	}
-	ipAddr := endpoint.InstanceIP
+	ipAddr := endpoint.LocalIP
 	origin := endpoint.SDKName
 	for _, f := range req.CustomFields {
 		if f.Type == certificate.CustomFieldOrigin {

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -181,10 +181,7 @@ func (c *Connector) RequestCertificate(req *certificate.Request) (requestID stri
 		return "", fmt.Errorf("Must be autheticated to request a certificate")
 	}
 
-	addr, err := endpoint.GetPrimaryNetAddr()
-	if err != nil {
-		return "", err
-	}
+	ipAddr := endpoint.InstanceIP
 	origin := endpoint.SDKName
 	for _, f := range req.CustomFields {
 		if f.Type == certificate.CustomFieldOrigin {
@@ -196,7 +193,7 @@ func (c *Connector) RequestCertificate(req *certificate.Request) (requestID stri
 		CSR:    string(req.GetCSR()),
 		ApiClientInformation: certificateRequestClientInfo{
 			Type:       origin,
-			Identifier: addr,
+			Identifier: ipAddr,
 		},
 	}
 
@@ -580,10 +577,7 @@ func (c *Connector) ImportCertificate(req *certificate.ImportRequest) (*certific
 	if zone == "" {
 		zone = c.zone
 	}
-	addr, err := endpoint.GetPrimaryNetAddr()
-	if err != nil {
-		return nil, err
-	}
+	ipAddr := endpoint.InstanceIP
 	origin := endpoint.SDKName
 	for _, f := range req.CustomFields {
 		if f.Type == certificate.CustomFieldOrigin {
@@ -598,9 +592,10 @@ func (c *Connector) ImportCertificate(req *certificate.ImportRequest) (*certific
 		CertificateName: req.ObjectName,
 		ApiClientInformation: importRequestClientInfo{
 			Type:       origin,
-			Identifier: addr,
+			Identifier: ipAddr,
 		},
 	}
+
 	url := c.getURL(urlResourceCertificateImport)
 	statusCode, status, body, err := c.request("POST", url, request)
 	if err != nil {

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -638,7 +638,7 @@ func (c *Connector) ListCertificates(filter endpoint.Filter) ([]certificate.Cert
 	if c.zone == "" {
 		return nil, fmt.Errorf("empty zone")
 	}
-	const batchSize = 100
+	const batchSize = 50
 	limit := 100000000
 	if filter.Limit != nil {
 		limit = *filter.Limit

--- a/pkg/venafi/cloud/connector_test.go
+++ b/pkg/venafi/cloud/connector_test.go
@@ -26,16 +26,17 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"github.com/Venafi/vcert/pkg/certificate"
-	"github.com/Venafi/vcert/pkg/endpoint"
-	"github.com/Venafi/vcert/pkg/verror"
-	"github.com/Venafi/vcert/test"
 	"math/big"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Venafi/vcert/pkg/certificate"
+	"github.com/Venafi/vcert/pkg/endpoint"
+	"github.com/Venafi/vcert/pkg/verror"
+	"github.com/Venafi/vcert/test"
 )
 
 var ctx *test.Context

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -847,10 +847,10 @@ func (c *Connector) ImportCertificate(req *certificate.ImportRequest) (*certific
 		r.PolicyDN = getPolicyDN(c.zone)
 	}
 
-	origin := endpoint.SDKName + " (+)"
+	origin := endpoint.SDKName + " (+)" // standard suffix needed to differentiate certificates imported from enrolled in TPP
 	for _, f := range req.CustomFields {
 		if f.Type == certificate.CustomFieldOrigin {
-			origin = f.Value
+			origin = f.Value + " (+)"
 		}
 	}
 	statusCode, _, body, err := c.request("POST", urlResourceCertificateImport, r)

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -430,7 +430,7 @@ func (c *Connector) getHTTPClient() *http.Client {
 	}
 	netTransport.TLSClientConfig = tlsConfig
 	c.client = &http.Client{
-		Timeout:   time.Second * 10,
+		Timeout:   time.Second * 30,
 		Transport: netTransport,
 	}
 	return c.client


### PR DESCRIPTION
- Switched import for Cloud from /v1/discovery to /v1/certificaterequests/externalissuance/certificates
- Added source application tagging for certificates enrolled and imported with Cloud