### PR TITLE
Fixed an issue with tests failing because of the TLS renegotiation issue

### DIFF
--- a/cmd/vcert/generate_test.go
+++ b/cmd/vcert/generate_test.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"encoding/json"
-  "github.com/Venafi/vcert/v4/pkg/certificate"
+	"github.com/Venafi/vcert/v4/pkg/certificate"
 	"io/ioutil"
 	t "log"
 	"os"

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -44,7 +44,9 @@ var ctx *test.Context
 
 func init() {
 	ctx = test.GetEnvContext()
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{
+		Renegotiation:      tls.RenegotiateFreelyAsClient,
+		InsecureSkipVerify: true}
 
 	if ctx.TPPurl == "" {
 		fmt.Println("TPP URL cannot be empty. See Makefile")


### PR DESCRIPTION
Some tests are failing because of the TLS renegotiation configuration not being setup for them.