### PR TITLE
CSR not being output when using --format pem

### DIFF
--- a/cmd/vcert/result_writer.go
+++ b/cmd/vcert/result_writer.go
@@ -128,25 +128,17 @@ func (o *Output) Format(c *Config) ([]byte, error) {
 
 	default: // pem
 		res := ""
-		certValue := ""
-		if o.Certificate == "" {
-			if o.CSR != "" {
-				certValue = o.CSR
-			}
-		} else {
-			certValue = o.Certificate
-		}
-
 		switch c.ChainOption {
 		case certificate.ChainOptionRootFirst:
 			res += strings.Join(o.Chain, "")
-			res += certValue
+			res += o.Certificate
 			res += o.PrivateKey
 		case certificate.ChainOptionIgnore:
-			res += certValue
+			res += o.Certificate
 			res += o.PrivateKey
 		default:
-			res += certValue
+			res += o.Certificate
+			res += o.CSR
 			res += o.PrivateKey
 			res += strings.Join(o.Chain, "")
 		}

--- a/cmd/vcert/result_writer.go
+++ b/cmd/vcert/result_writer.go
@@ -128,16 +128,25 @@ func (o *Output) Format(c *Config) ([]byte, error) {
 
 	default: // pem
 		res := ""
+		certValue := ""
+		if o.Certificate == "" {
+			if o.CSR != "" {
+				certValue = o.CSR
+			}
+		} else {
+			certValue = o.Certificate
+		}
+
 		switch c.ChainOption {
 		case certificate.ChainOptionRootFirst:
 			res += strings.Join(o.Chain, "")
-			res += o.Certificate
+			res += certValue
 			res += o.PrivateKey
 		case certificate.ChainOptionIgnore:
-			res += o.Certificate
+			res += certValue
 			res += o.PrivateKey
 		default:
-			res += o.Certificate
+			res += certValue
 			res += o.PrivateKey
 			res += strings.Join(o.Chain, "")
 		}


### PR DESCRIPTION
The following fix solves an issue where the csr is not being output in console or file when using --format pem