### PR TITLE
Fixes for issue #134 and fixing tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ build: get
 	env GOOS=linux   GOARCH=amd64 go build $(GO_LDFLAGS) -o bin/linux/vcert         ./cmd/vcert
 	env GOOS=linux   GOARCH=386   go build $(GO_LDFLAGS) -o bin/linux/vcert86       ./cmd/vcert
 	env GOOS=darwin  GOARCH=amd64 go build $(GO_LDFLAGS) -o bin/darwin/vcert        ./cmd/vcert
-	env GOOS=darwin  GOARCH=386   go build $(GO_LDFLAGS) -o bin/darwin/vcert86      ./cmd/vcert
 	env GOOS=windows GOARCH=amd64 go build $(GO_LDFLAGS) -o bin/windows/vcert.exe   ./cmd/vcert
 	env  GOOS=windows GOARCH=386   go build $(GO_LDFLAGS) -o bin/windows/vcert86.exe ./cmd/vcert
 

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ build: get
 	env GOOS=linux   GOARCH=amd64 go build $(GO_LDFLAGS) -o bin/linux/vcert         ./cmd/vcert
 	env GOOS=linux   GOARCH=386   go build $(GO_LDFLAGS) -o bin/linux/vcert86       ./cmd/vcert
 	env GOOS=darwin  GOARCH=amd64 go build $(GO_LDFLAGS) -o bin/darwin/vcert        ./cmd/vcert
+	env GOOS=darwin  GOARCH=386 go build $(GO_LDFLAGS) -o bin/darwin/vcert        ./cmd/vcert
 	env GOOS=windows GOARCH=amd64 go build $(GO_LDFLAGS) -o bin/windows/vcert.exe   ./cmd/vcert
 	env  GOOS=windows GOARCH=386   go build $(GO_LDFLAGS) -o bin/windows/vcert86.exe ./cmd/vcert
 
@@ -59,6 +60,9 @@ tpp_test: get
 
 cloud_test: get
 	go test -v $(GOFLAGS) ./pkg/venafi/cloud
+
+cmd_test: get
+	go test -v $(GOFLAGS) ./cmd/vcert
 
 collect_artifacts:
 	rm -rf artifcats

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ build: get
 	env GOOS=linux   GOARCH=amd64 go build $(GO_LDFLAGS) -o bin/linux/vcert         ./cmd/vcert
 	env GOOS=linux   GOARCH=386   go build $(GO_LDFLAGS) -o bin/linux/vcert86       ./cmd/vcert
 	env GOOS=darwin  GOARCH=amd64 go build $(GO_LDFLAGS) -o bin/darwin/vcert        ./cmd/vcert
-	env GOOS=darwin  GOARCH=386 go build $(GO_LDFLAGS) -o bin/darwin/vcert        ./cmd/vcert
+	env GOOS=darwin  GOARCH=386 go build $(GO_LDFLAGS) -o bin/darwin/vcert86       ./cmd/vcert
 	env GOOS=windows GOARCH=amd64 go build $(GO_LDFLAGS) -o bin/windows/vcert.exe   ./cmd/vcert
 	env  GOOS=windows GOARCH=386   go build $(GO_LDFLAGS) -o bin/windows/vcert86.exe ./cmd/vcert
 

--- a/README.md
+++ b/README.md
@@ -109,11 +109,9 @@ Integration tests for Trust Protection Platform and Cloud products require endpo
 export TPP_URL=https://tpp.venafi.example/vedsdk
 export TPP_USER=tpp-user
 export TPP_PASSWORD=tpp-password
-export TPP_ZONE='some\policy'
-export TPP_ZONE_RESTRICTED='some\policy'
-export TPP_ZONE_ECDSA='some\policy'
-
-make tpp_test
+export TPP_ZONE='some\suggested_policy'
+export TPP_ZONE_RESTRICTED='some\locked_policy'
+export TPP_ZONE_ECDSA='some\ecdsa_policy'
 ```
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ export TPP_URL=https://tpp.venafi.example/vedsdk
 export TPP_USER=tpp-user
 export TPP_PASSWORD=tpp-password
 export TPP_ZONE='some\policy'
+export TPP_ZONE_RESTRICTED='some\policy'
+export TPP_ZONE_ECDSA='some\policy'
 
 make tpp_test
 ```

