### PR TITLE
Wrap all Authenticate errors with verror.AuthError

### DIFF
--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -100,6 +100,12 @@ func (c *Connector) Ping() (err error) {
 
 // Authenticate authenticates the user to the TPP
 func (c *Connector) Authenticate(auth *endpoint.Authentication) (err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("%w: %s", verror.AuthError, err)
+		}
+	}()
+
 	if auth == nil {
 		return fmt.Errorf("failed to authenticate: missing credentials")
 	}


### PR DESCRIPTION
This makes it easier for users of the vcert library to distinguish between
temporary and permanent error conditions.

Signed-off-by: Richard Wall <richard.wall@jetstack.io>