### PR TITLE
Add support UPN and URI SAN types for TPP

### DIFF
--- a/cmd/vcert/args.go
+++ b/cmd/vcert/args.go
@@ -51,7 +51,7 @@ type commandFlags struct {
 	customFields      []string
 	distinguishedName string
 	dnsSans           stringSlice
-	emailSans         emailSlice
+	emailSans         rfc822NameSlice
 	file              string
 	format            string
 	friendlyName      string
@@ -86,6 +86,8 @@ type commandFlags struct {
 	tppToken          string
 	tppUser           string
 	trustBundle       string
+	upnSans           rfc822NameSlice
+	uriSans           uriSlice
 	url               string
 	verbose           bool
 	zone              string

--- a/cmd/vcert/commands.go
+++ b/cmd/vcert/commands.go
@@ -16,6 +16,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -100,6 +101,7 @@ func runBeforeCommand(c *cli.Context) error {
 	flags.orgUnits = c.StringSlice("ou")
 	flags.dnsSans = c.StringSlice("san-dns")
 	flags.emailSans = c.StringSlice("san-email")
+	flags.upnSans = c.StringSlice("san-upn")
 	flags.customFields = c.StringSlice("field")
 
 	noDuplicatedFlags := []string{"instance", "tls-address", "app-info"}
@@ -122,6 +124,10 @@ func runBeforeCommand(c *cli.Context) error {
 	for _, stringIP := range c.StringSlice("san-ip") {
 		ip := net.ParseIP(stringIP)
 		flags.ipSans = append(flags.ipSans, ip)
+	}
+	for _, stringURI := range c.StringSlice("san-uri") {
+		uri, _ := url.Parse(stringURI)
+		flags.uriSans = append(flags.uriSans, uri)
 	}
 
 	return nil

--- a/cmd/vcert/flags.go
+++ b/cmd/vcert/flags.go
@@ -158,7 +158,21 @@ var (
 	flagEmailSans = &cli.StringSliceFlag{
 		Name: "san-email",
 		Usage: "Use to specify an Email Subject Alternative Name. " +
-			"This option can be repeated to specify more than one value, like this: --san-email abc@abc.xyz --san-email def@abc.xyz etc.",
+			"This option can be repeated to specify more than one value, like this: --san-email me@abc.xyz --san-email you@abc.xyz etc.",
+	}
+
+	flagURISans = &cli.StringSliceFlag{
+		Name: "san-uri",
+		Usage: "Use to specify a Uniform Resource Identifier (URI) Subject Alternative Name. " +
+			"This option can be repeated to specify more than one value, like this: --san-uri https://www.abc.xyz --san-uri spiffe://node.abc.xyz etc.",
+		Hidden: true,
+	}
+
+	flagUPNSans = &cli.StringSliceFlag{
+		Name: "san-upn",
+		Usage: "Use to specify a User Principal Name (UPN) Subject Alternative Name. " +
+			"This option can be repeated to specify more than one value, like this: --san-upn me@abc.xyz --san-upn you@abc.xyz etc.",
+		Hidden: true,
 	}
 
 	flagFormat = &cli.StringFlag{
@@ -425,7 +439,7 @@ var (
 
 	commonFlags              = []cli.Flag{flagInsecure, flagFormat, flagVerbose, flagNoPrompt}
 	keyFlags                 = []cli.Flag{flagKeyType, flagKeySize, flagKeyCurve, flagKeyFile, flagKeyPassword}
-	sansFlags                = []cli.Flag{flagDNSSans, flagEmailSans, flagIPSans}
+	sansFlags                = []cli.Flag{flagDNSSans, flagEmailSans, flagIPSans, flagURISans, flagUPNSans}
 	subjectFlags             = flagsApppend(flagCommonName, flagCountry, flagState, flagLocality, flagOrg, flagOrgUnits)
 	sortableCredentialsFlags = []cli.Flag{
 		flagTestMode,

--- a/cmd/vcert/main_test.go
+++ b/cmd/vcert/main_test.go
@@ -499,16 +499,16 @@ func TestIPSliceSetByString(t *testing.T) {
 	}
 }
 
-func TestEmailSliceString(t *testing.T) {
-	emails := emailSlice{"email@email1.com", "email@email2.com", "email@email3.com"}
+func TestRFC822NameSliceString(t *testing.T) {
+	emails := rfc822NameSlice{"email@email1.com", "email@email2.com", "email@email3.com"}
 	emailString := emails.String()
 	if !strings.Contains(emailString, "email@email1.com") || !strings.Contains(emailString, "email@email2.com") || !strings.Contains(emailString, "email@email3.com") {
 		t.Fatalf("Unexpected string value was returned.  Expected: %s\n%s\n%s\n Actual: %s", "email@email1.com", "email@email2.com", "email@email3.com", emailString)
 	}
 }
 
-func TestEmailSliceSetByString(t *testing.T) {
-	emails := emailSlice{}
+func TestRFC822NameSliceSetByString(t *testing.T) {
+	emails := rfc822NameSlice{}
 	data := []string{"email@email1.com", "email@email2.com", "email@email3.com", "barney.fife@venafi.com", "gpile@venafi.com", "andy@venafi.com", "some.other@anything.co.uk"}
 	for i, s := range data {
 		err := emails.Set(s)
@@ -526,12 +526,12 @@ func TestIsValidEmailAddress(t *testing.T) {
 	bad := []string{"bob@bob", "User@", "user@a", "user@a.b.c.d.e.f.g.h.j.k.l.", "user@.com", "domain.com", "1.2.3.4"}
 
 	for _, e := range good {
-		if !isValidEmailAddress(e) {
+		if !isValidRFC822Name(e) {
 			t.Fatalf("Email address %s failed validation", e)
 		}
 	}
 	for _, e := range bad {
-		if isValidEmailAddress(e) {
+		if isValidRFC822Name(e) {
 			t.Fatalf("Email address %s should have failed validation", e)
 		}
 	}

--- a/cmd/vcert/main_test.go
+++ b/cmd/vcert/main_test.go
@@ -28,6 +28,7 @@ import (
 	"io/ioutil"
 	"math/big"
 	"net"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -495,6 +496,30 @@ func TestIPSliceSetByString(t *testing.T) {
 		ips.Set(s)
 		if len(ips) != i+1 {
 			t.Fatalf("Unexpected count after adding to [].  Expected: %d Actual: %d", i+1, len(ips))
+		}
+	}
+}
+
+func TestURISliceString(t *testing.T) {
+	var uris uriSlice
+	data := []string{"https://www.abc.xyz", "ldaps://directory.abc.xyz", "spiffe://cluster.abc.xyz"}
+	for _, s := range data {
+		u, _ := url.Parse(s)
+		uris = append(uris, u)
+	}
+	uriString := uris.String()
+	if !strings.Contains(uriString, data[0]) || !strings.Contains(uriString, data[1]) || !strings.Contains(uriString, data[2]) {
+		t.Fatalf("Unexpected string value was returned.  Expected: %s\n%s\n%s\n Actual: %s", data[0], data[1], data[2], uriString)
+	}
+}
+
+func TestURISliceSetByString(t *testing.T) {
+	uris := uriSlice{}
+	data := []string{"https://www.abc.xyz", "ldaps://directory.abc.xyz", "spiffe://cluster.abc.xyz"}
+	for i, s := range data {
+		uris.Set(s)
+		if len(uris) != i+1 {
+			t.Fatalf("Unexpected count after adding to [].  Expected: %d Actual: %d", i+1, len(uris))
 		}
 	}
 }

--- a/cmd/vcert/slices.go
+++ b/cmd/vcert/slices.go
@@ -19,6 +19,7 @@ package main
 import (
 	"fmt"
 	"net"
+	"net/url"
 )
 
 type stringSlice []string
@@ -36,24 +37,24 @@ func (ss *stringSlice) Set(value string) error {
 	return nil
 }
 
-const emailRegex = "[[:alnum:]][\\w\\.-]*[[:alnum:]]@[[:alnum:]][\\w\\.-]*[[:alnum:]]\\.[[:alpha:]][a-z\\.]*[[:alpha:]]$"
+const rfc822NameRegex = "[[:alnum:]][\\w\\.-]*[[:alnum:]]@[[:alnum:]][\\w\\.-]*[[:alnum:]]\\.[[:alpha:]][a-z\\.]*[[:alpha:]]$"
 
-type emailSlice []string
+type rfc822NameSlice []string
 
-func (es *emailSlice) String() string {
+func (rs *rfc822NameSlice) String() string {
 	var ret string
-	for _, s := range *es {
+	for _, s := range *rs {
 		ret += fmt.Sprintf("%s\n", s)
 	}
 	return ret
 }
 
-func (es *emailSlice) Set(value string) error {
-	if isValidEmailAddress(value) {
-		*es = append(*es, value)
+func (rs *rfc822NameSlice) Set(value string) error {
+	if isValidRFC822Name(value) {
+		*rs = append(*rs, value)
 		return nil
 	}
-	return fmt.Errorf("Failed to convert %s to an Email Address", value)
+	return fmt.Errorf("Failed to convert %s to an RFC 822 name (email or UPN)", value)
 }
 
 type ipSlice []net.IP
@@ -73,4 +74,23 @@ func (is *ipSlice) Set(value string) error {
 		return nil
 	}
 	return fmt.Errorf("Failed to convert %s to an IP Address", value)
+}
+
+type uriSlice []*url.URL
+
+func (us *uriSlice) String() string {
+	var ret string
+	for _, s := range *us {
+		ret += fmt.Sprintf("%s\n", s)
+	}
+	return ret
+}
+
+func (us *uriSlice) Set(value string) error {
+	temp, _ := url.Parse(value)
+	if temp != nil {
+		*us = append(*us, temp)
+		return nil
+	}
+	return fmt.Errorf("Failed to convert %s to a URI", value)
 }

--- a/cmd/vcert/utils.go
+++ b/cmd/vcert/utils.go
@@ -79,6 +79,12 @@ func fillCertificateRequest(req *certificate.Request, cf *commandFlags) *certifi
 	if len(cf.emailSans) > 0 {
 		req.EmailAddresses = cf.emailSans
 	}
+	if len(cf.uriSans) > 0 {
+		req.URIs = cf.uriSans
+	}
+	if len(cf.upnSans) > 0 {
+		req.UPNs = cf.upnSans
+	}
 	req.OmitSANs = cf.omitSans
 	for _, f := range cf.customFields {
 		k, v, err := parseCustomField(f)
@@ -286,9 +292,9 @@ func doValuesMatch(value1 []byte, value2 []byte) bool {
 	return true
 }
 
-func isValidEmailAddress(email string) bool {
-	reg := regexp.MustCompile(emailRegex)
-	return reg.FindStringIndex(email) != nil
+func isValidRFC822Name(name string) bool {
+	reg := regexp.MustCompile(rfc822NameRegex)
+	return reg.FindStringIndex(name) != nil
 }
 
 func sliceContains(slice []string, item string) bool {

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -175,6 +175,7 @@ type Request struct {
 	EmailAddresses     []string
 	IPAddresses        []net.IP
 	URIs               []*url.URL
+	UPNs               []string
 	Attributes         []pkix.AttributeTypeAndValueSET
 	SignatureAlgorithm x509.SignatureAlgorithm
 	FriendlyName       string
@@ -289,6 +290,10 @@ func (request *Request) GenerateCSR() error {
 		certificateRequest.EmailAddresses = request.EmailAddresses
 		certificateRequest.IPAddresses = request.IPAddresses
 		certificateRequest.URIs = request.URIs
+
+		if len(request.UPNs) > 0 {
+			addUserPrincipalNameSANs(&certificateRequest, request.UPNs)
+		}
 	}
 	certificateRequest.Attributes = request.Attributes
 
@@ -491,6 +496,9 @@ func NewRequest(cert *x509.Certificate) *Request {
 	req.DNSNames = cert.DNSNames
 	req.EmailAddresses = cert.EmailAddresses
 	req.IPAddresses = cert.IPAddresses
+	req.URIs = cert.URIs
+	req.UPNs, _ = getUserPrincipalNameSANs(cert)
+
 	req.SignatureAlgorithm = cert.SignatureAlgorithm
 	switch pub := cert.PublicKey.(type) {
 	case *rsa.PublicKey:

--- a/pkg/certificate/x509SubjectAltNameUPN.go
+++ b/pkg/certificate/x509SubjectAltNameUPN.go
@@ -109,7 +109,10 @@ func marshalSANs(dnsNames, emailAddresses []string, ipAddresses []net.IP, uris [
 				Name: upn,
 			},
 		})
-		asn1.Unmarshal(name, &raw)
+		_, err = asn1.Unmarshal(name, &raw)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse otherName SAN: %v", err)
+		}
 		rawValues = append(rawValues, asn1.RawValue{Tag: nameTypeOther, Class: 2, IsCompound: true, Bytes: raw.Bytes})
 	}
 

--- a/pkg/certificate/x509SubjectAltNameUPN.go
+++ b/pkg/certificate/x509SubjectAltNameUPN.go
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2020 Venafi, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package certificate
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"fmt"
+	"log"
+	"net"
+	"net/url"
+)
+
+// userPrincipalName format for ASN.1
+type userPrincipalName struct {
+	Name string `asn1:"utf8"`
+}
+
+// otherName SAN value format for ASN.1
+type otherName struct {
+	OID   asn1.ObjectIdentifier
+	Value userPrincipalName `asn1:"tag:0"`
+}
+
+var (
+	oidExtensionSubjectAltName = asn1.ObjectIdentifier{2, 5, 29, 17}
+	oidUserPrincipalName       = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 311, 20, 2, 3}
+)
+
+const (
+	nameTypeOther = 0
+	nameTypeEmail = 1
+	nameTypeDNS   = 2
+	nameTypeURI   = 6
+	nameTypeIP    = 7
+)
+
+// Workaround for lack of User Principal Name SAN support in crypto/x509 package
+func addUserPrincipalNameSANs(req *x509.CertificateRequest, upNames []string) {
+	sanBytes, err := marshalSANs(req.DNSNames, req.EmailAddresses, req.IPAddresses, req.URIs, upNames)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	extSubjectAltName := pkix.Extension{
+		Id:       oidExtensionSubjectAltName,
+		Critical: false,
+		Value:    sanBytes,
+	}
+
+	updatedExts := []pkix.Extension{extSubjectAltName}
+
+	// Preserve any other extra extensions, if any
+	for _, ext := range req.ExtraExtensions {
+		if !ext.Id.Equal(oidExtensionSubjectAltName) {
+			updatedExts = append(updatedExts, ext)
+		}
+	}
+	req.ExtraExtensions = updatedExts
+
+	// Clear the SAN request attributes to prevent the SAN extension from being clobbered when CSR is generated
+	req.DNSNames = nil
+	req.EmailAddresses = nil
+	req.IPAddresses = nil
+	req.URIs = nil
+}
+
+// Enhance crypto/x509 marshalSANs method to additionally support User Principal Name SANs
+// Based on https://github.com/golang/go/blob/master/src/crypto/x509/x509.go#L1656-L1678
+func marshalSANs(dnsNames, emailAddresses []string, ipAddresses []net.IP, uris []*url.URL, uPNames []string) (derBytes []byte, err error) {
+	var rawValues []asn1.RawValue
+	for _, name := range dnsNames {
+		rawValues = append(rawValues, asn1.RawValue{Tag: nameTypeDNS, Class: 2, Bytes: []byte(name)})
+	}
+	for _, email := range emailAddresses {
+		rawValues = append(rawValues, asn1.RawValue{Tag: nameTypeEmail, Class: 2, Bytes: []byte(email)})
+	}
+	for _, rawIP := range ipAddresses {
+		// If possible, we always want to encode IPv4 addresses in 4 bytes.
+		ip := rawIP.To4()
+		if ip == nil {
+			ip = rawIP
+		}
+		rawValues = append(rawValues, asn1.RawValue{Tag: nameTypeIP, Class: 2, Bytes: ip})
+	}
+	for _, uri := range uris {
+		rawValues = append(rawValues, asn1.RawValue{Tag: nameTypeURI, Class: 2, Bytes: []byte(uri.String())})
+	}
+	for _, upn := range uPNames {
+		var raw asn1.RawValue
+		name, _ := asn1.Marshal(otherName{
+			OID: oidUserPrincipalName,
+			Value: userPrincipalName{
+				Name: upn,
+			},
+		})
+		asn1.Unmarshal(name, &raw)
+		rawValues = append(rawValues, asn1.RawValue{Tag: nameTypeOther, Class: 2, IsCompound: true, Bytes: raw.Bytes})
+	}
+
+	return asn1.Marshal(rawValues)
+}
+
+// Since crypto/x509 package is not aware of UPN SANs, implement our own parsing method
+func getUserPrincipalNameSANs(cert *x509.Certificate) (ret []string, err error) {
+	for _, ext := range cert.Extensions {
+		if !ext.Id.Equal(oidExtensionSubjectAltName) {
+			continue
+		}
+
+		var seq asn1.RawValue
+		rest, err := asn1.Unmarshal(ext.Value, &seq)
+		if err != nil {
+			return nil, err
+		} else if len(rest) != 0 {
+			return nil, fmt.Errorf("unexpected trailing data after X.509 extension")
+		}
+		if !seq.IsCompound || seq.Tag != 16 || seq.Class != 0 {
+			return nil, asn1.StructuralError{Msg: "bad ASN.1 sequence for SAN"}
+		}
+
+		rest = seq.Bytes
+		for len(rest) > 0 {
+			var v asn1.RawValue
+			rest, err = asn1.Unmarshal(rest, &v)
+			if err != nil {
+				return nil, err
+			}
+
+			upn, err := parseUserPrincipalNameSAN(v.Tag, v.FullBytes)
+			if err != nil {
+				return nil, err
+			}
+			if upn != "" {
+				ret = append(ret, upn)
+			}
+		}
+	}
+
+	return ret, nil
+}
+
+func parseUserPrincipalNameSAN(tag int, data []byte) (name string, err error) {
+	if tag != 0 {
+		return "", nil // SAN is not an otherName
+	}
+
+	var other otherName
+	_, err = asn1.UnmarshalWithParams(data, &other, "tag:0")
+	if err != nil {
+		return "", fmt.Errorf("could not parse otherName SAN: %v", err)
+	}
+	if other.OID.Equal(oidUserPrincipalName) {
+		return other.Value.Name, nil
+	}
+	return "", nil // otherName SAN is not a user principal name
+}

--- a/pkg/venafi/fake/connector.go
+++ b/pkg/venafi/fake/connector.go
@@ -121,10 +121,8 @@ func issueCertificate(csr *x509.CertificateRequest) ([]byte, error) {
 		SerialNumber: serial,
 	}
 	certRequest.Subject = csr.Subject
-	certRequest.DNSNames = csr.DNSNames
-	certRequest.EmailAddresses = csr.EmailAddresses
-	certRequest.IPAddresses = csr.IPAddresses
-	certRequest.SignatureAlgorithm = x509.SHA512WithRSA
+	certRequest.ExtraExtensions = csr.Extensions // this will include any SANs including UPN
+	certRequest.SignatureAlgorithm = x509.SHA256WithRSA
 	certRequest.PublicKeyAlgorithm = csr.PublicKeyAlgorithm
 	certRequest.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
 	certRequest.NotBefore = time.Now().Add(-24 * time.Hour)

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -262,6 +262,12 @@ func wrapAltNames(req *certificate.Request) (items []sanItem) {
 	for _, name := range req.IPAddresses {
 		items = append(items, sanItem{7, name.String()})
 	}
+	for _, name := range req.URIs {
+		items = append(items, sanItem{6, name.String()})
+	}
+	for _, name := range req.UPNs {
+		items = append(items, sanItem{0, name})
+	}
 	return items
 }
 

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -143,8 +143,8 @@ type certificateRenewResponse struct {
 }
 
 type sanItem struct {
-	Type int    `json",string"`
-	Name string `json",string"`
+	Type int    `json:""`
+	Name string `json:""`
 }
 
 type nameValuePair struct {

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -143,8 +143,8 @@ type certificateRenewResponse struct {
 }
 
 type sanItem struct {
-	Type int    `json:",omitempty"`
-	Name string `json:",omitempty"`
+	Type int    `json`
+	Name string `json`
 }
 
 type nameValuePair struct {

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -143,8 +143,8 @@ type certificateRenewResponse struct {
 }
 
 type sanItem struct {
-	Type int    `json`
-	Name string `json`
+	Type int    `json",string"`
+	Name string `json",string"`
 }
 
 type nameValuePair struct {


### PR DESCRIPTION
This code builds and tests successfully and exhibits the desired behavior when using the CLI.  The new `--san-uri` and `--san-upn` command line parameters have been left hidden from the CLI help because the project driving this does not require CLI support and because neither parameter is currently supportable by Venafi Cloud.