### PR TITLE
Fix pickup id bad format

### DIFF
--- a/cmd/vcert/result_writer.go
+++ b/cmd/vcert/result_writer.go
@@ -278,7 +278,7 @@ func (r *Result) Flush() error {
 }
 
 func writeFile(output *Output, result *Result, filePath string) (err error) {
-	if output.Certificate != "" || output.PrivateKey != "" || output.CSR != "" {
+	if output.Certificate != "" || output.PrivateKey != "" || output.CSR != "" || len(output.Chain) > 0 {
 		var bytes []byte
 		bytes, err = output.Format(result.Config)
 		if err != nil {

--- a/cmd/vcert/result_writer.go
+++ b/cmd/vcert/result_writer.go
@@ -286,7 +286,7 @@ func writeFile(output *Output, result *Result, filePath string) (err error) {
 
 	} else {
 		if output.PickupId != "" {
-			err = ioutil.WriteFile(result.Config.PickupIdFile, []byte(result.format(result.PickupId)+"\n"), 0600)
+			err = ioutil.WriteFile(result.Config.PickupIdFile, []byte(result.PickupId+"\n"), 0600)
 		}
 	}
 	return

--- a/cmd/vcert/result_writer.go
+++ b/cmd/vcert/result_writer.go
@@ -279,9 +279,10 @@ func (r *Result) Flush() error {
 
 func writeFile(output *Output, result *Result, filePath string) (err error) {
 	if output.Certificate != "" || output.PrivateKey != "" || output.CSR != "" {
-		bytes, err := output.Format(result.Config)
+		var bytes []byte
+		bytes, err = output.Format(result.Config)
 		if err != nil {
-			return err // something worse than file permission problem
+			return // something worse than file permission problem
 		}
 		err = ioutil.WriteFile(filePath, bytes, 0600)
 
@@ -290,5 +291,5 @@ func writeFile(output *Output, result *Result, filePath string) (err error) {
 			err = ioutil.WriteFile(result.Config.PickupIdFile, []byte(result.format(result.PickupId)+"\n"), 0600)
 		}
 	}
-	return err
+	return
 }

--- a/cmd/vcert/result_writer.go
+++ b/cmd/vcert/result_writer.go
@@ -261,9 +261,7 @@ func (r *Result) Flush() error {
 	if err != nil {
 		return err // something worse than file permission problem
 	}
-	s := string(bytes)
-	s += "\n"
-	fmt.Fprint(os.Stdout, s)
+	fmt.Fprint(os.Stdout, string(bytes))
 
 	var finalError error
 	for _, e := range errors {


### PR DESCRIPTION
Fixes the pickup id serialization in the file. A key, value pair was being serialized, which is incorrect and breaks backwards compatibility. Change reverts back to only serialize the pickup id

