### PR TITLE
Vcert jks support

### DIFF
--- a/aruba/features/format/jks.feature
+++ b/aruba/features/format/jks.feature
@@ -52,6 +52,10 @@ Feature: JKS format output
       When I enroll random certificate in test-mode with -no-prompt -format jks -file all.jks -jks-alias alias
         Then it should fail with "JKS format requires passwords that are at least 6 characters long"
 
+  Scenario: where JKS format is specified but a key-password is not provided
+      When I enroll random certificate in test-mode with -no-prompt -format jks -file all.jks -jks-password 123456 -jks-alias alias
+        Then it should fail with "JKS format requires passwords that are at least 6 characters long"
+
   Scenario: where JKS format is not specified but the jks password is provided
     When I enroll random certificate in test-mode with -no-prompt -format pkcs12 -jks-password 123456 -file all.jks
       Then it should fail with "The --jks-password parameter may only be used with --format jks"
@@ -61,27 +65,17 @@ Feature: JKS format output
       Then it should fail with "The --jks-alias parameter may only be used with --format jks"
 
   Scenario: where all objects are written to one JKS archive
-    When I enroll random certificate in test-mode with -no-prompt -format jks -file all.jks -jks-password 123456 -jks-alias xxx
+    When I enroll random certificate in test-mode with -no-prompt -format jks -file all.jks -key-password 123456 -jks-password 123456 -jks-alias abc
     Then the exit status should be 0
     And "all.jks" should be jks archive with password "123456"
 
   Scenario: where all objects are written to one JKS archive
-      When I enroll random certificate in test-mode with -no-prompt -format jks -file all.jks -jks-password 123456 -jks-alias xxx -key-type ecdsa
+      When I enroll random certificate in test-mode with -no-prompt -format jks -file all.jks -key-password 123456 -jks-password 123456 -jks-alias abc -key-type ecdsa
       Then the exit status should be 0
       And "all.jks" should be jks archive with password "123456"
 
-  Scenario Outline: where all objects are written to one JKS archive providing with key-password
-    When I enroll random certificate in <endpoint> with -format jks -file all.jks -key-password 123456 -jks-alias xxx
-    Then the exit status should be 0
-    And "all.jks" should be jks archive with password "123456"
-    Examples:
-       | endpoint  |
-       | test-mode |
-       | TPP       |
-       | Cloud     |
-
   Scenario Outline: where all objects are written to one JKS archive with key-password and providing the jks-password
-    When I enroll random certificate in <endpoint> with -format jks -file all.jks -key-password 123abc -jks-password 123456 -jks-alias xxx
+    When I enroll random certificate in <endpoint> with -format jks -file all.jks -key-password 123abc -jks-password 123456 -jks-alias abc
     Then the exit status should be 0
     And "all.jks" should be jks archive with password "123456"
     Examples:
@@ -130,7 +124,7 @@ Feature: JKS format output
 
   Scenario Outline: where it pickups up service-generated certificate and outputs it in JKS format
     When I enroll random certificate using <endpoint> with -no-prompt -no-pickup -csr service
-    And I retrieve the certificate using <endpoint> using the same Pickup ID with -timeout 180 -key-password newPassw0rd! -file all.jks -format jks -jks-alias xxx
+    And I retrieve the certificate using <endpoint> using the same Pickup ID with -timeout 180 -key-password newPassw0rd! -file all.jks -format jks -jks-alias abc
     And "all.jks" should be JKS archive with password "newPassw0rd!"
     Examples:
       | endpoint  |
@@ -140,7 +134,7 @@ Feature: JKS format output
 
 #  Scenario Outline: Pickup JKS with typing pass phrases
 #    When I enroll random certificate using <endpoint> with -no-prompt -no-pickup -csr service
-#    And I interactively retrieve the certificate using <endpoint> using the same Pickup ID with -timeout 99 -file all.jks -format jks -jks-alias xxx
+#    And I interactively retrieve the certificate using <endpoint> using the same Pickup ID with -timeout 99 -file all.jks -format jks -jks-alias abc
 #    And I type "newPassw0rd!"
 #    And I type "newPassw0rd!"
 #    Then the exit status should be 0
@@ -148,8 +142,8 @@ Feature: JKS format output
 #    Examples:
 #      | endpoint  |
 #      | test-mode |
-      # | TPP       |
-      # | Cloud     | # -csr service is not supported by Cloud
+#      | TPP       |
+#      | Cloud     | # -csr service is not supported by Cloud
 
 #  Scenario Outline: where it should enroll a JKS certificate with -csr service and without file option (VEN-48622)
 #    When I enroll random certificate using <endpoint> with -csr service -no-prompt -no-pickup -format pkcs12

--- a/aruba/features/format/jks.feature
+++ b/aruba/features/format/jks.feature
@@ -37,14 +37,20 @@ Feature: JKS format output
       Then it should fail with "JKS format requires certificate, private key, and chain to be written to a single file; specify using --file"
 
   Scenario: where JKS format is specified, but a short password is used
-    When I enroll random certificate in test-mode with -no-prompt -format jks -key-password 1234 -file all.jks
+    When I enroll random certificate in test-mode with -no-prompt -format jks -key-password 1234 -jks-password 123456 -file all.jks
       Then it should fail with "JKS format requires passwords that are at least 6 characters long"
-    When I enroll random certificate in test-mode with -no-prompt -format jks -jks-password 1234 -file all.jks
+    When I enroll random certificate in test-mode with -no-prompt -format jks -key-password 123456 -jks-password 1234 -file all.jks
       Then it should fail with "JKS format requires passwords that are at least 6 characters long"
+    When I enroll random certificate in test-mode with -no-prompt -format jks -key-password 1234 -jks-password 1234 -file all.jks
+          Then it should fail with "JKS format requires passwords that are at least 6 characters long"
 
   Scenario: where JKS format is specified and a password is used but the jks alias is not provided
     When I enroll random certificate in test-mode with -no-prompt -format jks -key-password 123456 -file all.jks
       Then it should fail with "The --jks-alias parameter is required with --format jks"
+
+  Scenario: where JKS format is specified but a password is not provided
+      When I enroll random certificate in test-mode with -no-prompt -format jks -file all.jks -jks-alias alias
+        Then it should fail with "JKS format requires passwords that are at least 6 characters long"
 
   Scenario: where JKS format is not specified but the jks password is provided
     When I enroll random certificate in test-mode with -no-prompt -format pkcs12 -jks-password 123456 -file all.jks
@@ -75,7 +81,7 @@ Feature: JKS format output
        | Cloud     |
 
   Scenario Outline: where all objects are written to one JKS archive with key-password and providing the jks-password
-    When I enroll random certificate in <endpoint> with -format jks -file all.jks -key-password 123 -jks-password 123456 -jks-alias xxx
+    When I enroll random certificate in <endpoint> with -format jks -file all.jks -key-password 123abc -jks-password 123456 -jks-alias xxx
     Then the exit status should be 0
     And "all.jks" should be jks archive with password "123456"
     Examples:

--- a/aruba/features/format/jks.feature
+++ b/aruba/features/format/jks.feature
@@ -12,10 +12,10 @@ Feature: JKS format output
 
   - User always will be request for a password of at least 6 characters when he request a JKS file so it isn't possible to use the -no-prompt switch
 
-  - User specifies the password for the JKS file and the key entry, conformed by the private kye, the certificate and the chain certificates, using, preferable,
+  - User specifies the password for the JKS file and the key entry, conformed by the private key, the certificate and the chain certificates, using, preferable,
     the -jks-password or alternatively the -key-password switch
 
-  - User must use the -jks-alias switch to provide the alias for the jks entry that will conformed by the private kye, the certificate and the chain certificates
+  - User must use the -jks-alias switch to provide the alias for the jks entry that will be conformed by the private key, the certificate and the chain certificates
 
   - JKS format is not allowed for the enroll or renew actions when -csr is "file"
 
