### PR TITLE
Round number of days on validity days for tpp

### DIFF
--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -422,7 +422,18 @@ func prepareRequest(req *certificate.Request, zone string) (tppReq certificateRe
 		loc, _ := time.LoadLocation("UTC")
 		utcNow := time.Now().In(loc)
 
-		expirationDate := utcNow.AddDate(0, 0, req.ValidityHours/24)
+		//if the days have decimal parts then round it to next day.
+		daysDecimal := float64(req.ValidityHours)/24
+		integerDays := req.ValidityHours/24
+
+		validityDays := integerDays
+
+		if(daysDecimal > float64(integerDays)){
+			//have decimal part so round it.
+			validityDays = integerDays+1
+		}
+
+		expirationDate := utcNow.AddDate(0, 0, validityDays)
 
 		formattedExpirationDate := fmt.Sprintf("%d-%02d-%02d %02d:%02d:%02d",
 			expirationDate.Year(), expirationDate.Month(), expirationDate.Day(), expirationDate.Hour(), expirationDate.Minute(), expirationDate.Second())

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -423,14 +423,12 @@ func prepareRequest(req *certificate.Request, zone string) (tppReq certificateRe
 		utcNow := time.Now().In(loc)
 
 		//if the days have decimal parts then round it to next day.
-		daysDecimal := float64(req.ValidityHours)/24
-		integerDays := req.ValidityHours/24
+		validityDays := req.ValidityHours/24
 
-		validityDays := integerDays
+		if(req.ValidityHours % 24 > 0){
 
-		if(daysDecimal > float64(integerDays)){
-			//have decimal part so round it.
-			validityDays = integerDays+1
+			validityDays = validityDays+1
+
 		}
 
 		expirationDate := utcNow.AddDate(0, 0, validityDays)


### PR DESCRIPTION
for tpp case  when converting hours to days, if the result have fractional numbers then round the final result(number of days with fractions) to the next integer

for example if the number of hours is 50 then 55/24 =2.2916666667, then it will be rounded to 3.