--- a/cmd/vcert/generate_test.go
+++ b/cmd/vcert/generate_test.go
@@ -18,11 +18,12 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/Venafi/vcert/v4/pkg/certificate"
 	"io/ioutil"
 	t "log"
 	"os"
 	"testing"
+
+	"github.com/Venafi/vcert/v4/pkg/certificate"
 )
 
 func TestGenerateCsrForCommandGenCsr(t *testing.T) {
@@ -82,8 +83,8 @@ func getCommandFlags() *commandFlags {
 
 func TestGenerateCsrJson(t *testing.T) {
 
-	csrName := os.TempDir() + "csr.txt"
-	keyName := os.TempDir() + "key.txt"
+	csrName := os.TempDir() + "/csr.txt"
+	keyName := os.TempDir() + "/key.txt"
 
 	cf := getCommandFlags()
 	cf.csrFormat = "json"

--- a/cmd/vcert/generate_test.go
+++ b/cmd/vcert/generate_test.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	t "log"
 	"os"
@@ -83,8 +84,8 @@ func getCommandFlags() *commandFlags {
 
 func TestGenerateCsrJson(t *testing.T) {
 
-	csrName := os.TempDir() + "/csr.txt"
-	keyName := os.TempDir() + "/key.txt"
+	csrName := os.TempDir() + fmt.Sprintf("%ccsr.txt", os.PathSeparator)
+	keyName := os.TempDir() + fmt.Sprintf("%ckey.txt", os.PathSeparator)
 
 	cf := getCommandFlags()
 	cf.csrFormat = "json"

--- a/cmd/vcert/main_test.go
+++ b/cmd/vcert/main_test.go
@@ -23,8 +23,6 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
-	"github.com/Venafi/vcert/v4/pkg/certificate"
-	"github.com/Venafi/vcert/v4/pkg/endpoint"
 	"io/ioutil"
 	"math/big"
 	"net"
@@ -33,6 +31,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Venafi/vcert/v4/pkg/certificate"
+	"github.com/Venafi/vcert/v4/pkg/endpoint"
 )
 
 var testEmail = "test@vcert.test"
@@ -918,4 +919,47 @@ func TestValidatePrecedenceForFlagsCloud(t *testing.T) {
 	}
 	unsetEnvironmentVariables()
 	unsetFlags()
+}
+
+func TestInvalidFileCSROptionFlagsTPP(t *testing.T) {
+
+	flags = commandFlags{}
+	var err error
+	flags.csrOption = "file:test.csr"
+	flags.keySize = 2048
+	flags.keyTypeString = "rsa"
+	flags.keyCurveString = "P521"
+
+	err = validateCommonFlags(commandEnrollName)
+	if err == nil {
+		t.Fatalf("Error was not expected to be nil.  The keySize, keyType and keyCurve options should not be allowed when csr option with file: is used")
+	}
+
+	flags.csrOption = "local"
+	flags.keySize = 2048
+	flags.keyTypeString = "rsa"
+	flags.keyCurveString = "P521"
+
+	err = validateCommonFlags(commandEnrollName)
+	if err != nil {
+		t.Fatalf("Error was expected to be nil; got %s. keySize, keyType and keyCurve are OK when local option is used", err)
+	}
+
+	flags.csrOption = "service"
+	flags.keySize = 2048
+	flags.keyTypeString = "rsa"
+	flags.keyCurveString = "P521"
+
+	err = validateCommonFlags(commandEnrollName)
+	if err != nil {
+		t.Fatalf("Error was expected to be nil; got %s. keySize, keyType and keyCurve are OK when service option is used", err)
+	}
+
+	flags.csrOption = "service"
+	flags.keySize = 2048
+
+	err = validateCommonFlags(commandEnrollName)
+	if err != nil {
+		t.Fatalf("Error was expected to be nil; got %s. keySize are OK when service option is used", err)
+	}
 }

--- a/cmd/vcert/validators.go
+++ b/cmd/vcert/validators.go
@@ -59,9 +59,15 @@ func validateCommonFlags(commandName string) error {
 		return fmt.Errorf("The '-file' option cannot be used used with any other -*-file flags. Either all data goes into one file or individual files must be specified using the appropriate flags")
 	}
 
-	csrOptionRegex := regexp.MustCompile(`^file:.*$|^local$|^service$|^$`)
+	csrOptionRegex := regexp.MustCompile(`(^file:).*$|^local$|^service$|^$`)
 	if !csrOptionRegex.MatchString(flags.csrOption) {
-		return fmt.Errorf("unexpected -csr option provided: %s; specify one of the following options: %s, %s, or %s.", flags.csrOption, "'file:<filename>'", "'local'", "'service'")
+		return fmt.Errorf("unexpected -csr option provided: %s; specify one of the following options: %s, %s, or %s", flags.csrOption, "'file:<filename>'", "'local'", "'service'")
+	}
+
+	csrOptFlagResults := csrOptionRegex.FindStringSubmatch(flags.csrOption)
+
+	if csrOptFlagResults[1] != "" && (flags.keyTypeString != "" || flags.keyCurveString != "" || flags.keySize > 0) {
+		return fmt.Errorf("the '-keytype','-keycurve' and 'key-size' options cannot be used when '-csr file:' option is provided")
 	}
 
 	switch flags.keyTypeString {

--- a/cmd/vcert/validators.go
+++ b/cmd/vcert/validators.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/Venafi/vcert/v4/pkg/certificate"
 	"io/ioutil"
 	"regexp"
 	"strings"
+
+	"github.com/Venafi/vcert/v4/pkg/certificate"
 )
 
 // RevocationReasonOptions is an array of strings containing reasons for certificate revocation
@@ -60,7 +61,7 @@ func validateCommonFlags(commandName string) error {
 
 	csrOptionRegex := regexp.MustCompile(`^file:.*$|^local$|^service$|^$`)
 	if !csrOptionRegex.MatchString(flags.csrOption) {
-		return fmt.Errorf("unexpected -csr option: %s", flags.csrOption)
+		return fmt.Errorf("unexpected -csr option provided: %s; specify one of the following options: %s, %s, or %s.", flags.csrOption, "'file:<filename>'", "'local'", "'service'")
 	}
 
 	switch flags.keyTypeString {

--- a/cmd/vcert/validators.go
+++ b/cmd/vcert/validators.go
@@ -61,13 +61,13 @@ func validateCommonFlags(commandName string) error {
 
 	csrOptionRegex := regexp.MustCompile(`(^file:).*$|^local$|^service$|^$`)
 	if !csrOptionRegex.MatchString(flags.csrOption) {
-		return fmt.Errorf("unexpected -csr option provided: %s; specify one of the following options: %s, %s, or %s", flags.csrOption, "'file:<filename>'", "'local'", "'service'")
+		return fmt.Errorf("unexpected --csr option provided: %s; specify one of the following options: %s, %s, or %s", flags.csrOption, "'file:<filename>'", "'local'", "'service'")
 	}
 
 	csrOptFlagResults := csrOptionRegex.FindStringSubmatch(flags.csrOption)
 
 	if csrOptFlagResults[1] != "" && (flags.keyTypeString != "" || flags.keyCurveString != "" || flags.keySize > 0) {
-		return fmt.Errorf("the '-keytype','-keycurve' and 'key-size' options cannot be used when '-csr file:' option is provided")
+		return fmt.Errorf("the '--keytype','--keycurve' and '--key-size' options cannot be used when '--csr file:' option is provided")
 	}
 
 	switch flags.keyTypeString {

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -1249,7 +1249,7 @@ func Test_GetCertificateList(t *testing.T) {
 			}
 		}
 		if len(set) != count {
-			t.Errorf("mismatched certificates number: wait %d, got %d", count, len(set))
+			t.Errorf("mismatched certificates number: wait %d, got %d for zone %s", count, len(set), ctx.TPPZone)
 		}
 	}
 }


### PR DESCRIPTION
This PR attempts to address the issues reported in #134 . For this fix, I also included some minor updates to the docs to indicate all the environment variables that should be set when running 'make tpp_test'. I also added some new tests for the cmd package and added an option to the makefile to be able to run those tests with make. Finally, I fixed a broken test in the cmd package where the path separator was missing from a call to create a local file.

I am not setup to run cross-platform tests across all 3 platforms and the only test I am unable to execute successfully is Test_GetCertificateList in pkg/venafi/tpp due to not having a system with a large enough list of certificates in a single policy folder to test against. Other than these comments, all TPP tests pass on Linux as well as all cmd/vcert tests pass.