@@ -142,28 +142,4 @@ Feature: JKS format output
       | test-mode |
       | TPP       |
       # | Cloud     | # -csr service is not supported by Cloud
-
-#  Scenario Outline: Pickup JKS with typing pass phrases
-#    When I enroll random certificate using <endpoint> with -no-prompt -no-pickup -csr service
-#    And I interactively retrieve the certificate using <endpoint> using the same Pickup ID with -timeout 99 -file all.jks -format jks -jks-alias abc
-#    And I type "newPassw0rd!"
-#    And I type "newPassw0rd!"
-#    Then the exit status should be 0
-#    And "all.jks" should be JKS archive with password "newPassw0rd!"
-#    Examples:
-#      | endpoint  |
-#      | test-mode |
-#      | TPP       |
-#      | Cloud     | # -csr service is not supported by Cloud
-
-#  Scenario Outline: where it should enroll a JKS certificate with -csr service and without file option (VEN-48622)
-#    When I enroll random certificate using <endpoint> with -csr service -no-prompt -no-pickup -format pkcs12
-#     Then it should post certificate request
-#    Then I retrieve the certificate using <endpoint> using the same Pickup ID with -key-password newPassw0rd! -timeout 59
-#      And it should retrieve certificate
-#      And it should output encrypted private key
-#    Examples:
-#      | endpoint  |
-#      | test-mode |
-#      | TPP       |
 

--- a/aruba/features/format/jks.feature
+++ b/aruba/features/format/jks.feature
@@ -30,29 +30,29 @@ Feature: JKS format output
 
   Scenario: where it outputs error if JKS format is specified, but STDOUT output is used (default output)
     When I enroll random certificate in test-mode with -no-prompt -format jks
-      Then it should fail with "JKS format can only be used if all objects are written to one file (see -file option)"
+      Then it should fail with "JKS format requires certificate, private key, and chain to be written to a single file; specify using --file"
     When I retrieve the certificate in test-mode with -pickup-id xxx -key-password xxx -format jks
-      Then it should fail with "JKS format can only be used if all objects are written to one file (see -file option)"
+      Then it should fail with "JKS format requires certificate, private key, and chain to be written to a single file; specify using --file"
     When I renew the certificate in TPP with flags -id xxx -no-prompt -format jks
-      Then it should fail with "JKS format can only be used if all objects are written to one file (see -file option)"
+      Then it should fail with "JKS format requires certificate, private key, and chain to be written to a single file; specify using --file"
 
   Scenario: where JKS format is specified, but a short password is used
     When I enroll random certificate in test-mode with -no-prompt -format jks -key-password 1234 -file all.jks
-      Then it should fail with "Password for JKS format must be at least 6 characters (see --jks-password)"
+      Then it should fail with "JKS format requires passwords that are at least 6 characters long"
     When I enroll random certificate in test-mode with -no-prompt -format jks -jks-password 1234 -file all.jks
-      Then it should fail with "Password for JKS format must be at least 6 characters (see --jks-password)"
+      Then it should fail with "JKS format requires passwords that are at least 6 characters long"
 
   Scenario: where JKS format is specified and a password is used but the jks alias is not provided
     When I enroll random certificate in test-mode with -no-prompt -format jks -key-password 123456 -file all.jks
-      Then it should fail with "JKS format needs that the --jks-alias be specified (see --format option)"
+      Then it should fail with "The --jks-alias parameter is required with --format jks"
 
   Scenario: where JKS format is not specified but the jks password is provided
     When I enroll random certificate in test-mode with -no-prompt -format pkcs12 -jks-password 123456 -file all.jks
-      Then it should fail with "The --jks-password flag only can be used when the format is jks (see --jks-password option)"
+      Then it should fail with "The --jks-password parameter may only be used with --format jks"
 
   Scenario: where JKS format is not specified but the jks alias is provided
     When I enroll random certificate in test-mode with -no-prompt -format pkcs12 -jks-alias alias -file all.jks
-      Then it should fail with "The --jks-alias flag only can be used when the format is jks (see --jks-alias option)"
+      Then it should fail with "The --jks-alias parameter may only be used with --format jks"
 
   Scenario: where all objects are written to one JKS archive
     When I enroll random certificate in test-mode with -no-prompt -format jks -file all.jks -jks-password 123456 -jks-alias xxx
@@ -97,7 +97,7 @@ Feature: JKS format output
   Scenario Outline: where it outputs error when trying to enroll certificate in -csr file: mode and output it in JKS format
     Given I generate random CSR with -no-prompt -csr-file csr.pem -key-file k.pem
     When I enroll certificate using <endpoint> with -no-prompt -csr file:csr.pem -file all.jks -format jks
-    And it should fail with "JKS format is not allowed for the enroll or renew actions when -csr is \"file\""
+    And it should fail with "The --csr \"file\" option may not be used with the enroll or renew actions when --format is \"jks\""
     Examples:
       | endpoint  |
       | test-mode |
@@ -106,7 +106,7 @@ Feature: JKS format output
 
   Scenario Outline: where it outputs error when trying to enroll certificate in -csr local (by default), -no-pickup and output it in JKS format
     When I enroll random certificate using <endpoint> with -no-prompt -file all.jks -format jks -no-pickup
-    And it should fail with "JKS format is not allowed for the enroll or renew actions when -csr is "local" and -no-pickup is specified"
+    And it should fail with "The --csr \"local\" option may not be used with the enroll or renew actions when --format is \"jks\" and --no-pickup is specified"
     Examples:
       | endpoint  |
       | test-mode |
@@ -115,7 +115,7 @@ Feature: JKS format output
 
   Scenario Outline: where it outputs error when trying to enroll certificate in -csr local (specified), -no-pickup and output it in JKS format
     When I enroll random certificate using <endpoint> with -no-prompt -file all.jks -format jks -no-pickup -csr local
-    And it should fail with "JKS format is not allowed for the enroll or renew actions when -csr is "local" and -no-pickup is specified"
+    And it should fail with "The --csr \"local\" option may not be used with the enroll or renew actions when --format is \"jks\" and --no-pickup is specified"
     Examples:
       | endpoint  |
       | test-mode |

