### PR TITLE
Fix for: Add the ability to specify validity when requesting a certificate

### DIFF
--- a/cmd/vcert/args.go
+++ b/cmd/vcert/args.go
@@ -94,4 +94,5 @@ type commandFlags struct {
 	zone              string
 	omitSans          bool
 	csrFormat         string
+	validDays         string
 }

--- a/cmd/vcert/flags.go
+++ b/cmd/vcert/flags.go
@@ -448,8 +448,8 @@ var (
 
 	flagValidDays = &cli.StringFlag{
 		Name: "valid-days",
-		Usage: "Specify the number of days a certificate will be valid, and also the Issuer hint, it will have this format number_of_days#issuer_hint\n" +
-			"\toptions	 for issuer hint will be D for DIGICERT, E for ENTRUST, and M for MICROSOFT, so a valid example would be 30#M\n",
+		Usage: "Specify the number of days a certificate needs to be valid. For TPP, optionally indicate the target issuer by\n" +
+			"\tappending #D for DigiCert, #E for Entrust, or #M for Microsoft. Example: --valid-days 90#M\n",
 		Destination: &flags.validDays,
 	}
 

--- a/cmd/vcert/flags.go
+++ b/cmd/vcert/flags.go
@@ -446,6 +446,13 @@ var (
 		Value:       "pem",
 	}
 
+	flagValidDays = &cli.StringFlag{
+		Name: "valid-days",
+		Usage: "Specify the number of days a certificate will be valid, and also the Issuer hint, it will have this format number_of_days#issuer_hint\n" +
+			"\toptions	 for issuer hint will be D for DIGICERT, E for ENTRUST, and M for MICROSOFT, so a valid example would be 30#M\n",
+		Destination: &flags.validDays,
+	}
+
 	commonFlags              = []cli.Flag{flagInsecure, flagFormat, flagVerbose, flagNoPrompt}
 	keyFlags                 = []cli.Flag{flagKeyType, flagKeySize, flagKeyCurve, flagKeyFile, flagKeyPassword}
 	sansFlags                = []cli.Flag{flagDNSSans, flagEmailSans, flagIPSans, flagURISans, flagUPNSans}
@@ -508,6 +515,7 @@ var (
 			flagInstance,
 			flagReplace,
 			flagOmitSans,
+			flagValidDays,
 		)),
 	)
 

--- a/cmd/vcert/main_test.go
+++ b/cmd/vcert/main_test.go
@@ -920,7 +920,7 @@ func TestValidatePrecedenceForFlagsCloud(t *testing.T) {
 	unsetFlags()
 }
 
