### PR TITLE
Wrap URL errors from tpp.NewConnector with verror.UserDataError

### DIFF
--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -50,7 +50,7 @@ func NewConnector(url string, zone string, verbose bool, trust *x509.CertPool) (
 	var err error
 	c.baseURL, err = normalizeURL(url)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: failed to normalize URL: %v", verror.UserDataError, err)
 	}
 	return &c, nil
 }

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -1202,40 +1202,6 @@ func TestNormalizeURL(t *testing.T) {
 	}
 }
 
-func TestGetURL(t *testing.T) {
-	var err error
-	tpp := Connector{}
-	url := "http://localhost/vedsdk/"
-	tpp.baseURL = ""
-	tpp.baseURL, err = normalizeURL(url)
-	if err != nil {
-		t.Fatalf("err is not nil, err: %s url: %s", err, url)
-	}
-	if !strings.EqualFold(tpp.baseURL, expectedURL) {
-		t.Fatalf("Base URL did not match expected value. Expected: %s Actual: %s", expectedURL, tpp.baseURL)
-	}
-
-	url, err = tpp.getURL(urlResourceAuthorize)
-	if !strings.EqualFold(url, fmt.Sprintf("%s%s", expectedURL, urlResourceAuthorize)) {
-		t.Fatalf("Get URL did not match expected value. Expected: %s Actual: %s", fmt.Sprintf("%s%s", expectedURL, urlResourceAuthorize), url)
-	}
-
-	url, err = tpp.getURL(urlResourceCertificateRequest)
-	if !strings.EqualFold(url, fmt.Sprintf("%s%s", expectedURL, urlResourceCertificateRequest)) {
-		t.Fatalf("Get URL did not match expected value. Expected: %s Actual: %s", fmt.Sprintf("%s%s", expectedURL, urlResourceCertificateRequest), url)
-	}
-
-	url, err = tpp.getURL(urlResourceCertificateRetrieve)
-	if !strings.EqualFold(url, fmt.Sprintf("%s%s", expectedURL, urlResourceCertificateRetrieve)) {
-		t.Fatalf("Get URL did not match expected value. Expected: %s Actual: %s", fmt.Sprintf("%s%s", expectedURL, urlResourceCertificateRetrieve), url)
-	}
-	tpp.baseURL = ""
-	url, err = tpp.getURL(urlResourceAuthorize)
-	if err == nil {
-		t.Fatalf("Get URL did not return an error when the base url had not been set.")
-	}
-}
-
 func Test_GetCertificateList(t *testing.T) {
 	tpp, err := getTestConnector(ctx.TPPurl, ctx.TPPZone)
 	if err != nil {

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -345,18 +345,8 @@ func retrieveChainOptionFromString(order string) retrieveChainOption {
 	}
 }
 
-func (c *Connector) getURL(resource urlResource) (string, error) {
-	if c.baseURL == "" {
-		return "", fmt.Errorf("The Host URL has not been set")
-	}
-	return fmt.Sprintf("%s%s", c.baseURL, resource), nil
-}
-
 func (c *Connector) request(method string, resource urlResource, data interface{}) (statusCode int, statusText string, body []byte, err error) {
-	url, err := c.getURL(resource)
-	if err != nil {
-		return
-	}
+	url := c.baseURL + string(resource)
 	var payload io.Reader
 	var b []byte
 	if method == "POST" || method == "PUT" {


### PR DESCRIPTION
 Allows a vcert user to distinguish between errors caused by bad configuration
and temporary errors which may be resolved by retrying.

I also removed getURL and associated tests.
`baseURL` (a private field) will never be the empty because it is validated earlier in
`NewConnector`  via `normalizeURL`.