--- a/aruba/features/format/jks.feature
+++ b/aruba/features/format/jks.feature
@@ -1,0 +1,158 @@
+Feature: JKS format output
+
+  As user, I need VCert to output my certificate, private key, and chain certificates in the JKS format
+  required by my application so that I don't have to use OpenSSL to combine the individual PEM files generated
+  by VCert into a PKCS#12 keystore and then use the Java KeyTool to convert the PKCS#12 keystore to a Java keystore.
+
+  - User requests JKS by specifying "jks" after the -format switch
+
+  - User must use the -file switch to specify the name of the keystore file when they specify -format jks
+    (i.e. neither the -cert-file, -key-file, nor -chain-file switches may appear on the command line,
+    and console output as a base64 encoded blob will not be supported).
+
+  - User always will be request for a password of at least 6 characters when he request a JKS file so it isn't possible to use the -no-prompt switch
+
+  - User specifies the password for the JKS file and the key entry, conformed by the private kye, the certificate and the chain certificates, using, preferable,
+    the -jks-password or alternatively the -key-password switch
+
+  - User must use the -jks-alias switch to provide the alias for the jks entry that will conformed by the private kye, the certificate and the chain certificates
+
+  - JKS format is not allowed for the enroll or renew actions when -csr is "file"
+
+  - JKS format is not allowed for the enroll or renew action when -csr is "local" (or not specified)
+    and the -no-pickup switch is used
+
+  - JKS format is only allowed for the pickup action when the private key is stored in the Venafi Platform
+
+  
+  Background:
+    And the default aruba exit timeout is 180 seconds
+
+  Scenario: where it outputs error if JKS format is specified, but STDOUT output is used (default output)
+    When I enroll random certificate in test-mode with -no-prompt -format jks
+      Then it should fail with "JKS format can only be used if all objects are written to one file (see -file option)"
+    When I retrieve the certificate in test-mode with -pickup-id xxx -key-password xxx -format jks
+      Then it should fail with "JKS format can only be used if all objects are written to one file (see -file option)"
+    When I renew the certificate in TPP with flags -id xxx -no-prompt -format jks
+      Then it should fail with "JKS format can only be used if all objects are written to one file (see -file option)"
+
+  Scenario: where JKS format is specified, but a short password is used
+    When I enroll random certificate in test-mode with -no-prompt -format jks -key-password 1234 -file all.jks
+      Then it should fail with "Password for JKS format must be at least 6 characters (see --jks-password)"
+    When I enroll random certificate in test-mode with -no-prompt -format jks -jks-password 1234 -file all.jks
+      Then it should fail with "Password for JKS format must be at least 6 characters (see --jks-password)"
+
+  Scenario: where JKS format is specified and a password is used but the jks alias is not provided
+    When I enroll random certificate in test-mode with -no-prompt -format jks -key-password 123456 -file all.jks
+      Then it should fail with "JKS format needs that the --jks-alias be specified (see --format option)"
+
+  Scenario: where JKS format is not specified but the jks password is provided
+    When I enroll random certificate in test-mode with -no-prompt -format pkcs12 -jks-password 123456 -file all.jks
+      Then it should fail with "The --jks-password flag only can be used when the format is jks (see --jks-password option)"
+
+  Scenario: where JKS format is not specified but the jks alias is provided
+    When I enroll random certificate in test-mode with -no-prompt -format pkcs12 -jks-alias alias -file all.jks
+      Then it should fail with "The --jks-alias flag only can be used when the format is jks (see --jks-alias option)"
+
+  Scenario: where all objects are written to one JKS archive
+    When I enroll random certificate in test-mode with -no-prompt -format jks -file all.jks -jks-password 123456 -jks-alias xxx
+    Then the exit status should be 0
+    And "all.jks" should be jks archive with password "123456"
+
+  Scenario: where all objects are written to one JKS archive
+      When I enroll random certificate in test-mode with -no-prompt -format jks -file all.jks -jks-password 123456 -jks-alias xxx -key-type ecdsa
+      Then the exit status should be 0
+      And "all.jks" should be jks archive with password "123456"
+
+  Scenario Outline: where all objects are written to one JKS archive providing with key-password
+    When I enroll random certificate in <endpoint> with -format jks -file all.jks -key-password 123456 -jks-alias xxx
+    Then the exit status should be 0
+    And "all.jks" should be jks archive with password "123456"
+    Examples:
+       | endpoint  |
+       | test-mode |
+       | TPP       |
+       | Cloud     |
+
+  Scenario Outline: where all objects are written to one JKS archive with key-password and providing the jks-password
+    When I enroll random certificate in <endpoint> with -format jks -file all.jks -key-password 123 -jks-password 123456 -jks-alias xxx
+    Then the exit status should be 0
+    And "all.jks" should be jks archive with password "123456"
+    Examples:
+       | endpoint  |
+       | test-mode |
+       | TPP       |
+       | Cloud     |
+
+  Scenario Outline: where it outputs error when trying to pickup local-generated certificate and output it in JKS format
+    When I enroll random certificate using <endpoint> with -no-prompt -no-pickup
+    And I retrieve the certificate using <endpoint> using the same Pickup ID with -timeout 180 -no-prompt -file all.jks -format jks
+    And it should fail with "key password must be provided"
+    Examples:
+      | endpoint  |
+      | test-mode |
+      | TPP       |
+      | Cloud     |
+
+  Scenario Outline: where it outputs error when trying to enroll certificate in -csr file: mode and output it in JKS format
+    Given I generate random CSR with -no-prompt -csr-file csr.pem -key-file k.pem
+    When I enroll certificate using <endpoint> with -no-prompt -csr file:csr.pem -file all.jks -format jks
+    And it should fail with "JKS format is not allowed for the enroll or renew actions when -csr is \"file\""
+    Examples:
+      | endpoint  |
+      | test-mode |
+      | TPP       |
+      | Cloud     |
+
+  Scenario Outline: where it outputs error when trying to enroll certificate in -csr local (by default), -no-pickup and output it in JKS format
+    When I enroll random certificate using <endpoint> with -no-prompt -file all.jks -format jks -no-pickup
+    And it should fail with "JKS format is not allowed for the enroll or renew actions when -csr is "local" and -no-pickup is specified"
+    Examples:
+      | endpoint  |
+      | test-mode |
+      | TPP       |
+      | Cloud     |
+
+  Scenario Outline: where it outputs error when trying to enroll certificate in -csr local (specified), -no-pickup and output it in JKS format
+    When I enroll random certificate using <endpoint> with -no-prompt -file all.jks -format jks -no-pickup -csr local
+    And it should fail with "JKS format is not allowed for the enroll or renew actions when -csr is "local" and -no-pickup is specified"
+    Examples:
+      | endpoint  |
+      | test-mode |
+      | TPP       |
+      | Cloud     |
+
+  Scenario Outline: where it pickups up service-generated certificate and outputs it in JKS format
+    When I enroll random certificate using <endpoint> with -no-prompt -no-pickup -csr service
+    And I retrieve the certificate using <endpoint> using the same Pickup ID with -timeout 180 -key-password newPassw0rd! -file all.jks -format jks -jks-alias xxx
+    And "all.jks" should be JKS archive with password "newPassw0rd!"
+    Examples:
+      | endpoint  |
+      | test-mode |
+      | TPP       |
+      # | Cloud     | # -csr service is not supported by Cloud
+
+#  Scenario Outline: Pickup JKS with typing pass phrases
+#    When I enroll random certificate using <endpoint> with -no-prompt -no-pickup -csr service
+#    And I interactively retrieve the certificate using <endpoint> using the same Pickup ID with -timeout 99 -file all.jks -format jks -jks-alias xxx
+#    And I type "newPassw0rd!"
+#    And I type "newPassw0rd!"
+#    Then the exit status should be 0
+#    And "all.jks" should be JKS archive with password "newPassw0rd!"
+#    Examples:
+#      | endpoint  |
+#      | test-mode |
+      # | TPP       |
+      # | Cloud     | # -csr service is not supported by Cloud
+
+#  Scenario Outline: where it should enroll a JKS certificate with -csr service and without file option (VEN-48622)
+#    When I enroll random certificate using <endpoint> with -csr service -no-prompt -no-pickup -format pkcs12
+#     Then it should post certificate request
+#    Then I retrieve the certificate using <endpoint> using the same Pickup ID with -key-password newPassw0rd! -timeout 59
+#      And it should retrieve certificate
+#      And it should output encrypted private key
+#    Examples:
+#      | endpoint  |
+#      | test-mode |
+#      | TPP       |
+

--- a/aruba/features/format/jks.feature
+++ b/aruba/features/format/jks.feature
@@ -84,6 +84,17 @@ Feature: JKS format output
        | TPP       |
        | Cloud     |
 
+  Scenario Outline: where all objects are written to one JKS archive with key-password and providing the jks-password and the key-type is ecdsa
+    When I enroll random certificate in <endpoint> with -format jks -file all.jks -key-password 123abc -jks-password 123456 -jks-alias abc key-type ecdsa
+    Then the exit status should be 0
+    And "all.jks" should be jks archive with password "123456"
+    Examples:
+       | endpoint  |
+       | test-mode |
+       | TPP       |
+       | Cloud     |
+
+
   Scenario Outline: where it outputs error when trying to pickup local-generated certificate and output it in JKS format
     When I enroll random certificate using <endpoint> with -no-prompt -no-pickup
     And I retrieve the certificate using <endpoint> using the same Pickup ID with -timeout 180 -no-prompt -file all.jks -format jks