-func TestValidateValidDaysFlagWithValidValues(t *testing.T) {
+func TestValidateValidDaysFlag(t *testing.T) {
 
 	context := getCliEnrollContext()
 
@@ -935,7 +935,7 @@ func TestValidateValidDaysFlagWithValidValues(t *testing.T) {
 	unsetFlags()
 }
 
-func TestValidateValidDaysFlagWithInvalidValidValues(t *testing.T) {
+func TestValidateValidDaysFlagWithInvalidValues(t *testing.T) {
 
 	context := getCliEnrollContext()
 

--- a/cmd/vcert/main_test.go
+++ b/cmd/vcert/main_test.go
@@ -794,7 +794,7 @@ func TestConfigEnvironmentVariablesForTpp(t *testing.T) {
 	//create the environment variables.
 	setEnvironmentVariablesForTpp()
 
-	//create a context, thiw will be used on the build config function.
+	//create a context, this will be used on the build config function.
 	context := getCliContext()
 
 	cfg, err := buildConfig(context, &flags)
@@ -824,7 +824,7 @@ func TestConfigEnvironmentVariablesForCloud(t *testing.T) {
 	//create the environment variables.
 	setEnvironmentVariablesForCloud()
 
-	//create a context, thiw will be used on the build config function.
+	//create a context, this will be used on the build config function.
 	context := getCliContext()
 
 	cfg, err := buildConfig(context, &flags)
@@ -899,7 +899,7 @@ func TestValidatePrecedenceForFlagsCloud(t *testing.T) {
 	//create the environment variables.
 	setEnvironmentVariablesForCloud()
 
-	//create a context, thiw will be used on the build config function.
+	//create a context, this will be used on the build config function.
 	context := getCliContext()
 
 	cfg, err := buildConfig(context, &flags)
@@ -917,5 +917,35 @@ func TestValidatePrecedenceForFlagsCloud(t *testing.T) {
 		t.Fatalf("API key is empty")
 	}
 	unsetEnvironmentVariables()
+	unsetFlags()
+}
+
+func TestValidateValidDaysFlagWithValidValues(t *testing.T) {
+
+	context := getCliEnrollContext()
+
+	flags.validDays = validDaysData
+
+	valid := validateValidDaysFlag(context.Command.Name)
+
+	if !valid {
+		t.Fatal("--valid-days is set but, it have an invalid format/data")
+	}
+
+	unsetFlags()
+}
+
+func TestValidateValidDaysFlagWithInvalidValidValues(t *testing.T) {
+
+	context := getCliEnrollContext()
+
+	flags.validDays = invalidDaysData
+
+	valid := validateValidDaysFlag(context.Command.Name)
+
+	if valid {
+		t.Fatal("valid days Data format is invalid, then validation should not be valid")
+	}
+
 	unsetFlags()
 }

--- a/cmd/vcert/test_utils.go
+++ b/cmd/vcert/test_utils.go
@@ -11,6 +11,8 @@ const (
 	tppURlTestFlagValue   = "www.test.venafile.com"
 	cloudApiKeyTestValue  = "apiKeyTest"
 	cloudZoneTestValue    = "cloudZoneTest"
+	validDaysData         = "20#M"
+	invalidDaysData       = "0#S"
 )
 
 func setEnvironmentVariablesForTpp() {
@@ -36,6 +38,15 @@ func getCliContext() *cli.Context {
 	return context
 }
 
+func getCliEnrollContext() *cli.Context {
+	context := &cli.Context{
+		Command: &cli.Command{
+			Name: "enroll",
+		},
+	}
+	return context
+}
+
 func setEnvironmentVariablesForCloud() {
 	os.Setenv(vCertZone, "devops")
 	os.Setenv(vCertApiKey, "abvcekjej3232ssss")
@@ -49,4 +60,5 @@ func unsetFlags() {
 	flags.tppToken = ""
 	flags.zone = ""
 	flags.url = ""
+	flags.validDays = ""
 }

--- a/cmd/vcert/utils.go
+++ b/cmd/vcert/utils.go
@@ -27,6 +27,7 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -165,6 +166,36 @@ func fillCertificateRequest(req *certificate.Request, cf *commandFlags) *certifi
 		}
 		req.CsrOrigin = certificate.LocalGeneratedCSR
 	}
+
+	if cf.validDays != "" {
+		validDays := cf.validDays
+
+		data := strings.Split(validDays, "#")
+		days, _ := strconv.ParseInt(data[0], 10, 64)
+		hours := days * 24
+
+		req.ValidityHours = int(hours)
+
+		issuerHint := "Specific End Date"
+		if len(data) > 1 { //means that issuer hint is set
+
+			option := strings.ToLower(data[1])
+
+			switch option {
+
+			case "m":
+				issuerHint = "MICROSOFT"
+			case "d":
+				issuerHint = "DIGICERT"
+			case "e":
+				issuerHint = "ENTRUST"
+
+			}
+		}
+
+		req.IssuesHint = issuerHint
+	}
+
 	return req
 }
 

--- a/cmd/vcert/utils.go
+++ b/cmd/vcert/utils.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/Venafi/vcert/v4/pkg/certificate"
 	"github.com/Venafi/vcert/v4/pkg/endpoint"
+	"github.com/Venafi/vcert/v4/pkg/util"
 )
 
 const (
@@ -184,11 +185,11 @@ func fillCertificateRequest(req *certificate.Request, cf *commandFlags) *certifi
 			switch option {
 
 			case "m":
-				issuerHint = "MICROSOFT"
+				issuerHint = util.MicrosoftStr
 			case "d":
-				issuerHint = "DIGICERT"
+				issuerHint = util.DigicertConst
 			case "e":
-				issuerHint = "ENTRUST"
+				issuerHint = util.EntrustConst
 
 			}
 		}

--- a/cmd/vcert/utils.go
+++ b/cmd/vcert/utils.go
@@ -185,11 +185,11 @@ func fillCertificateRequest(req *certificate.Request, cf *commandFlags) *certifi
 			switch option {
 
 			case "m":
-				issuerHint = util.MicrosoftStr
+				issuerHint = util.IssuerHintMicrosoft
 			case "d":
-				issuerHint = util.DigicertConst
+				issuerHint = util.IssuerHintDigicert
 			case "e":
-				issuerHint = util.EntrustConst
+				issuerHint = util.IssuerHintEntrust
 
 			}
 		}

--- a/cmd/vcert/utils.go
+++ b/cmd/vcert/utils.go
@@ -174,9 +174,9 @@ func fillCertificateRequest(req *certificate.Request, cf *commandFlags) *certifi
 		days, _ := strconv.ParseInt(data[0], 10, 64)
 		hours := days * 24
 
-		req.ValidityHours = int(hours)
+		req.ExpirationDateAttribute = int(hours)
 
-		issuerHint := "Specific End Date"
+		issuerHint := ""
 		if len(data) > 1 { //means that issuer hint is set
 
 			option := strings.ToLower(data[1])
@@ -193,7 +193,7 @@ func fillCertificateRequest(req *certificate.Request, cf *commandFlags) *certifi
 			}
 		}
 
-		req.IssuesHint = issuerHint
+		req.IssuerHint = issuerHint
 	}
 
 	return req

--- a/cmd/vcert/utils.go
+++ b/cmd/vcert/utils.go
@@ -174,7 +174,7 @@ func fillCertificateRequest(req *certificate.Request, cf *commandFlags) *certifi
 		days, _ := strconv.ParseInt(data[0], 10, 64)
 		hours := days * 24
 
-		req.ExpirationDateAttribute = int(hours)
+		req.ValidityHours = int(hours)
 
 		issuerHint := ""
 		if len(data) > 1 { //means that issuer hint is set

--- a/cmd/vcert/validators.go
+++ b/cmd/vcert/validators.go
@@ -240,6 +240,17 @@ func validateEnrollFlags(commandName string) error {
 				return fmt.Errorf("-client-pkcs12-pw can only be specified in combination with -client-pkcs12")
 			}
 		}
+
+		if flags.validDays != "" {
+
+			valid := validateValidDaysFlag(commandName)
+
+			if !valid {
+				return fmt.Errorf("--valid-days is set but, it have an invalid format/data")
+			}
+
+		}
+
 	}
 
 	if flags.csrOption == "file" && flags.keyFile != "" { // Do not specify -key-file with -csr file as VCert cannot access the private key
@@ -268,6 +279,24 @@ func validateEnrollFlags(commandName string) error {
 	}
 
 	return nil
+}
+
+func validateValidDaysFlag(cn string) bool {
+	if cn != "enroll" {
+		return false
+	}
+
+	if flags.validDays != "" {
+
+		validDays := flags.validDays
+
+		var regex = regexp.MustCompile("[1-9]+[0-9]*(#[DdEeMm])?")
+
+		return regex.MatchString(validDays)
+
+	}
+
+	return true
 }
 
 func validateGetcredFlags1(commandName string) error {

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -193,12 +193,12 @@ type Request struct {
 	FetchPrivateKey bool
 	/*	Thumbprint is here because *Request is used in RetrieveCertificate().
 		Code should be refactored so that RetrieveCertificate() uses some abstract search object, instead of *Request{PickupID} */
-	Thumbprint              string
-	Timeout                 time.Duration
-	CustomFields            []CustomField
-	Location                *Location
-	ExpirationDateAttribute int
-	IssuerHint              string
+	Thumbprint    string
+	Timeout       time.Duration
+	CustomFields  []CustomField
+	Location      *Location
+	ValidityHours int
+	IssuerHint    string
 }
 
 type RevocationRequest struct {

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -193,12 +193,12 @@ type Request struct {
 	FetchPrivateKey bool
 	/*	Thumbprint is here because *Request is used in RetrieveCertificate().
 		Code should be refactored so that RetrieveCertificate() uses some abstract search object, instead of *Request{PickupID} */
-	Thumbprint    string
-	Timeout       time.Duration
-	CustomFields  []CustomField
-	Location      *Location
-	ValidityHours int
-	IssuesHint    string
+	Thumbprint              string
+	Timeout                 time.Duration
+	CustomFields            []CustomField
+	Location                *Location
+	ExpirationDateAttribute int
+	IssuerHint              string
 }
 
 type RevocationRequest struct {

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -193,10 +193,12 @@ type Request struct {
 	FetchPrivateKey bool
 	/*	Thumbprint is here because *Request is used in RetrieveCertificate().
 		Code should be refactored so that RetrieveCertificate() uses some abstract search object, instead of *Request{PickupID} */
-	Thumbprint   string
-	Timeout      time.Duration
-	CustomFields []CustomField
-	Location     *Location
+	Thumbprint    string
+	Timeout       time.Duration
+	CustomFields  []CustomField
+	Location      *Location
+	ValidityHours int
+	IssuesHint    string
 }
 
 type RevocationRequest struct {

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -1,7 +1,7 @@
 package util
 
 const (
-	MicrosoftStr  = "MICROSOFT"
-	DigicertConst = "DIGICERT"
-	EntrustConst  = "ENTRUST"
+	IssuerHintMicrosoft = "MICROSOFT"
+	IssuerHintDigicert  = "DIGICERT"
+	IssuerHintEntrust   = "ENTRUST"
 )

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -1,0 +1,7 @@
+package util
+
+const (
+	MicrosoftStr  = "MICROSOFT"
+	DigicertConst = "DIGICERT"
+	EntrustConst  = "ENTRUST"
+)

--- a/pkg/venafi/cloud/cloud.go
+++ b/pkg/venafi/cloud/cloud.go
@@ -84,6 +84,7 @@ type certificateRequest struct {
 	ExistingManagedCertificateId string                       `json:"existingManagedCertificateId,omitempty"`
 	ReuseCSR                     bool                         `json:"reuseCSR,omitempty"`
 	ApiClientInformation         certificateRequestClientInfo `json:"apiClientInformation,omitempty"`
+	ValidityPeriod               string                       `json:"validityPeriod,omitempty"`
 }
 
 type certificateStatus struct {

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -199,8 +199,8 @@ func (c *Connector) RequestCertificate(req *certificate.Request) (requestID stri
 		},
 	}
 
-	if req.ValidityHours > 0 {
-		hoursStr := strconv.Itoa(req.ValidityHours)
+	if req.ExpirationDateAttribute > 0 {
+		hoursStr := strconv.Itoa(req.ExpirationDateAttribute)
 		validityHoursStr := "PT" + hoursStr + "H"
 		cloudReq.ValidityPeriod = validityHoursStr
 	}

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -196,6 +197,12 @@ func (c *Connector) RequestCertificate(req *certificate.Request) (requestID stri
 			Type:       origin,
 			Identifier: ipAddr,
 		},
+	}
+
+	if req.ValidityHours > 0 {
+		hoursStr := strconv.Itoa(req.ValidityHours)
+		validityHoursStr := "PT" + hoursStr + "H"
+		cloudReq.ValidityPeriod = validityHoursStr
 	}
 
 	statusCode, status, body, err := c.request("POST", url, cloudReq)

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -199,8 +199,8 @@ func (c *Connector) RequestCertificate(req *certificate.Request) (requestID stri
 		},
 	}
 
-	if req.ExpirationDateAttribute > 0 {
-		hoursStr := strconv.Itoa(req.ExpirationDateAttribute)
+	if req.ValidityHours > 0 {
+		hoursStr := strconv.Itoa(req.ValidityHours)
 		validityHoursStr := "PT" + hoursStr + "H"
 		cloudReq.ValidityPeriod = validityHoursStr
 	}

--- a/pkg/venafi/cloud/connector_test.go
+++ b/pkg/venafi/cloud/connector_test.go
@@ -159,7 +159,7 @@ func TestRequestCertificateWithValidDays(t *testing.T) {
 	req.Subject.OrganizationalUnit = []string{"Automated Tests"}
 
 	validHours := 144
-	req.ExpirationDateAttribute = validHours
+	req.ValidityHours = validHours
 	req.IssuerHint = "MICROSOFT"
 
 	err = conn.GenerateRequest(zoneConfig, req)

--- a/pkg/venafi/cloud/connector_test.go
+++ b/pkg/venafi/cloud/connector_test.go
@@ -159,8 +159,8 @@ func TestRequestCertificateWithValidDays(t *testing.T) {
 	req.Subject.OrganizationalUnit = []string{"Automated Tests"}
 
 	validHours := 144
-	req.ValidityHours = validHours
-	req.IssuesHint = "MICROSOFT"
+	req.ExpirationDateAttribute = validHours
+	req.IssuerHint = "MICROSOFT"
 
 	err = conn.GenerateRequest(zoneConfig, req)
 	if err != nil {

--- a/pkg/venafi/cloud/connector_test.go
+++ b/pkg/venafi/cloud/connector_test.go
@@ -141,6 +141,81 @@ func TestRequestCertificate(t *testing.T) {
 	}
 }
 
+func TestRequestCertificateWithValidDays(t *testing.T) {
+	conn := getTestConnector(ctx.CloudZone)
+	conn.verbose = true
+	err := conn.Authenticate(&endpoint.Authentication{APIKey: ctx.CloudAPIkey})
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	zoneConfig, err := conn.ReadZoneConfiguration()
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	req := &certificate.Request{}
+	req.Subject.CommonName = test.RandCN()
+	req.Subject.Organization = []string{"Venafi, Inc."}
+	req.Subject.OrganizationalUnit = []string{"Automated Tests"}
+
+	validHours := 144
+	req.ValidityHours = validHours
+	req.IssuesHint = "MICROSOFT"
+
+	err = conn.GenerateRequest(zoneConfig, req)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	pickupID, err := conn.RequestCertificate(req)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	req.PickupID = pickupID
+	req.ChainOption = certificate.ChainOptionRootLast
+
+	pcc, _ := certificate.NewPEMCollection(nil, nil, nil)
+	startTime := time.Now()
+	for {
+
+		pcc, err = conn.RetrieveCertificate(req)
+		if err != nil {
+			_, ok := err.(endpoint.ErrCertificatePending)
+			if ok {
+				if time.Now().After(startTime.Add(time.Duration(600) * time.Second)) {
+					err = endpoint.ErrRetrieveCertificateTimeout{CertificateID: pickupID}
+					break
+				}
+				time.Sleep(time.Duration(10) * time.Second)
+				continue
+			}
+			break
+		}
+		break
+	}
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	p, _ := pem.Decode([]byte(pcc.Certificate))
+	cert, err := x509.ParseCertificate(p.Bytes)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	certValidUntil := cert.NotAfter.Format("2006-01-02")
+
+	//need to convert local date on utc, since the certificate' NotAfter value we got on previous step, is on utc
+	//so for comparing them we need to have both dates on utc.
+	loc, _ := time.LoadLocation("UTC")
+	utcNow := time.Now().In(loc)
+	expectedValidDate := utcNow.AddDate(0, 0, validHours/24).Format("2006-01-02")
+
+	if expectedValidDate != certValidUntil {
+		t.Fatalf("Expiration date is different than expected, expected: %s, but got %s: ", expectedValidDate, certValidUntil)
+	}
+
+}
+
 func TestRetrieveCertificate(t *testing.T) {
 	conn := getTestConnector(ctx.CloudZone)
 	err := conn.Authenticate(&endpoint.Authentication{APIKey: ctx.CloudAPIkey})

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -403,11 +403,11 @@ func prepareRequest(req *certificate.Request, zone string) (tppReq certificateRe
 	tppReq.CASpecificAttributes = append(tppReq.CASpecificAttributes, nameValuePair{Name: "Origin", Value: origin})
 	tppReq.Origin = origin
 
-	if req.ValidityHours > 0 {
+	if req.ExpirationDateAttribute > 0 {
 
 		issuerHint := ""
 
-		switch req.IssuesHint {
+		switch req.IssuerHint {
 		case "MICROSOFT":
 			issuerHint = "Microsoft CA:Specific End Date"
 		case "DIGICERT":
@@ -421,7 +421,7 @@ func prepareRequest(req *certificate.Request, zone string) (tppReq certificateRe
 		loc, _ := time.LoadLocation("UTC")
 		utcNow := time.Now().In(loc)
 
-		expirationDate := utcNow.AddDate(0, 0, req.ValidityHours/24)
+		expirationDate := utcNow.AddDate(0, 0, req.ExpirationDateAttribute/24)
 
 		formattedExpirationDate := fmt.Sprintf("%d-%02d-%02d %02d:%02d:%02d",
 			expirationDate.Year(), expirationDate.Month(), expirationDate.Day(), expirationDate.Hour(), expirationDate.Minute(), expirationDate.Second())

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -409,11 +409,11 @@ func prepareRequest(req *certificate.Request, zone string) (tppReq certificateRe
 		expirationDateAttribute := ""
 
 		switch req.IssuerHint {
-		case util.MicrosoftStr:
+		case util.IssuerHintMicrosoft:
 			expirationDateAttribute = "Microsoft CA:Specific End Date"
-		case util.DigicertConst:
+		case util.IssuerHintDigicert:
 			expirationDateAttribute = "DigiCert CA:Specific End Date"
-		case util.EntrustConst:
+		case util.IssuerHintEntrust:
 			expirationDateAttribute = "EntrustNET CA:Specific End Date"
 		default:
 			expirationDateAttribute = "Specific End Date"

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -403,30 +403,30 @@ func prepareRequest(req *certificate.Request, zone string) (tppReq certificateRe
 	tppReq.CASpecificAttributes = append(tppReq.CASpecificAttributes, nameValuePair{Name: "Origin", Value: origin})
 	tppReq.Origin = origin
 
-	if req.ExpirationDateAttribute > 0 {
+	if req.ValidityHours > 0 {
 
-		issuerHint := ""
+		expirationDateAttribute := ""
 
 		switch req.IssuerHint {
 		case "MICROSOFT":
-			issuerHint = "Microsoft CA:Specific End Date"
+			expirationDateAttribute = "Microsoft CA:Specific End Date"
 		case "DIGICERT":
-			issuerHint = "DigiCert CA:Specific End Date"
+			expirationDateAttribute = "DigiCert CA:Specific End Date"
 		case "ENTRUST":
-			issuerHint = "EntrustNET CA:Specific End Date"
+			expirationDateAttribute = "EntrustNET CA:Specific End Date"
 		default:
-			issuerHint = "Specific End Date"
+			expirationDateAttribute = "Specific End Date"
 		}
 
 		loc, _ := time.LoadLocation("UTC")
 		utcNow := time.Now().In(loc)
 
-		expirationDate := utcNow.AddDate(0, 0, req.ExpirationDateAttribute/24)
+		expirationDate := utcNow.AddDate(0, 0, req.ValidityHours/24)
 
 		formattedExpirationDate := fmt.Sprintf("%d-%02d-%02d %02d:%02d:%02d",
 			expirationDate.Year(), expirationDate.Month(), expirationDate.Day(), expirationDate.Hour(), expirationDate.Minute(), expirationDate.Second())
 
-		tppReq.CASpecificAttributes = append(tppReq.CASpecificAttributes, nameValuePair{Name: issuerHint, Value: formattedExpirationDate})
+		tppReq.CASpecificAttributes = append(tppReq.CASpecificAttributes, nameValuePair{Name: expirationDateAttribute, Value: formattedExpirationDate})
 
 	}
 

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"github.com/Venafi/vcert/v4/pkg/util"
 	"log"
 	"net/http"
 	neturl "net/url"
@@ -408,11 +409,11 @@ func prepareRequest(req *certificate.Request, zone string) (tppReq certificateRe
 		expirationDateAttribute := ""
 
 		switch req.IssuerHint {
-		case "MICROSOFT":
+		case util.MicrosoftStr:
 			expirationDateAttribute = "Microsoft CA:Specific End Date"
-		case "DIGICERT":
+		case util.DigicertConst:
 			expirationDateAttribute = "DigiCert CA:Specific End Date"
-		case "ENTRUST":
+		case util.EntrustConst:
 			expirationDateAttribute = "EntrustNET CA:Specific End Date"
 		default:
 			expirationDateAttribute = "Specific End Date"

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -486,8 +486,8 @@ func DoRequestCertificateWithValidHours(t *testing.T, tpp *Connector) {
 	}
 
 	validHours := 144
-	req.ValidityHours = validHours
-	req.IssuesHint = "MICROSOFT"
+	req.ExpirationDateAttribute = validHours
+	req.IssuerHint = "MICROSOFT"
 
 	err = tpp.GenerateRequest(config, req)
 	if err != nil {

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -486,7 +486,7 @@ func DoRequestCertificateWithValidHours(t *testing.T, tpp *Connector) {
 	}
 
 	validHours := 144
-	req.ExpirationDateAttribute = validHours
+	req.ValidityHours = validHours
 	req.IssuerHint = "MICROSOFT"
 
 	err = tpp.GenerateRequest(config, req)

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -449,6 +449,80 @@ func TestRequestCertificateToken(t *testing.T) {
 	DoRequestCertificate(t, tpp)
 }
 
+func TestRequestCertificateWithValidHours(t *testing.T) {
+	tpp, err := getTestConnector(ctx.TPPurl, ctx.TPPZone)
+	if err != nil {
+		t.Fatalf("err is not nil, err: %s url: %s", err, expectedURL)
+	}
+
+	if tpp.apiKey == "" {
+		err = tpp.Authenticate(&endpoint.Authentication{AccessToken: ctx.TPPaccessToken})
+		if err != nil {
+			t.Fatalf("err is not nil, err: %s", err)
+		}
+	}
+	DoRequestCertificateWithValidHours(t, tpp)
+}
+
+func DoRequestCertificateWithValidHours(t *testing.T, tpp *Connector) {
+	config, err := tpp.ReadZoneConfiguration()
+	if err != nil {
+		t.Fatalf("err is not nil, err: %s", err)
+	}
+
+	cn := test.RandCN()
+	req := &certificate.Request{Timeout: time.Second * 30}
+	req.Subject.CommonName = cn
+	req.Subject.Organization = []string{"Venafi, Inc."}
+	req.Subject.OrganizationalUnit = []string{"Automated Tests"}
+	req.Subject.Locality = []string{"Las Vegas"}
+	req.Subject.Province = []string{"Nevada"}
+	req.Subject.Country = []string{"US"}
+	u := url.URL{Scheme: "https", Host: "example.com", Path: "/test"}
+	req.URIs = []*url.URL{&u}
+	req.FriendlyName = cn
+	req.CustomFields = []certificate.CustomField{
+		{Name: "custom", Value: "2019-10-10"},
+	}
+
+	validHours := 144
+	req.ValidityHours = validHours
+	req.IssuesHint = "MICROSOFT"
+
+	err = tpp.GenerateRequest(config, req)
+	if err != nil {
+		t.Fatalf("err is not nil, err: %s", err)
+	}
+
+	t.Logf("getPolicyDN(ctx.TPPZone) = %s", getPolicyDN(ctx.TPPZone))
+	req.PickupID, err = tpp.RequestCertificate(req)
+	if err != nil {
+		t.Fatalf("err is not nil, err: %s", err)
+	}
+	certCollections, err := tpp.RetrieveCertificate(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, _ := pem.Decode([]byte(certCollections.Certificate))
+	cert, err := x509.ParseCertificate(p.Bytes)
+	if err != nil {
+		t.Fatalf("err is not nil, err: %s", err)
+	}
+
+	certValidUntil := cert.NotAfter.Format("2006-01-02")
+
+	//need to convert local date on utc, since the certificate' NotAfter value we got on previous step, is on utc
+	//so for comparing them we need to have both dates on utc.
+	loc, _ := time.LoadLocation("UTC")
+	utcNow := time.Now().In(loc)
+	expectedValidDate := utcNow.AddDate(0, 0, validHours/24).Format("2006-01-02")
+
+	if expectedValidDate != certValidUntil {
+		t.Fatalf("Expiration date is different than expected, expected: %s, but got %s: ", expectedValidDate, certValidUntil)
+	}
+
+}
+
 func DoRequestCertificate(t *testing.T, tpp *Connector) {
 	config, err := tpp.ReadZoneConfiguration()
 	if err != nil {


### PR DESCRIPTION
Add the ability to specify validity when requesting a certificate
now use can request a certificate:
using tpp:
vcert enroll --u https://tpp.urlcom/ -t accesstken -cn abc.com -z zone --valid-days 4#M 

or using cloud:
enroll -k apikey -z zone -cn com.abc.com --valid-days 5#M

all test suite ran well.