### PR TITLE
GitHub 114

### DIFF
--- a/cmd/vcert/args.go
+++ b/cmd/vcert/args.go
@@ -90,4 +90,5 @@ type commandFlags struct {
 	verbose           bool
 	zone              string
 	omitSans          bool
+	csrFormat         string
 }

--- a/cmd/vcert/commands.go
+++ b/cmd/vcert/commands.go
@@ -721,7 +721,7 @@ func generateCsrForCommandGenCsr(cf *commandFlags, privateKeyPass []byte) (priva
 
 func writeOutKeyAndCsr(commandName string, cf *commandFlags, key []byte, csr []byte) (err error) {
 	pcc := &certificate.PEMCollection{}
-	pcc.Certificate = string(csr[:])
+	pcc.CSR = string(csr[:])
 	pcc.PrivateKey = string(key[:])
 
 	result := &Result{
@@ -733,7 +733,7 @@ func writeOutKeyAndCsr(commandName string, cf *commandFlags, key []byte, csr []b
 			ChainOption:  certificate.ChainOptionFromString(cf.chainOption),
 			AllFile:      cf.file,
 			KeyFile:      cf.keyFile,
-			CertFile:     cf.csrFile,
+			CSRFile:      cf.csrFile,
 			ChainFile:    "",
 			PickupIdFile: "",
 			KeyPassword:  cf.keyPassword,

--- a/cmd/vcert/flags.go
+++ b/cmd/vcert/flags.go
@@ -425,9 +425,9 @@ var (
 
 	flagCSRFormat = &cli.StringFlag{
 		Name: "format",
-		Usage: "Generates the Certificate Signing Request in the specified format. Options include: pem | json\n" +
-			"\t\tpem: Generates the CSR in classic pem format to be used as a file.\n" +
-			"\t\tjson: Generates the CSR in json format, suitable for rest api operations.",
+		Usage: "Generates the Certificate Signing Request in the specified format. Options include: PEM | JSON\n" +
+			"\tpem: Generates the CSR in classic PEM format to be used as a file.\n" +
+			"\tjson: Generates the CSR in JSON format, suitable for rest API operations.",
 		Destination: &flags.csrFormat,
 		Value:       "pem",
 	}

--- a/cmd/vcert/flags.go
+++ b/cmd/vcert/flags.go
@@ -423,7 +423,7 @@ var (
 		Destination: &flags.omitSans,
 	}
 
-	flagGenCSRFormat = &cli.StringFlag{
+	flagCSRFormat = &cli.StringFlag{
 		Name: "format",
 		Usage: "Generates the Certificate Signing Request in the specified format. Options include: pem | json\n" +
 			"\t\tpem: Generates the CSR in classic pem format to be used as a file.\n" +
@@ -465,8 +465,7 @@ var (
 		keyFlags,
 		flagNoPrompt,
 		flagVerbose,
-		flagGenCSRFormat,
-		flagFile,
+		flagCSRFormat,
 	))
 
 	enrollFlags = flagsApppend(

--- a/cmd/vcert/flags.go
+++ b/cmd/vcert/flags.go
@@ -425,9 +425,9 @@ var (
 
 	flagCSRFormat = &cli.StringFlag{
 		Name: "format",
-		Usage: "Generates the Certificate Signing Request in the specified format. Options include: PEM | JSON\n" +
+		Usage: "Generates the Certificate Signing Request in the specified format. Options include: pem | json\n" +
 			"\tpem: Generates the CSR in classic PEM format to be used as a file.\n" +
-			"\tjson: Generates the CSR in JSON format, suitable for rest API operations.",
+			"\tjson: Generates the CSR in JSON format, suitable for REST API operations.",
 		Destination: &flags.csrFormat,
 		Value:       "pem",
 	}

--- a/cmd/vcert/flags.go
+++ b/cmd/vcert/flags.go
@@ -423,6 +423,15 @@ var (
 		Destination: &flags.omitSans,
 	}
 
+	flagGenCSRFormat = &cli.StringFlag{
+		Name: "format",
+		Usage: "Generates the Certificate Signing Request in the specified format. Options include: pem | json\n" +
+			"\t\tpem: Generates the CSR in classic pem format to be used as a file.\n" +
+			"\t\tjson: Generates the CSR in json format, suitable for rest api operations.",
+		Destination: &flags.csrFormat,
+		Value:       "pem",
+	}
+
 	commonFlags              = []cli.Flag{flagInsecure, flagFormat, flagVerbose, flagNoPrompt}
 	keyFlags                 = []cli.Flag{flagKeyType, flagKeySize, flagKeyCurve, flagKeyFile, flagKeyPassword}
 	sansFlags                = []cli.Flag{flagDNSSans, flagEmailSans, flagIPSans}
@@ -456,6 +465,8 @@ var (
 		keyFlags,
 		flagNoPrompt,
 		flagVerbose,
+		flagGenCSRFormat,
+		flagFile,
 	))
 
 	enrollFlags = flagsApppend(

--- a/cmd/vcert/generate_test.go
+++ b/cmd/vcert/generate_test.go
@@ -17,8 +17,10 @@
 package main
 
 import (
+	"encoding/json"
 	"github.com/Venafi/vcert/pkg/certificate"
 	"io/ioutil"
+	t "log"
 	"os"
 	"testing"
 )
@@ -58,7 +60,7 @@ func TestWriteOutKeyAndCsr(t *testing.T) {
 	fileName := temp.Name()
 	temp.Close()
 	cf.file = fileName
-	err = writeOutKeyAndCsr(cf, key, csr)
+	err = writeOutKeyAndCsr(commandGenCSRName, cf, key, csr)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}
@@ -76,4 +78,121 @@ func getCommandFlags() *commandFlags {
 	cf.keyCurve = certificate.EllipticCurveP384
 
 	return &cf
+}
+
+func TestGenerateCsrJsonFormat(t *testing.T) {
+	t.Skip()
+	//
+	//	flags := getCommandFlags()
+	//
+	//
+	//	flags.csrFile = "/Users/rvelamia/Desktop/vcertWorkingDir/cert.csr"
+	//	flags.keyFile = "/Users/rvelamia/Desktop/vcertWorkingDir/cert.key"
+	//	flags.csrFormat = "json"
+	//	flags.noPrompt = true
+	//	flags.commonName = "localhost"
+	//	flags.org = "venafi"
+	//	flags.orgUnits = stringSlice{"devops"}
+	//	flags.keyTypeString = "rsa"
+	//	kt := certificate.KeyTypeRSA
+	//	flags.keyType = &kt
+	//	flags.keySize = 4096
+	//	flags.locality = "Merida"
+	//	flags.state = "Yucatan"
+	//	flags.country = "Mx"
+	//
+	//	key, csr, err := generateCsrForCommandGenCsr(flags, []byte(flags.keyPassword))
+	//	if err != nil {
+	//		t.Fatalf("%s", err)
+	//	}
+	//	err = writeOutKeyAndCsr(commandGenCSRName, flags, key, csr)
+	//	if err != nil {
+	//		t.Fatalf("%s", err)
+	//	}
+	//
+	//	csrData, err := ioutil.ReadFile(flags.csrFile)
+	//	if err != nil {
+	//		t.Fatalf("%s", err)
+	//	}
+	//	keyData, err := ioutil.ReadFile(flags.keyFile)
+	//	if err != nil {
+	//		t.Fatalf("%s", err)
+	//	}
+	//
+	//	csrStr := byteToStr(csrData)
+	//	keyStr := byteToStr(keyData)
+	//
+	//	csrStr = strings.TrimLeft(csrStr, "{\"Certificate\":")
+	//	csrStr = strings.TrimRight(csrStr, "}")
+	//	keyStr = strings.TrimLeft(keyStr, "{\"PrivateKey\":")
+	//	keyStr = strings.TrimRight(keyStr, "}")
+	//
+	//	jsonBody := "{\n" +
+	//		"\"PolicyDN\" : \"rvela.test.venafi.example.com\",\n" +
+	//		"\"ObjectName\" : \"rvela.demoGo\",\n" +
+	//		"\"CertificateData\" : \"" + csrStr + ",\n" +
+	//		"\"PrivateKeyData\" : \"" + keyStr + ",\n" +
+	//		"\"Password\" : \"\",\n" +
+	//		"\"CASpecificAttributes\" : \"[]\",\n" +
+	//		"\"Reconcile\" : false\n" +
+	//		"}"
+	//
+	//	//Json client
+	//	client := resty.New()
+	//	apiResp, err := client.R().
+	//		SetHeader("Content-type", "application/json").
+	//		SetAuthToken(token).
+	//		SetBody(jsonBody).
+	//		Post(flags.url + "/vedsdk/certificates/import")
+	//
+	//	fmt.Println(apiResp.Header())
+}
+
+func TestGenerateCsrJson(t *testing.T) {
+	cf := getCommandFlags()
+
+	cf.csrFormat = "json"
+	cf.noPrompt = true
+
+	key, csr := generateCsrJson(cf)
+
+	jsonOutput := Output{}
+	err := json.Unmarshal(csr, jsonOutput)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	if jsonOutput.Certificate == "" {
+		t.Fatalf("CSR data is empty")
+	}
+
+	err = json.Unmarshal(key, jsonOutput)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	if jsonOutput.PrivateKey == "" {
+		t.Fatalf("CSR data is empty")
+	}
+}
+
+func TestGenerateCsrJsonSingleFile(t *testing.T) {
+	return
+}
+
+func TestGenerateCsrJsonMultipleFiles(t *testing.T) {
+	return
+}
+
+func generateCsrJson(cf *commandFlags) (key []byte, csr []byte) {
+
+	key, csr, err := generateCsrForCommandGenCsr(cf, []byte(cf.keyPassword))
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	if key == nil {
+		t.Fatalf("Key should not be nil")
+	}
+	if csr == nil {
+		t.Fatalf("CSR should not be nil")
+	}
+	return
 }

--- a/cmd/vcert/generate_test.go
+++ b/cmd/vcert/generate_test.go
@@ -108,7 +108,7 @@ func TestGenerateCsrJson(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%s", err)
 	}
-	if csrOutput.Certificate == "" {
+	if csrOutput.CSR == "" {
 		t.Fatalf("CSR data is not in expected format : JSON")
 	}
 

--- a/cmd/vcert/result_writer.go
+++ b/cmd/vcert/result_writer.go
@@ -37,6 +37,7 @@ type Config struct {
 	AllFile      string
 	KeyFile      string
 	CertFile     string
+	CSRFile      string
 	ChainFile    string
 	PickupIdFile string
 
@@ -51,6 +52,7 @@ type Result struct {
 
 type Output struct {
 	Certificate string   `json:",omitempty"`
+	CSR         string   `json:",omitempty"`
 	PrivateKey  string   `json:",omitempty"`
 	Chain       []string `json:",omitempty"`
 	PickupId    string   `json:",omitempty"`
@@ -184,6 +186,7 @@ func (r *Result) Flush() error {
 		allFileOutput.PrivateKey = r.Pcc.PrivateKey
 		allFileOutput.Certificate = r.Pcc.Certificate
 		allFileOutput.Chain = r.Pcc.Chain
+		allFileOutput.CSR = r.Pcc.CSR
 
 		var bytes []byte
 		if r.Config.Format == "pkcs12" {
@@ -200,6 +203,7 @@ func (r *Result) Flush() error {
 		err = ioutil.WriteFile(r.Config.AllFile, bytes, 0600)
 		errors = append(errors, err)
 	} else {
+
 		if r.Config.CertFile != "" && r.Pcc.Certificate != "" {
 			certFileOutput := &Output{}
 			certFileOutput.Certificate = r.Pcc.Certificate
@@ -207,29 +211,25 @@ func (r *Result) Flush() error {
 				certFileOutput.Chain = r.Pcc.Chain
 			}
 			err = writeFile(certFileOutput, r.Config, r.Config.CertFile)
-			//bytes, err := certFileOutput.Format(r.Config)
-			//if err != nil {
-			//	return err // something worse than file permission problem
-			//} else {
-			//	err = ioutil.WriteFile(r.Config.CertFile, bytes, 0600)
 			errors = append(errors, err)
-			//}
 		} else {
 			stdOut.Certificate = r.Pcc.Certificate
+		}
+
+		if r.Config.CSRFile != "" && r.Pcc.CSR != "" {
+			csrFileOutput := &Output{}
+			csrFileOutput.CSR = r.Pcc.CSR
+			err = writeFile(csrFileOutput, r.Config, r.Config.CSRFile)
+			errors = append(errors, err)
+		} else {
+			stdOut.CSR = r.Pcc.CSR
 		}
 
 		if r.Config.KeyFile != "" && r.Pcc.PrivateKey != "" {
 			keyFileOutput := &Output{}
 			keyFileOutput.PrivateKey = r.Pcc.PrivateKey
 			err = writeFile(keyFileOutput, r.Config, r.Config.KeyFile)
-			//bytes, err := keyFileOutput.Format(r.Config)
-			//err = ioutil.WriteFile(r.Config.KeyFile, []byte(r.format(r.Pcc.PrivateKey)), 0600)
-			//if err != nil{
-			//	return err
-			//}else{
-			//	err = ioutil.WriteFile(r.Config.KeyFile, bytes, 0600)
 			errors = append(errors, err)
-			//}
 		} else {
 			stdOut.PrivateKey = r.Pcc.PrivateKey
 		}
@@ -238,14 +238,7 @@ func (r *Result) Flush() error {
 			chainFileOutput := &Output{}
 			chainFileOutput.Chain = r.Pcc.Chain
 			err = writeFile(chainFileOutput, r.Config, r.Config.ChainFile)
-			//bytes, err := chainFileOutput.Format(r.Config)
-			//err = ioutil.WriteFile(r.Config.ChainFile, []byte(r.formatChain(r.Pcc.Chain)), 0600)
-			//if err != nil{
-			//	return err
-			//}else{
-			//	err = ioutil.WriteFile(r.Config.ChainFile, bytes, 0600)
 			errors = append(errors, err)
-			//}
 		} else if r.Config.CertFile == "" {
 			stdOut.Chain = r.Pcc.Chain
 		}
@@ -256,7 +249,6 @@ func (r *Result) Flush() error {
 			pickupFileOutput := &Output{}
 			pickupFileOutput.PickupId = r.PickupId
 			err = writeFile(pickupFileOutput, r.Config, r.Config.PickupIdFile)
-			//err = ioutil.WriteFile(r.Config.PickupIdFile, []byte(r.format(r.PickupId)+"\n"), 0600)
 			errors = append(errors, err)
 		} else {
 			stdOut.PickupId = r.PickupId

--- a/cmd/vcert/result_writer_test.go
+++ b/cmd/vcert/result_writer_test.go
@@ -117,6 +117,7 @@ func TestPKCS12withEncPK(t *testing.T) {
 			"",
 			"",
 			"",
+			"",
 			"asdf",
 		},
 	}
@@ -145,6 +146,7 @@ func TestPKCS12withPlainPK(t *testing.T) {
 			"",
 			"",
 			"",
+			"",
 		},
 	}
 	err := result.Flush()
@@ -167,6 +169,7 @@ func TestPKCS12withPlainEcPK(t *testing.T) {
 			"pkcs12",
 			certificate.ChainOptionFromString(""),
 			"/tmp/TestPKCS12withPlainEcPK",
+			"",
 			"",
 			"",
 			"",

--- a/cmd/vcert/validators.go
+++ b/cmd/vcert/validators.go
@@ -54,7 +54,7 @@ func validateCommonFlags(commandName string) error {
 	if flags.format != "" && flags.format != "pem" && flags.format != "json" && flags.format != "pkcs12" {
 		return fmt.Errorf("Unexpected output format: %s", flags.format)
 	}
-	if flags.file != "" && (flags.certFile != "" || flags.chainFile != "" || flags.keyFile != "" || flags.csrFile != "") {
+	if flags.file != "" && (flags.certFile != "" || flags.chainFile != "" || flags.keyFile != "") {
 		return fmt.Errorf("The '-file' option cannot be used used with any other -*-file flags. Either all data goes into one file or individual files must be specified using the appropriate flags")
 	}
 

--- a/cmd/vcert/validators.go
+++ b/cmd/vcert/validators.go
@@ -54,7 +54,7 @@ func validateCommonFlags(commandName string) error {
 	if flags.format != "" && flags.format != "pem" && flags.format != "json" && flags.format != "pkcs12" {
 		return fmt.Errorf("Unexpected output format: %s", flags.format)
 	}
-	if flags.file != "" && (flags.certFile != "" || flags.chainFile != "" || flags.keyFile != "") {
+	if flags.file != "" && (flags.certFile != "" || flags.chainFile != "" || flags.keyFile != "" || flags.csrFile != "") {
 		return fmt.Errorf("The '-file' option cannot be used used with any other -*-file flags. Either all data goes into one file or individual files must be specified using the appropriate flags")
 	}
 

--- a/examples/simple-cli/main_test.go
+++ b/examples/simple-cli/main_test.go
@@ -29,9 +29,10 @@ import (
 	"time"
 )
 
-var effectiveConfig = tppConfig
+var effectiveConfig *vcert.Config
 
 func init() {
+	effectiveConfig = tppConfig
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a // indirect
 	github.com/urfave/cli/v2 v2.1.1
 	golang.org/x/crypto v0.0.0-20190424203555-c05e17bb3b2d
-	golang.org/x/sys v0.0.0-20190425045458-9f0b1ff7b46a // indirect
+	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd // indirect
 	gopkg.in/ini.v1 v1.38.2
 	software.sslmate.com/src/go-pkcs12 v0.0.0-20180114231543-2291e8f0f237
 )

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190425045458-9f0b1ff7b46a h1:8cVTj31lbQ2I9z63Y1LjjHVKGisLuXDt12kKR0+r89w=
-golang.org/x/sys v0.0.0-20190425045458-9f0b1ff7b46a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/certificate/certificateCollection.go
+++ b/pkg/certificate/certificateCollection.go
@@ -55,6 +55,7 @@ type PEMCollection struct {
 	Certificate string   `json:",omitempty"`
 	PrivateKey  string   `json:",omitempty"`
 	Chain       []string `json:",omitempty"`
+	CSR         string   `json:",omitempty"`
 }
 
 //NewPEMCollection creates a PEMCollection based on the data being passed in


### PR DESCRIPTION
The follwing set of fixes provides the ability to generate the CSR and private key in json format.
Also fixes an issue with the enroll command and the json format when exported to multiple files (certificate, key, chain). The json structure was not generated correctly.