--- a/aruba/features/format/pkcs12.feature
+++ b/aruba/features/format/pkcs12.feature
@@ -27,11 +27,11 @@ Feature: PKCS#12 format output
 
   Scenario: where it outputs error if PKCS#12 format is specified, but STDOUT output is used (default output)
     When I enroll random certificate in test-mode with -no-prompt -format pkcs12
-      Then it should fail with "PKCS#12 format can only be used if all objects are written to one file (see -file option)"
+      Then it should fail with "PKCS#12 format requires certificate, private key, and chain to be written to a single file; specify using --file"
     When I retrieve the certificate in test-mode with -pickup-id xxx -key-password xxx -format pkcs12
-      Then it should fail with "PKCS#12 format can only be used if all objects are written to one file (see -file option)"
+      Then it should fail with "PKCS#12 format requires certificate, private key, and chain to be written to a single file; specify using --file"
     When I renew the certificate in TPP with flags -id xxx -no-prompt -format pkcs12
-      Then it should fail with "PKCS#12 format can only be used if all objects are written to one file (see -file option)"
+      Then it should fail with "PKCS#12 format requires certificate, private key, and chain to be written to a single file; specify using --file"
 
   Scenario: where all objects are written to one PKCS#12 archive
     When I enroll random certificate in test-mode with -no-prompt -format pkcs12 -file all.p12
@@ -66,7 +66,7 @@ Feature: PKCS#12 format output
   Scenario Outline: where it outputs error when trying to enroll certificate in -csr file: mode and output it in PKCS#12 format
     Given I generate random CSR with -no-prompt -csr-file csr.pem -key-file k.pem
     When I enroll certificate using <endpoint> with -no-prompt -csr file:csr.pem -file all.p12 -format pkcs12
-    And it should fail with "PKCS#12 format is not allowed for the enroll or renew actions when -csr is \"file\""
+    And it should fail with "The --csr \"file\" option may not be used with the enroll or renew actions when --format is \"pkcs12\""
     Examples:
       | endpoint  |
       | test-mode |
@@ -75,7 +75,7 @@ Feature: PKCS#12 format output
 
   Scenario Outline: where it outputs error when trying to enroll certificate in -csr local (by default), -no-pickup and output it in PKCS#12 format
     When I enroll random certificate using <endpoint> with -no-prompt -file all.p12 -format pkcs12 -no-pickup
-    And it should fail with "PKCS#12 format is not allowed for the enroll or renew actions when -csr is "local" and -no-pickup is specified"
+    And it should fail with "The --csr \"local\" option may not be used with the enroll or renew actions when --format is \"pkcs12\" and --no-pickup is specified"
     Examples:
       | endpoint  |
       | test-mode |
@@ -84,7 +84,7 @@ Feature: PKCS#12 format output
 
   Scenario Outline: where it outputs error when trying to enroll certificate in -csr local (specified), -no-pickup and output it in PKCS#12 format
     When I enroll random certificate using <endpoint> with -no-prompt -file all.p12 -format pkcs12 -no-pickup -csr local
-    And it should fail with "PKCS#12 format is not allowed for the enroll or renew actions when -csr is "local" and -no-pickup is specified"
+    And it should fail with "The --csr \"local\" option may not be used with the enroll or renew actions when --format is \"pkcs12\" and --no-pickup is specified"
     Examples:
       | endpoint  |
       | test-mode |

