### PR TITLE
Hide deprecated parameters and fix inaccuracies in CLI online help

### DIFF
--- a/cmd/vcert/args.go
+++ b/cmd/vcert/args.go
@@ -94,4 +94,5 @@ type commandFlags struct {
 	zone              string
 	omitSans          bool
 	csrFormat         string
+	credFormat        string
 }

--- a/cmd/vcert/commands.go
+++ b/cmd/vcert/commands.go
@@ -300,7 +300,7 @@ func doCommandGetcred1(c *cli.Context) error {
 	}
 
 	//TODO: quick workaround to supress logs when output is in JSON.
-	if flags.format != "json" {
+	if flags.credFormat != "json" {
 		logf("Getting credentials")
 	}
 
@@ -330,7 +330,7 @@ func doCommandGetcred1(c *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		if flags.format == "json" {
+		if flags.credFormat == "json" {
 			jsonData, err := json.MarshalIndent(resp, "", "    ")
 			if err != nil {
 				return err
@@ -351,7 +351,7 @@ func doCommandGetcred1(c *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		if flags.format == "json" {
+		if flags.credFormat == "json" {
 			jsonData, err := json.MarshalIndent(resp, "", "    ")
 			if err != nil {
 				return err
@@ -373,7 +373,7 @@ func doCommandGetcred1(c *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		if flags.format == "json" {
+		if flags.credFormat == "json" {
 			jsonData, err := json.MarshalIndent(resp, "", "    ")
 			if err != nil {
 				return err

--- a/cmd/vcert/flags.go
+++ b/cmd/vcert/flags.go
@@ -345,6 +345,7 @@ var (
 		Usage:       "Use p12-file",
 		Destination: &flags.clientP12,
 		TakesFile:   true,
+		Hidden:      true,
 	}
 
 	flagClientP12PWDeprecated = &cli.StringFlag{
@@ -397,12 +398,7 @@ var (
 	flagRevocationReason = &cli.StringFlag{
 		Name: "reason",
 		Usage: `The revocation reason. Options include: 
-	"none",
-	"key-compromise",
-	"ca-compromise",
-	"affiliation-changed",
-	"superseded",
-	"cessation-of-operation"`,
+	"none", "key-compromise", "ca-compromise", "affiliation-changed", "superseded", "cessation-of-operation"`,
 		Destination: &flags.revocationReason,
 	}
 
@@ -446,7 +442,13 @@ var (
 		Value:       "pem",
 	}
 
-	commonFlags              = []cli.Flag{flagInsecure, flagFormat, flagVerbose, flagNoPrompt}
+	flagCredFormat = &cli.StringFlag{
+		Name:        "format",
+		Usage:       "Use to output credentials in an alternate format. Example: --format json",
+		Destination: &flags.credFormat,
+	}
+
+	commonFlags              = []cli.Flag{flagInsecure, flagVerbose, flagNoPrompt}
 	keyFlags                 = []cli.Flag{flagKeyType, flagKeySize, flagKeyCurve, flagKeyFile, flagKeyPassword}
 	sansFlags                = []cli.Flag{flagDNSSans, flagEmailSans, flagIPSans, flagURISans, flagUPNSans}
 	subjectFlags             = flagsApppend(flagCommonName, flagCountry, flagState, flagLocality, flagOrg, flagOrgUnits)
@@ -497,6 +499,7 @@ var (
 			flagCSROption,
 			sansFlags,
 			flagFile,
+			flagFormat,
 			flagFriendlyName,
 			keyFlags,
 			flagNoPickup,
@@ -519,6 +522,7 @@ var (
 			flagChainFile,
 			flagChainOption,
 			flagFile,
+			flagFormat,
 			flagKeyFile,
 			flagKeyPassword,
 			flagPickupID,
@@ -536,7 +540,6 @@ var (
 			flagRevocationNoRetire,
 			flagRevocationReason,
 			flagThumbprint,
-			flagZone,
 			commonFlags,
 			sortableCredentialsFlags,
 		)),
@@ -551,6 +554,7 @@ var (
 			hiddenFlags(subjectFlags, true), //todo: fix aruba tests and remove
 			flagCADN,
 			flagFile,
+			flagFormat,
 			flagCertFile,
 			flagChainFile,
 			flagChainOption,
@@ -569,6 +573,7 @@ var (
 		flagClientP12,
 		flagClientP12PW,
 		flagConfig,
+		flagCredFormat,
 		flagProfile,
 		flagTPPPassword,
 		flagTPPToken,


### PR DESCRIPTION
- Hide `--client-pkcs12` from help since it is deprecated (was replaced by `--p12-file`)
- Remove `-z` and `--format` from revoke action (not applicable)
- Correct description for `--format` with getcred action