--- a/cmd/vcert/args.go
+++ b/cmd/vcert/args.go
@@ -58,6 +58,8 @@ type commandFlags struct {
 	insecure          bool
 	instance          string
 	ipSans            ipSlice
+	jksAlias          string
+	jksPassword       string
 	keyCurve          certificate.EllipticCurve
 	keyCurveString    string
 	keyFile           string

--- a/cmd/vcert/commands.go
+++ b/cmd/vcert/commands.go
@@ -259,6 +259,8 @@ func doCommandEnroll1(c *cli.Context) error {
 		Config: &Config{
 			Command:      c.Command.Name,
 			Format:       flags.format,
+			JKSAlias:     flags.jksAlias,
+			JKSPassword:  flags.jksPassword,
 			ChainOption:  certificate.ChainOptionFromString(flags.chainOption),
 			AllFile:      flags.file,
 			KeyFile:      flags.keyFile,
@@ -458,6 +460,8 @@ func doCommandPickup1(c *cli.Context) error {
 		Config: &Config{
 			Command:      c.Command.Name,
 			Format:       flags.format,
+			JKSAlias:     flags.jksAlias,
+			JKSPassword:  flags.jksPassword,
 			ChainOption:  certificate.ChainOptionFromString(flags.chainOption),
 			AllFile:      flags.file,
 			KeyFile:      flags.keyFile,
@@ -673,6 +677,8 @@ func doCommandRenew1(c *cli.Context) error {
 		Config: &Config{
 			Command:      c.Command.Name,
 			Format:       flags.format,
+			JKSAlias:     flags.jksAlias,
+			JKSPassword:  flags.jksPassword,
 			ChainOption:  certificate.ChainOptionFromString(flags.chainOption),
 			AllFile:      flags.file,
 			KeyFile:      flags.keyFile,

--- a/cmd/vcert/flags.go
+++ b/cmd/vcert/flags.go
@@ -194,6 +194,7 @@ var (
 	flagJKSPassword = &cli.StringFlag{
 		Name: "jks-password",
 		Usage: "Use to specify a password of at least 6 characters that will protect the Java keystore. Only applicable with --format jks. " +
+			"If --key-password (or password prompt) is not specified, the value specified by --jks-password will be used for the store and key passwords." +
 			"If --jks-password is not specified, the value specified by --key-password (or password prompt) will be used for the store and key passwords.",
 		Destination: &flags.jksPassword,
 		Value:       "",

--- a/cmd/vcert/flags.go
+++ b/cmd/vcert/flags.go
@@ -177,10 +177,26 @@ var (
 
 	flagFormat = &cli.StringFlag{
 		Name: "format",
-		Usage: "Use to specify the output format. Options include: pem | json | pkcs12." +
-			" If PKCS#12 format is specified, then all objects should be written using --file option.",
+		Usage: "Use to specify the output format. Options include: pem | json | pkcs12 | jks." +
+			" If PKCS#12 or JKS format is specified, then all objects should be written using --file option." +
+			" When JKS format is specified, it's mandatory to use the --jks-alias option and provide a password for the keystore(see --jks-password for details).",
 		Destination: &flags.format,
 		Value:       "pem",
+	}
+
+	flagJKSAlias = &cli.StringFlag{
+		Name:        "jks-alias",
+		Usage:       "Use to specify the jks-alias of the entry in the keystore. Only can be used when --format flag is specified and value is jks.",
+		Destination: &flags.jksAlias,
+		Value:       "",
+	}
+
+	flagJKSPassword = &cli.StringFlag{
+		Name: "jks-password",
+		Usage: "Use to specify a password of at least 6 characters which will be used to protect both, the keystore and the entry in the keystore. Only can be used when --format flag is specified and value is jks. " +
+			"If the --jks-password is not provided, then it will be used the value provided in --key-password or the pass phrase provided in the prompt.",
+		Destination: &flags.jksPassword,
+		Value:       "",
 	}
 
 	flagFile = &cli.StringFlag{
@@ -507,6 +523,8 @@ var (
 			sansFlags,
 			flagFile,
 			flagFormat,
+			flagJKSAlias,
+			flagJKSPassword,
 			flagFriendlyName,
 			keyFlags,
 			flagNoPickup,
@@ -531,6 +549,8 @@ var (
 			flagChainOption,
 			flagFile,
 			flagFormat,
+			flagJKSAlias,
+			flagJKSPassword,
 			flagKeyFile,
 			flagKeyPassword,
 			flagPickupID,
@@ -561,6 +581,8 @@ var (
 			flagCADN,
 			flagFile,
 			flagFormat,
+			flagJKSAlias,
+			flagJKSPassword,
 			flagCertFile,
 			flagChainFile,
 			flagChainOption,

--- a/cmd/vcert/flags.go
+++ b/cmd/vcert/flags.go
@@ -178,23 +178,23 @@ var (
 	flagFormat = &cli.StringFlag{
 		Name: "format",
 		Usage: "Use to specify the output format. Options include: pem | json | pkcs12 | jks." +
-			" If PKCS#12 or JKS format is specified, then all objects should be written using --file option." +
-			" When JKS format is specified, it's mandatory to use the --jks-alias option and provide a password for the keystore(see --jks-password for details).",
+			" If PKCS#12 or JKS formats are specified, the --file parameter is required." +
+			" For JKS format, the --jks-alias parameter is required and a password must be provided (see --key-password and --jks-password).",
 		Destination: &flags.format,
 		Value:       "pem",
 	}
 
 	flagJKSAlias = &cli.StringFlag{
 		Name:        "jks-alias",
-		Usage:       "Use to specify the jks-alias of the entry in the keystore. Only can be used when --format flag is specified and value is jks.",
+		Usage:       "Use to specify the alias of the entry in the Java keystore. Only applicable with --format jks.",
 		Destination: &flags.jksAlias,
 		Value:       "",
 	}
 
 	flagJKSPassword = &cli.StringFlag{
 		Name: "jks-password",
-		Usage: "Use to specify a password of at least 6 characters which will be used to protect both, the keystore and the entry in the keystore. Only can be used when --format flag is specified and value is jks. " +
-			"If the --jks-password is not provided, then it will be used the value provided in --key-password or the pass phrase provided in the prompt.",
+		Usage: "Use to specify a password of at least 6 characters that will protect the Java keystore. Only applicable with --format jks. " +
+			"If --jks-password is not specified, the value specified by --key-password (or password prompt) will be used for the store and key passwords.",
 		Destination: &flags.jksPassword,
 		Value:       "",
 	}

--- a/cmd/vcert/flags.go
+++ b/cmd/vcert/flags.go
@@ -194,8 +194,7 @@ var (
 	flagJKSPassword = &cli.StringFlag{
 		Name: "jks-password",
 		Usage: "Use to specify a password of at least 6 characters that will protect the Java keystore. Only applicable with --format jks. " +
-			"If --key-password (or password prompt) is not specified, the value specified by --jks-password will be used for the store and key passwords." +
-			"If --jks-password is not specified, the value specified by --key-password (or password prompt) will be used for the store and key passwords.",
+			"If --jks-password is not specified, the value specified by --key-password (or password prompt) will be used for the store.",
 		Destination: &flags.jksPassword,
 		Value:       "",
 	}

--- a/cmd/vcert/passwords.go
+++ b/cmd/vcert/passwords.go
@@ -57,7 +57,7 @@ func readPasswordsFromInputFlags(commandName string, cf *commandFlags) error {
 		}
 	}
 
-	if commandName == commandEnrollName || commandName == commandGenCSRName || commandName == commandRenewName || commandName == commandPickupName && (cf.format == "pkcs12" || cf.format == "jks") {
+	if commandName == commandEnrollName || commandName == commandGenCSRName || commandName == commandRenewName || commandName == commandPickupName && (cf.format == "pkcs12" || cf.format == JKSFormat) {
 		var keyPasswordNotNeeded = false
 
 		keyPasswordNotNeeded = keyPasswordNotNeeded || (cf.csrOption == "service" && cf.noPickup)

--- a/cmd/vcert/passwords.go
+++ b/cmd/vcert/passwords.go
@@ -57,7 +57,7 @@ func readPasswordsFromInputFlags(commandName string, cf *commandFlags) error {
 		}
 	}
 
-	if commandName == commandEnrollName || commandName == commandGenCSRName || commandName == commandRenewName || commandName == commandPickupName && cf.format == "pkcs12" {
+	if commandName == commandEnrollName || commandName == commandGenCSRName || commandName == commandRenewName || commandName == commandPickupName && (cf.format == "pkcs12" || cf.format == "jks") {
 		var keyPasswordNotNeeded = false
 
 		keyPasswordNotNeeded = keyPasswordNotNeeded || (cf.csrOption == "service" && cf.noPickup)

--- a/cmd/vcert/result_writer.go
+++ b/cmd/vcert/result_writer.go
@@ -26,7 +26,6 @@ import (
 	"github.com/Venafi/vcert/v4/pkg/certificate"
 	"github.com/pavel-v-chernykh/keystore-go/v4"
 	"io/ioutil"
-	"log"
 	"os"
 	"software.sslmate.com/src/go-pkcs12"
 	"strings"
@@ -185,7 +184,7 @@ func (o *Output) AsJKS(c *Config) ([]byte, error) {
 
 	//adding the PK entry to the JKS
 	if err := keyStore.SetPrivateKeyEntry(c.JKSAlias, pkeIn, jksPassword); err != nil {
-		log.Fatal(err) // nolint: gocritic
+		return nil, fmt.Errorf("JKS private key error: %s", err) //log.Fatal(err) // nolint: gocritic
 	}
 
 	buffer := new(bytes.Buffer)
@@ -193,7 +192,7 @@ func (o *Output) AsJKS(c *Config) ([]byte, error) {
 	//storing the JKS to the buffer
 	err := keyStore.Store(buffer, jksPassword)
 	if err != nil {
-		log.Fatal(err) // nolint: gocritic
+		return nil, fmt.Errorf("JKS keystore error: %s", err) //log.Fatal(err) // nolint: gocritic
 	}
 
 	return buffer.Bytes(), nil

--- a/cmd/vcert/result_writer_test.go
+++ b/cmd/vcert/result_writer_test.go
@@ -65,15 +65,15 @@ ozO8ZQRvOf56AHRMUBmVR4ouRrP0ABOfxSGWjhTBqCgtqeI/+FNDwxpQP/4kiXoT
 
 	encPKForJKS = `-----BEGIN RSA PRIVATE KEY-----
 Proc-Type: 4,ENCRYPTED
-DEK-Info: AES-256-CBC,456539594CBC1F45250AD705DC305909
+DEK-Info: AES-256-CBC,8DCD95996B09B376940FDDF85C339EAB
 
-Y8r6qVo7iLT2jdFf5vAxdhI5y1vKQoN14zddkQL3QWd+W70G7BSujeYKXY3hTV1R
-GOvrI+D7bTf7NRVhlf2CxZlFEb8QU/EdFUH+14v47eF1whbUoPLisHLeqjHdE5mo
-xGGggEej0bLHzKQ8+qHKZ7/FOq+ebzpqaNAWvhoK6agokf0c6Z4ElEVRJViUcU4s
-TSOiNut3uCZV7KD1yrVdC7RjTPyLP4xtZKLGq8s6lPJIuYT6W6GxX3mta7nt6Pq+
-BjFUbaWb4ktj2pP1hZMZf2Iiw31/ZIphjGlpEg1v2BnW9eTQegrFilmplSoA39pU
-WV70bluSX4ZTjYoSv1AQ6yClGuZ9JWGHhU7qhwSwMpmWqxbH1IimtvLXUR+mq9w7
-qVr6Ld4SoWTyhdcZYTyYCwLTAIUbnsm3oZi3af8Gvo9CWYvzQuvYDZBkqmy8wasU
+3fOby1I1A5uKeSl2mrib6P8lh5cvZrbMDrKhzeDeOSZNa0ea+XLyJpyjwFX07STt
+ExAZUkqznVBdv4qhGBo1ubhsDDzc5+A/6cyo/MFyuT00wZpGqW9iq/EXXO9cIQ5c
+lE1CnJaNeH/IQIVMmJ5zchlxL136B1N0TrbxyLMSwYZz6vTDLXyX6+UCaUa6Jvkz
+6BbrY01LGYng4KkeTZRWLnY+srCWat3bKf8qT/cDmanspg6resBB7jJNYgms8Axu
+c44bb3ha8NmF8cJYxvXEjJgLqaKyY7ymtrnvDBjOddurN6Ksh3O2zDGg5yfN5Y9A
+oR2vBkvZgKipE75kh10j65DjkKrTQ8NPeDqCgwzOEdM3oQ4hiA0Wi7g9ea3sO8n7
+9oQr1O184Joo89+KHVShSDGDeCyMOpSOvtqDgnmaHUrR93XCH5YnEgaTw34McNpA
 -----END RSA PRIVATE KEY-----`
 
 	ec = `-----BEGIN EC PRIVATE KEY-----
@@ -223,7 +223,7 @@ func TestJKSWithEncPKWithoutJKSPass(t *testing.T) {
 			"",
 			"",
 			"",
-			"123456",
+			"password",
 		},
 	}
 	err := result.Flush()
@@ -237,7 +237,7 @@ func TestJKSWithEncPKAndJKSPass(t *testing.T) {
 	result := &Result{
 		&certificate.PEMCollection{
 			Certificate: cert,
-			PrivateKey:  encPK,
+			PrivateKey:  encPKForJKS,
 			Chain:       chain,
 		},
 		"==pickup-id==",
@@ -253,67 +253,7 @@ func TestJKSWithEncPKAndJKSPass(t *testing.T) {
 			"",
 			"",
 			"",
-			"asdf",
-		},
-	}
-	err := result.Flush()
-
-	if err != nil {
-		t.Fatal("Failed to output the results: ", err)
-	}
-}
-
-func TestJKSWithPlainPK(t *testing.T) {
-	result := &Result{
-		&certificate.PEMCollection{
-			Certificate: cert,
-			PrivateKey:  PK,
-			Chain:       chain,
-		},
-		"==pickup-id==",
-		&Config{
-			"enroll",
-			"jks",
-			"jksAlias",
-			"123456",
-			certificate.ChainOptionFromString(""),
-			"/tmp/TestJKSWithPlainPK",
-			"",
-			"",
-			"",
-			"",
-			"",
-			"",
-		},
-	}
-	err := result.Flush()
-
-	if err != nil {
-		t.Fatal("Failed to output the results: ", err)
-	}
-}
-
-func TestJKSWithPlainEcPK(t *testing.T) {
-	result := &Result{
-		&certificate.PEMCollection{
-			Certificate: cert,
-			PrivateKey:  ec,
-			Chain:       chain,
-		},
-		"==pickup-id==",
-		&Config{
-			"enroll",
-			"jks",
-			"jksAlias",
-			"123456",
-			certificate.ChainOptionFromString(""),
-			"/tmp/TestJKSWithPlainEcPK",
-			"",
-			"",
-			"",
-			"",
-			"",
-			"",
+			"password",
 		},
 	}
 	err := result.Flush()

--- a/cmd/vcert/result_writer_test.go
+++ b/cmd/vcert/result_writer_test.go
@@ -63,6 +63,19 @@ JdT1+vbzuKt50CcU6uqaYxBbU7lpwT61Gvw8bnrLhXVrOcs4Oi2Cc8nt+5qt+++y
 ozO8ZQRvOf56AHRMUBmVR4ouRrP0ABOfxSGWjhTBqCgtqeI/+FNDwxpQP/4kiXoT
 -----END RSA PRIVATE KEY-----`
 
+	encPKForJKS = `-----BEGIN RSA PRIVATE KEY-----
+Proc-Type: 4,ENCRYPTED
+DEK-Info: AES-256-CBC,456539594CBC1F45250AD705DC305909
+
+Y8r6qVo7iLT2jdFf5vAxdhI5y1vKQoN14zddkQL3QWd+W70G7BSujeYKXY3hTV1R
+GOvrI+D7bTf7NRVhlf2CxZlFEb8QU/EdFUH+14v47eF1whbUoPLisHLeqjHdE5mo
+xGGggEej0bLHzKQ8+qHKZ7/FOq+ebzpqaNAWvhoK6agokf0c6Z4ElEVRJViUcU4s
+TSOiNut3uCZV7KD1yrVdC7RjTPyLP4xtZKLGq8s6lPJIuYT6W6GxX3mta7nt6Pq+
+BjFUbaWb4ktj2pP1hZMZf2Iiw31/ZIphjGlpEg1v2BnW9eTQegrFilmplSoA39pU
+WV70bluSX4ZTjYoSv1AQ6yClGuZ9JWGHhU7qhwSwMpmWqxbH1IimtvLXUR+mq9w7
+qVr6Ld4SoWTyhdcZYTyYCwLTAIUbnsm3oZi3af8Gvo9CWYvzQuvYDZBkqmy8wasU
+-----END RSA PRIVATE KEY-----`
+
 	ec = `-----BEGIN EC PRIVATE KEY-----
 MIHcAgEBBEIB6apqEMa3ByjYQPfLLsyNJNo6rmqt8Niyy6w6f0qf8GZ8052oGq9v
 7uZBhm8TcmowAYhc2OzKXtC+YH7Xr3Rd//egBwYFK4EEACOhgYkDgYYABAB4M4U4
@@ -111,6 +124,8 @@ func TestPKCS12withEncPK(t *testing.T) {
 		&Config{
 			"enroll",
 			"pkcs12",
+			"",
+			"",
 			certificate.ChainOptionFromString(""),
 			"/tmp/TestPKCS12withEncPK",
 			"",
@@ -139,6 +154,8 @@ func TestPKCS12withPlainPK(t *testing.T) {
 		&Config{
 			"enroll",
 			"pkcs12",
+			"",
+			"",
 			certificate.ChainOptionFromString(""),
 			"/tmp/TestPKCS12withPlainPK",
 			"",
@@ -167,8 +184,130 @@ func TestPKCS12withPlainEcPK(t *testing.T) {
 		&Config{
 			"enroll",
 			"pkcs12",
+			"",
+			"",
 			certificate.ChainOptionFromString(""),
 			"/tmp/TestPKCS12withPlainEcPK",
+			"",
+			"",
+			"",
+			"",
+			"",
+			"",
+		},
+	}
+	err := result.Flush()
+
+	if err != nil {
+		t.Fatal("Failed to output the results: ", err)
+	}
+}
+
+func TestJKSWithEncPKWithoutJKSPass(t *testing.T) {
+	result := &Result{
+		&certificate.PEMCollection{
+			Certificate: cert,
+			PrivateKey:  encPKForJKS,
+			Chain:       chain,
+		},
+		"==pickup-id==",
+		&Config{
+			"enroll",
+			"jks",
+			"jksAlias",
+			"",
+			certificate.ChainOptionFromString(""),
+			"/tmp/TestJKSWithEncPKAndJKSPass",
+			"",
+			"",
+			"",
+			"",
+			"",
+			"123456",
+		},
+	}
+	err := result.Flush()
+
+	if err != nil {
+		t.Fatal("Failed to output the results: ", err)
+	}
+}
+
+func TestJKSWithEncPKAndJKSPass(t *testing.T) {
+	result := &Result{
+		&certificate.PEMCollection{
+			Certificate: cert,
+			PrivateKey:  encPK,
+			Chain:       chain,
+		},
+		"==pickup-id==",
+		&Config{
+			"enroll",
+			"jks",
+			"jksAlias",
+			"123456",
+			certificate.ChainOptionFromString(""),
+			"/tmp/TestJKSWithEncPKAndJKSPass",
+			"",
+			"",
+			"",
+			"",
+			"",
+			"asdf",
+		},
+	}
+	err := result.Flush()
+
+	if err != nil {
+		t.Fatal("Failed to output the results: ", err)
+	}
+}
+
+func TestJKSWithPlainPK(t *testing.T) {
+	result := &Result{
+		&certificate.PEMCollection{
+			Certificate: cert,
+			PrivateKey:  PK,
+			Chain:       chain,
+		},
+		"==pickup-id==",
+		&Config{
+			"enroll",
+			"jks",
+			"jksAlias",
+			"123456",
+			certificate.ChainOptionFromString(""),
+			"/tmp/TestJKSWithPlainPK",
+			"",
+			"",
+			"",
+			"",
+			"",
+			"",
+		},
+	}
+	err := result.Flush()
+
+	if err != nil {
+		t.Fatal("Failed to output the results: ", err)
+	}
+}
+
+func TestJKSWithPlainEcPK(t *testing.T) {
+	result := &Result{
+		&certificate.PEMCollection{
+			Certificate: cert,
+			PrivateKey:  ec,
+			Chain:       chain,
+		},
+		"==pickup-id==",
+		&Config{
+			"enroll",
+			"jks",
+			"jksAlias",
+			"123456",
+			certificate.ChainOptionFromString(""),
+			"/tmp/TestJKSWithPlainEcPK",
 			"",
 			"",
 			"",

--- a/cmd/vcert/utils.go
+++ b/cmd/vcert/utils.go
@@ -44,6 +44,8 @@ const (
 	/* #nosec */
 	vCertApiKey      = "VCERT_APIKEY"
 	vCertTrustBundle = "VCERT_TRUST_BUNDLE"
+
+	JKSFormat = "jks"
 )
 
 func parseCustomField(s string) (key, value string, err error) {

--- a/cmd/vcert/validators.go
+++ b/cmd/vcert/validators.go
@@ -192,7 +192,7 @@ func validateJKSFlags(commandName string) error {
 			return fmt.Errorf(`The --csr "local" option may not be used with the enroll or renew actions when --format is "jks" and --no-pickup is specified`)
 		}
 
-		if flags.jksPassword == "" && flags.keyPassword == "" {
+		if flags.keyPassword == "" {
 			return fmt.Errorf("JKS format requires passwords that are at least %d characters long", JKSMinPasswordLen)
 		} else {
 			if (flags.jksPassword != "" && len(flags.jksPassword) < JKSMinPasswordLen) || (flags.keyPassword != "" && len(flags.keyPassword) < JKSMinPasswordLen) {

--- a/cmd/vcert/validators.go
+++ b/cmd/vcert/validators.go
@@ -150,21 +150,21 @@ func validatePKCS12Flags(commandName string) error {
 	if flags.format == "pkcs12" {
 		if commandName == commandEnrollName {
 			if flags.file == "" && flags.csrOption != "service" {
-				return fmt.Errorf("PKCS#12 format can only be used if all objects are written to one file (see -file option)")
+				return fmt.Errorf("PKCS#12 format requires certificate, private key, and chain to be written to a single file; specify using --file")
 			}
 		} else {
 			if flags.file == "" { // todo: for enroll it also checks  flags.csrOption != "service"
-				return fmt.Errorf("PKCS#12 format can only be used if all objects are written to one file (see -file option)")
+				return fmt.Errorf("PKCS#12 format requires certificate, private key, and chain to be written to a single file; specify using --file")
 			}
 		}
 		if flags.certFile != "" || flags.chainFile != "" || flags.keyFile != "" {
-			return fmt.Errorf("The '-file' cannot be used used with any other -*-file flags. Either all data goes into one file or individual files must be specified using the appropriate flags")
+			return fmt.Errorf(`The --file parameter may not be combined with the --cert-file, --key-file, or --chain-file parameters when --format is "pkcs12"`)
 		}
 		if strings.HasPrefix(flags.csrOption, "file:") {
-			return fmt.Errorf(`PKCS#12 format is not allowed for the enroll or renew actions when -csr is "file"`)
+			return fmt.Errorf(`The --csr "file" option may not be used with the enroll or renew actions when --format is "pkcs12"`)
 		}
 		if (flags.csrOption == "" || flags.csrOption == "local") && flags.noPickup {
-			return fmt.Errorf(`PKCS#12 format is not allowed for the enroll or renew actions when -csr is "local" and -no-pickup is specified`)
+			return fmt.Errorf(`The --csr "local" option may not be used with the enroll or renew actions when --format is "pkcs12" and --no-pickup is specified`)
 		}
 	}
 	return nil
@@ -175,47 +175,47 @@ func validateJKSFlags(commandName string) error {
 
 		if commandName == commandEnrollName {
 			if flags.file == "" && flags.csrOption != "service" {
-				return fmt.Errorf("JKS format can only be used if all objects are written to one file (see -file option)")
+				return fmt.Errorf("JKS format requires certificate, private key, and chain to be written to a single file; specify using --file")
 			}
 		} else {
 			if flags.file == "" { // todo: for enroll it also checks  flags.csrOption != "service"
-				return fmt.Errorf("JKS format can only be used if all objects are written to one file (see -file option)")
+				return fmt.Errorf("JKS format requires certificate, private key, and chain to be written to a single file; specify using --file")
 			}
 		}
 		if flags.certFile != "" || flags.chainFile != "" || flags.keyFile != "" {
-			return fmt.Errorf("The '-file' cannot be used used with any other -*-file flags. Either all data goes into one file or individual files must be specified using the appropriate flags")
+			return fmt.Errorf(`The --file parameter may not be combined with the --cert-file, --key-file, or --chain-file parameters when --format is "jks"`)
 		}
 		if strings.HasPrefix(flags.csrOption, "file:") {
-			return fmt.Errorf(`JKS format is not allowed for the enroll or renew actions when -csr is "file"`)
+			return fmt.Errorf(`The --csr "file" option may not be used with the enroll or renew actions when --format is "jks"`)
 		}
 		if (flags.csrOption == "" || flags.csrOption == "local") && flags.noPickup {
-			return fmt.Errorf(`JKS format is not allowed for the enroll or renew actions when -csr is "local" and -no-pickup is specified`)
+			return fmt.Errorf(`The --csr "local" option may not be used with the enroll or renew actions when --format is "jks" and --no-pickup is specified`)
 		}
 
 		if flags.jksPassword != "" {
 			if len(flags.jksPassword) < JKSMinPasswordLen {
-				return fmt.Errorf("Password for JKS format must be at least %d characters (see --jks-password)", JKSMinPasswordLen)
+				return fmt.Errorf("JKS format requires passwords that are at least %d characters long", JKSMinPasswordLen)
 			}
 		} else if flags.keyPassword != "" {
 			if len(flags.keyPassword) < JKSMinPasswordLen {
-				return fmt.Errorf("Password for JKS format must be at least %d characters (see --jks-password)", JKSMinPasswordLen)
+				return fmt.Errorf("JKS format requires passwords that are at least %d characters long", JKSMinPasswordLen)
 			}
 		} else if flags.noPrompt {
-			return fmt.Errorf("JKS format needs that a password be provided (see --jks-password)")
+			return fmt.Errorf("JKS format requires a password; see --key-password and --jks-password")
 		}
 
 		if flags.jksAlias == "" {
-			return fmt.Errorf("JKS format needs that the --jks-alias be specified (see --format option)")
+			return fmt.Errorf("The --jks-alias parameter is required with --format jks")
 		}
 
 	} else {
 
 		if flags.jksPassword != "" {
-			return fmt.Errorf("The --jks-password flag only can be used when the format is jks (see --jks-password option)")
+			return fmt.Errorf("The --jks-password parameter may only be used with --format jks")
 		}
 
 		if flags.jksAlias != "" {
-			return fmt.Errorf("The --jks-alias flag only can be used when the format is jks (see --jks-alias option)")
+			return fmt.Errorf("The --jks-alias parameter may only be used with --format jks")
 		}
 	}
 

--- a/cmd/vcert/validators.go
+++ b/cmd/vcert/validators.go
@@ -173,22 +173,6 @@ func validatePKCS12Flags(commandName string) error {
 func validateJKSFlags(commandName string) error {
 	if flags.format == "jks" {
 
-		if flags.jksAlias == "" {
-			return fmt.Errorf("JKS format needs that the --jks-alias be specified (see --format option)")
-		}
-
-		if flags.jksPassword != "" {
-			if len(flags.jksPassword) < JKSMinPasswordLen {
-				return fmt.Errorf("Password for JKS format must be at least %d characters (see --jks-password)", JKSMinPasswordLen)
-			}
-		} else if flags.keyPassword != "" {
-			if len(flags.keyPassword) < JKSMinPasswordLen {
-				return fmt.Errorf("Password for JKS format must be at least %d characters (see --jks-password)", JKSMinPasswordLen)
-			}
-		} else if flags.noPrompt {
-			return fmt.Errorf("JKS format needs that a password be provided (see --jks-password)")
-		}
-
 		if commandName == commandEnrollName {
 			if flags.file == "" && flags.csrOption != "service" {
 				return fmt.Errorf("JKS format can only be used if all objects are written to one file (see -file option)")
@@ -207,13 +191,31 @@ func validateJKSFlags(commandName string) error {
 		if (flags.csrOption == "" || flags.csrOption == "local") && flags.noPickup {
 			return fmt.Errorf(`JKS format is not allowed for the enroll or renew actions when -csr is "local" and -no-pickup is specified`)
 		}
-	} else {
-		if flags.jksAlias != "" {
-			return fmt.Errorf("The --jks-alias flag only can be used when the format is jks (see --jks-alias option)")
+
+		if flags.jksPassword != "" {
+			if len(flags.jksPassword) < JKSMinPasswordLen {
+				return fmt.Errorf("Password for JKS format must be at least %d characters (see --jks-password)", JKSMinPasswordLen)
+			}
+		} else if flags.keyPassword != "" {
+			if len(flags.keyPassword) < JKSMinPasswordLen {
+				return fmt.Errorf("Password for JKS format must be at least %d characters (see --jks-password)", JKSMinPasswordLen)
+			}
+		} else if flags.noPrompt {
+			return fmt.Errorf("JKS format needs that a password be provided (see --jks-password)")
 		}
+
+		if flags.jksAlias == "" {
+			return fmt.Errorf("JKS format needs that the --jks-alias be specified (see --format option)")
+		}
+
+	} else {
 
 		if flags.jksPassword != "" {
 			return fmt.Errorf("The --jks-password flag only can be used when the format is jks (see --jks-password option)")
+		}
+
+		if flags.jksAlias != "" {
+			return fmt.Errorf("The --jks-alias flag only can be used when the format is jks (see --jks-alias option)")
 		}
 	}
 

--- a/cmd/vcert/validators.go
+++ b/cmd/vcert/validators.go
@@ -55,7 +55,7 @@ func readData(commandName string) error {
 }
 
 func validateCommonFlags(commandName string) error {
-	if flags.format != "" && flags.format != "pem" && flags.format != "json" && flags.format != "pkcs12" && flags.format != "jks" {
+	if flags.format != "" && flags.format != "pem" && flags.format != "json" && flags.format != "pkcs12" && flags.format != JKSFormat {
 		return fmt.Errorf("Unexpected output format: %s", flags.format)
 	}
 	if flags.file != "" && (flags.certFile != "" || flags.chainFile != "" || flags.keyFile != "") {
@@ -171,7 +171,7 @@ func validatePKCS12Flags(commandName string) error {
 }
 
 func validateJKSFlags(commandName string) error {
-	if flags.format == "jks" {
+	if flags.format == JKSFormat {
 
 		if commandName == commandEnrollName {
 			if flags.file == "" && flags.csrOption != "service" {
@@ -192,22 +192,17 @@ func validateJKSFlags(commandName string) error {
 			return fmt.Errorf(`The --csr "local" option may not be used with the enroll or renew actions when --format is "jks" and --no-pickup is specified`)
 		}
 
-		if flags.jksPassword != "" {
-			if len(flags.jksPassword) < JKSMinPasswordLen {
+		if flags.jksPassword == "" && flags.keyPassword == "" {
+			return fmt.Errorf("JKS format requires passwords that are at least %d characters long", JKSMinPasswordLen)
+		} else {
+			if (flags.jksPassword != "" && len(flags.jksPassword) < JKSMinPasswordLen) || (flags.keyPassword != "" && len(flags.keyPassword) < JKSMinPasswordLen) {
 				return fmt.Errorf("JKS format requires passwords that are at least %d characters long", JKSMinPasswordLen)
 			}
-		} else if flags.keyPassword != "" {
-			if len(flags.keyPassword) < JKSMinPasswordLen {
-				return fmt.Errorf("JKS format requires passwords that are at least %d characters long", JKSMinPasswordLen)
-			}
-		} else if flags.noPrompt {
-			return fmt.Errorf("JKS format requires a password; see --key-password and --jks-password")
 		}
 
 		if flags.jksAlias == "" {
 			return fmt.Errorf("The --jks-alias parameter is required with --format jks")
 		}
-
 	} else {
 
 		if flags.jksPassword != "" {

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/Venafi/vcert/v4
 
 require (
 	github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c
+	github.com/pavel-v-chernykh/keystore-go/v4 v4.1.0
 	github.com/spf13/viper v1.7.0
 	github.com/urfave/cli/v2 v2.1.1
 	golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/pavel-v-chernykh/keystore-go/v4 v4.1.0 h1:xKxUVGoB9VJU+lgQLPN0KURjw+XCVVSpHfQEeyxk3zo=
+github.com/pavel-v-chernykh/keystore-go/v4 v4.1.0/go.mod h1:2ejgys4qY+iNVW1IittZhyRYA6MNv8TgM6VHqojbB9g=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
This PR is for the code to provide the support to format the output of the certificate, private key and the chain of trust to JKS similar to the behavior when the format to export is PKCS12.
In accordance of the Java Key Store specification, it's required a password to protect the Java Key Store, also it's required a password to protect the entry that will contain the certificate, private key and the chain of trust, and an alias for that entry.

So given the previous explanation, following the rules which are implemented in the current PR:

- User requests a **Java Key Store** by specifying _"jks"_ after the _-format_ switch

- User must use the _-file_ switch to specify the name of the keystore file when they specify _-format jks_.

- User specifies the password for the **store file and the key entry**( conformed by the private key, the certificate and the chain certificates) using the _-jks-password_(optionally) switch and the **key password**(_-key-password_ switch or pass phrase from prompt) respectively. If the _-jks-password_ is not provided, then the value of _key password_ is used for that.

- User always will be requested for passwords of at least 6 characters so the _-no-prompt_ switch only can be used if the _-key-password_ switch is specified.

- User must use the _-jks-alias_ switch to provide the alias for the key entry.

In summary, the rules existing for PKCS12 format applies for JKS format, with the difference that the passwords and the alias are mandatory.

Following a valid enroll declaration: 
`vcert enroll -u https://supertreat.venqa.venafi.com/ -t jhKi1xFxM5UmClnXsvaAoA== -cn amoo69.test.venafi.example.com -z devops -format jks -file test.jks -key-password abcdef -jks-alias alias1 -jks-password 123456`