### PR TITLE
Adding checkcred and voidcred actions to VCert CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ get: gofmt
 
 build_quick: get
 	env GOOS=linux   GOARCH=amd64 go build $(GO_LDFLAGS) -o bin/linux/vcert         ./cmd/vcert
-	cp bin/linux/vcert aruba/bin/vcert
 
 build: get
 	env GOOS=linux   GOARCH=amd64 go build $(GO_LDFLAGS) -o bin/linux/vcert         ./cmd/vcert

--- a/aruba/features/cred/cred.feature
+++ b/aruba/features/cred/cred.feature
@@ -45,7 +45,7 @@ Feature: Managing credentials tokens from TPP
     When I get credentials from TPP
     And I remember the output
       And it should output access token
-    Then I check access token from TPP
+    Then I check access token
     And I remember the output
       And it should output application
       And it should output expires
@@ -55,16 +55,16 @@ Feature: Managing credentials tokens from TPP
     When I get credentials from TPP with -format json
     And I remember the output
       And it should output access token in JSON
-    Then I check access token from TPP with -format json
+    Then I check access token with -format json
     And I remember the output
       And it should output application in JSON
       And it should output expires in JSON
       And it should output scope in JSON
 
-  Scenario: revoke access token
+  Scenario: revoke access token grant
     When I get credentials from TPP
     And I remember the output
       And it should output access token
-    Then I revoke access token from TPP
+    Then I revoke access token grant
     And I remember the output
       And it should output revoked

--- a/aruba/features/cred/cred.feature
+++ b/aruba/features/cred/cred.feature
@@ -1,7 +1,7 @@
-Feature: Getting credentials tokens from TPP
+Feature: Managing credentials tokens from TPP
 
   As a user
-  I want to get credentials tokens from TPP
+  I want to get, check, and revoke credentials tokens from TPP
 
   Background:
     Given the default aruba exit timeout is 180 seconds
@@ -40,3 +40,31 @@ Feature: Getting credentials tokens from TPP
     And I remember the output
       And it should output access token
       And it should output refresh token
+
+  Scenario: check access token
+    When I get credentials from TPP
+    And I remember the output
+      And it should output access token
+    Then I check access token from TPP
+    And I remember the output
+      And it should output application
+      And it should output expires
+      And it should output scope
+
+  Scenario: check token in json format
+    When I get credentials from TPP with -format json
+    And I remember the output
+      And it should output access token in JSON
+    Then I check access token from TPP with -format json
+    And I remember the output
+      And it should output application in JSON
+      And it should output expires in JSON
+      And it should output scope in JSON
+
+  Scenario: revoke access token
+    When I get credentials from TPP
+    And I remember the output
+      And it should output access token
+    Then I revoke access token from TPP
+    And I remember the output
+      And it should output revoked

--- a/aruba/features/credmgmt/credmgmt.feature
+++ b/aruba/features/credmgmt/credmgmt.feature
@@ -1,7 +1,7 @@
 Feature: Managing credentials tokens from TPP
 
   As a user
-  I want to get, check, and revoke credentials tokens from TPP
+  I want to get, check, and void credentials (tokens) from TPP
 
   Background:
     Given the default aruba exit timeout is 180 seconds
@@ -61,10 +61,10 @@ Feature: Managing credentials tokens from TPP
       And it should output expires in JSON
       And it should output scope in JSON
 
-  Scenario: revoke access token grant
+  Scenario: void access token grant
     When I get credentials from TPP
     And I remember the output
       And it should output access token
-    Then I revoke access token grant
+    Then I void access token grant
     And I remember the output
       And it should output revoked

--- a/aruba/features/step_definitions/actions.rb
+++ b/aruba/features/step_definitions/actions.rb
@@ -127,21 +127,16 @@ When(/^I refresh access token$/) do
   }
 end
 
-When(/^I check access token$/) do
-  cmd = "vcert checkcred -u '#{ENV['TPP_URL']}' -t #{@access_token} -insecure"
+When(/^I check access token(?: with)?(.+)?$/) do |flags|
+  cmd = "vcert checkcred -u '#{ENV['TPP_URL']}' -t #{@access_token} #{flags} -insecure"
   steps %{
     Then I try to run `#{cmd}`
-      And I remember the output
-      And it should output application
-      And it should output expires
-      And it should output scope
   }
 end
 
-When(/^I revoke access token$/) do
+When(/^I revoke access token grant$/) do
   cmd = "vcert voidcred -u '#{ENV['TPP_URL']}' -t #{@access_token} -insecure"
   steps %{
     Then I try to run `#{cmd}`
-      And it should output revoked
   }
 end

--- a/aruba/features/step_definitions/actions.rb
+++ b/aruba/features/step_definitions/actions.rb
@@ -126,3 +126,22 @@ When(/^I refresh access token$/) do
       And it should output refresh token
   }
 end
+
+When(/^I check access token$/) do
+  cmd = "vcert checkcred -u '#{ENV['TPP_URL']}' -t #{@access_token} -insecure"
+  steps %{
+    Then I try to run `#{cmd}`
+      And I remember the output
+      And it should output application
+      And it should output expires
+      And it should output scope
+  }
+end
+
+When(/^I revoke access token$/) do
+  cmd = "vcert voidcred -u '#{ENV['TPP_URL']}' -t #{@access_token} -insecure"
+  steps %{
+    Then I try to run `#{cmd}`
+      And it should output revoked
+  }
+end

--- a/aruba/features/step_definitions/actions.rb
+++ b/aruba/features/step_definitions/actions.rb
@@ -134,7 +134,7 @@ When(/^I check access token(?: with)?(.+)?$/) do |flags|
   }
 end
 
-When(/^I revoke access token grant$/) do
+When(/^I void access token grant$/) do
   cmd = "vcert voidcred -u '#{ENV['TPP_URL']}' -t #{@access_token} -insecure"
   steps %{
     Then I try to run `#{cmd}`

--- a/aruba/features/step_definitions/my_steps.rb
+++ b/aruba/features/step_definitions/my_steps.rb
@@ -126,7 +126,7 @@ Then(/^it should( not)? output (application|expires|scope)( in JSON)?$/) do |neg
 
   Kernel.puts("Checking output:\n"+@previous_command_output)
   unless json
-    steps %{Then the output should#{negated} contain "access_token:"}
+    steps %{Then the output should#{negated} contain "access_token_expires:"}
   end
 
   unless negated
@@ -159,5 +159,6 @@ Then(/^it should( not)? output (application|expires|scope)( in JSON)?$/) do |neg
 end
 
 Then(/^it should( not)? output revoked$/) do |negated|
-  steps %{Then the output should#{negated} contain "access token successfully revoked"}
+  Kernel.puts("Checking output:\n"+@previous_command_output)
+  steps %{Then the output should#{negated} contain "Access token grant successfully revoked"}
 end

--- a/aruba/features/step_definitions/my_steps.rb
+++ b/aruba/features/step_definitions/my_steps.rb
@@ -117,3 +117,47 @@ Then(/^it should( not)? output (access|refresh) token( in JSON)?$/) do |negated,
     end
   end
 end
+
+Then(/^it should( not)? output (application|expires|scope)( in JSON)?$/) do |negated, property, json|
+
+  if @previous_command_output.nil?
+    fail(ArgumentError.new('@previous_command_output is nil'))
+  end
+
+  Kernel.puts("Checking output:\n"+@previous_command_output)
+  unless json
+    steps %{Then the output should#{negated} contain "access_token:"}
+  end
+
+  unless negated
+    if json then
+      JSON.parse(@previous_command_output)
+      if property === "application"
+        @application = unescape_text(normalize_json(@previous_command_output, "application")).tr('"', '')
+      elsif property === "expires"
+        @expires = unescape_text(normalize_json(@previous_command_output, "expires_ISO8601")).tr('"', '')
+      elsif property === "scope"
+        @scope = unescape_text(normalize_json(@previous_command_output, "scope")).tr('"', '')
+      else
+        fail(ArgumentError.new("Cant determine property type for #{property}"))
+      end
+    else
+      if property === "application"
+        m = @previous_command_output.match /^client_id:  (.+)$/
+        @application = m[1]
+      elsif property === "expires"
+        m = @previous_command_output.match /^access_token_expires:  (.+)$/
+        @expires = m[1]
+      elsif property === "scope"
+        m = @previous_command_output.match /^scope:  (.+)$/
+        @scope = m[1]
+      else
+        fail(ArgumentError.new("Cant determine property type for #{property}"))
+      end
+    end
+  end
+end
+
+Then(/^it should( not)? output revoked$/) do |negated|
+  steps %{Then the output should#{negated} contain "access token successfully revoked"}
+end

--- a/cmd/vcert/args.go
+++ b/cmd/vcert/args.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Venafi, Inc.
+ * Copyright 2018-2021 Venafi, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,14 @@ import (
 )
 
 const (
-	commandGenCSRName  = "gencsr"
-	commandEnrollName  = "enroll"
-	commandPickupName  = "pickup"
-	commandRevokeName  = "revoke"
-	commandRenewName   = "renew"
-	commandGetcredName = "getcred"
+	commandGenCSRName    = "gencsr"
+	commandEnrollName    = "enroll"
+	commandPickupName    = "pickup"
+	commandRevokeName    = "revoke"
+	commandRenewName     = "renew"
+	commandGetCredName   = "getcred"
+	commandCheckCredName = "checkcred"
+	commandVoidCredName  = "voidcred"
 )
 
 var (

--- a/cmd/vcert/commands.go
+++ b/cmd/vcert/commands.go
@@ -415,7 +415,9 @@ func doCommandCredMgmt1(c *cli.Context) error {
 				tm := time.Unix(int64(resp.Expires), 0).UTC().Format(time.RFC3339)
 				fmt.Println("access_token: ", resp.Access_token)
 				fmt.Println("access_token_expires: ", tm)
-				fmt.Println("refresh_token: ", resp.Refresh_token)
+				if resp.Refresh_token != "" {
+					fmt.Println("refresh_token: ", resp.Refresh_token)
+				}
 			}
 		} else {
 			return fmt.Errorf("Failed to determine credentials set")
@@ -443,9 +445,7 @@ func doCommandCredMgmt1(c *cli.Context) error {
 				iso8601fmt := "2006-01-02T15:04:05Z"
 				tm, _ := time.Parse(iso8601fmt, resp.AccessIssuedOn)
 				accessExpires := tm.Add(time.Duration(resp.ValidFor) * time.Second).Format(iso8601fmt)
-				fmt.Println("access_token_issued: ", resp.AccessIssuedOn)
 				fmt.Println("access_token_expires: ", accessExpires)
-				fmt.Println("grant_issued: ", resp.GrantIssuedOn)
 				fmt.Println("grant_expires: ", resp.Expires)
 				fmt.Println("client_id: ", resp.ClientID)
 				fmt.Println("scope: ", resp.Scope)

--- a/cmd/vcert/commands.go
+++ b/cmd/vcert/commands.go
@@ -526,7 +526,7 @@ func doCommandVoidCred1(c *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		logf("Access token successfully revoked")
+		logf("Access token grant successfully revoked")
 	} else {
 		return fmt.Errorf("Failed to determine credentials set")
 	}

--- a/cmd/vcert/commands.go
+++ b/cmd/vcert/commands.go
@@ -347,7 +347,7 @@ func doCommandCredMgmt1(c *cli.Context) error {
 	}
 
 	switch c.Command.Name {
-	case "getcred":
+	case commandGetCredName:
 		//TODO: quick workaround to supress logs when output is in JSON.
 		if flags.credFormat != "json" {
 			logf("Getting credentials...")
@@ -420,7 +420,7 @@ func doCommandCredMgmt1(c *cli.Context) error {
 		} else {
 			return fmt.Errorf("Failed to determine credentials set")
 		}
-	case "checkcred":
+	case commandCheckCredName:
 		//TODO: quick workaround to supress logs when output is in JSON.
 		if flags.credFormat != "json" {
 			logf("Checking credentials...")
@@ -453,7 +453,7 @@ func doCommandCredMgmt1(c *cli.Context) error {
 		} else {
 			return fmt.Errorf("Failed to determine credentials set")
 		}
-	case "voidcred":
+	case commandVoidCredName:
 		if cfg.Credentials.AccessToken != "" {
 			err := tppConnector.RevokeAccessToken(&endpoint.Authentication{
 				AccessToken: cfg.Credentials.AccessToken,

--- a/cmd/vcert/commands.go
+++ b/cmd/vcert/commands.go
@@ -836,11 +836,3 @@ func writeOutKeyAndCsr(commandName string, cf *commandFlags, key []byte, csr []b
 	err = result.Flush()
 	return
 }
-
-func outputJSON(resp interface{}) error {
-	jsonData, err := json.MarshalIndent(resp, "", "    ")
-	if err == nil {
-		fmt.Println(string(jsonData))
-	}
-	return err
-}

--- a/cmd/vcert/commands.go
+++ b/cmd/vcert/commands.go
@@ -363,11 +363,9 @@ func doCommandCredMgmt1(c *cli.Context) error {
 				return err
 			}
 			if flags.credFormat == "json" {
-				jsonData, err := json.MarshalIndent(resp, "", "    ")
-				if err != nil {
+				if err := outputJSON(resp); err != nil {
 					return err
 				}
-				fmt.Println(string(jsonData))
 			} else {
 				tm := time.Unix(int64(resp.Expires), 0).UTC().Format(time.RFC3339)
 				fmt.Println("access_token: ", resp.Access_token)
@@ -384,11 +382,9 @@ func doCommandCredMgmt1(c *cli.Context) error {
 				return err
 			}
 			if flags.credFormat == "json" {
-				jsonData, err := json.MarshalIndent(resp, "", "    ")
-				if err != nil {
+				if err := outputJSON(resp); err != nil {
 					return err
 				}
-				fmt.Println(string(jsonData))
 			} else {
 				tm := time.Unix(int64(resp.Expires), 0).UTC().Format(time.RFC3339)
 				fmt.Println("access_token: ", resp.Access_token)
@@ -406,11 +402,9 @@ func doCommandCredMgmt1(c *cli.Context) error {
 				return err
 			}
 			if flags.credFormat == "json" {
-				jsonData, err := json.MarshalIndent(resp, "", "    ")
-				if err != nil {
+				if err := outputJSON(resp); err != nil {
 					return err
 				}
-				fmt.Println(string(jsonData))
 			} else {
 				tm := time.Unix(int64(resp.Expires), 0).UTC().Format(time.RFC3339)
 				fmt.Println("access_token: ", resp.Access_token)
@@ -436,11 +430,9 @@ func doCommandCredMgmt1(c *cli.Context) error {
 				return err
 			}
 			if flags.credFormat == "json" {
-				jsonData, err := json.MarshalIndent(resp, "", "    ")
-				if err != nil {
+				if err := outputJSON(resp); err != nil {
 					return err
 				}
-				fmt.Println(string(jsonData))
 			} else {
 				iso8601fmt := "2006-01-02T15:04:05Z"
 				tm, _ := time.Parse(iso8601fmt, resp.AccessIssuedOn)
@@ -843,4 +835,12 @@ func writeOutKeyAndCsr(commandName string, cf *commandFlags, key []byte, csr []b
 
 	err = result.Flush()
 	return
+}
+
+func outputJSON(resp interface{}) error {
+	jsonData, err := json.MarshalIndent(resp, "", "    ")
+	if err == nil {
+		fmt.Println(string(jsonData))
+	}
+	return err
 }

--- a/cmd/vcert/commands.go
+++ b/cmd/vcert/commands.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020-2021 Venafi, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package main
 
 import (
@@ -6,12 +22,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"github.com/Venafi/vcert/v4"
-	"github.com/Venafi/vcert/v4/pkg/certificate"
-	"github.com/Venafi/vcert/v4/pkg/endpoint"
-	"github.com/Venafi/vcert/v4/pkg/venafi/tpp"
-	"github.com/urfave/cli/v2"
-	"golang.org/x/crypto/pkcs12"
 	"io/ioutil"
 	"log"
 	"net"
@@ -19,6 +29,13 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/Venafi/vcert/v4"
+	"github.com/Venafi/vcert/v4/pkg/certificate"
+	"github.com/Venafi/vcert/v4/pkg/endpoint"
+	"github.com/Venafi/vcert/v4/pkg/venafi/tpp"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/crypto/pkcs12"
 )
 
 var (
@@ -38,16 +55,32 @@ var (
 		vcert enroll -u https://tpp.example.com -t <TPP access token> -z <zone> --cn <common name> --key-type ecdsa --key-curve p384 --san-dns <alt name> -san-dns <alt name2>
 		vcert enroll -u https://tpp.example.com -t <TPP access token> -z <zone> --p12-file <PKCS#12 client cert> --p12-password <PKCS#12 password> --cn <common name>`,
 	}
-	commandGetcred = &cli.Command{
+	commandGetCred = &cli.Command{
 		Before: runBeforeCommand,
-		Name:   commandGetcredName,
-		Flags:  getcredFlags,
-		Action: doCommandGetcred1,
+		Name:   commandGetCredName,
+		Flags:  getCredFlags,
+		Action: doCommandGetCred1,
 		Usage:  "To obtain a new credential (token) for authentication",
 		UsageText: ` vcert getcred -u https://tpp.example.com --username <TPP user> --password <TPP user password>
 		vcert getcred -u https://tpp.example.com --p12-file <PKCS#12 client cert> --p12-password <PKCS#12 password> --trust-bundle /path-to/bundle.pem
 		vcert getcred -u https://tpp.example.com -t <TPP refresh token>
 		vcert getcred -u https://tpp.example.com -t <TPP refresh token> --scope <scopes and restrictions>`,
+	}
+	commandCheckCred = &cli.Command{
+		Before:    runBeforeCommand,
+		Name:      commandCheckCredName,
+		Flags:     checkCredFlags,
+		Action:    doCommandCheckCred1,
+		Usage:     "To check whether a credential (token) is valid and view its attributes",
+		UsageText: " vcert trycred -u https://tpp.example.com -t <TPP access token> --trust-bundle /path-to/bundle.pem",
+	}
+	commandVoidCred = &cli.Command{
+		Before:    runBeforeCommand,
+		Name:      commandVoidCredName,
+		Flags:     voidCredFlags,
+		Action:    doCommandVoidCred1,
+		Usage:     "To invalidate an authentication credential (token)",
+		UsageText: " vcert voidcred -u https://tpp.example.com -t <TPP access token> --trust-bundle /path-to/bundle.pem",
 	}
 	commandGenCSR = &cli.Command{
 		Before: runBeforeCommand,
@@ -279,8 +312,8 @@ func doCommandEnroll1(c *cli.Context) error {
 	return nil
 }
 
-func doCommandGetcred1(c *cli.Context) error {
-	err := validateGetcredFlags1(c.Command.Name)
+func doCommandGetCred1(c *cli.Context) error {
+	err := validateGetCredFlags1(c.Command.Name)
 	if err != nil {
 		return err
 	}
@@ -298,7 +331,7 @@ func doCommandGetcred1(c *cli.Context) error {
 
 	//TODO: quick workaround to supress logs when output is in JSON.
 	if flags.credFormat != "json" {
-		logf("Getting credentials")
+		logf("Getting credentials...")
 	}
 
 	var clientP12 bool
@@ -383,6 +416,117 @@ func doCommandGetcred1(c *cli.Context) error {
 			fmt.Println("refresh_token: ", resp.Refresh_token)
 
 		}
+	} else {
+		return fmt.Errorf("Failed to determine credentials set")
+	}
+
+	return nil
+}
+
+func doCommandCheckCred1(c *cli.Context) error {
+	err := validateCheckCredFlags1(c.Command.Name)
+	if err != nil {
+		return err
+	}
+	validateOverWritingEnviromentVariables()
+
+	err = setTLSConfig()
+	if err != nil {
+		return err
+	}
+
+	cfg, err := buildConfig(c, &flags)
+	if err != nil {
+		return fmt.Errorf("Failed to build vcert config: %s", err)
+	}
+
+	//TODO: quick workaround to supress logs when output is in JSON.
+	if flags.credFormat != "json" {
+		logf("Checking credentials...")
+	}
+
+	var connectionTrustBundle *x509.CertPool
+	if cfg.ConnectionTrust != "" {
+		logf("You specified a trust bundle.")
+		connectionTrustBundle = x509.NewCertPool()
+		if !connectionTrustBundle.AppendCertsFromPEM([]byte(cfg.ConnectionTrust)) {
+			return fmt.Errorf("Failed to parse PEM trust bundle")
+		}
+	}
+	tppConnector, err := tpp.NewConnector(cfg.BaseUrl, "", cfg.LogVerbose, connectionTrustBundle)
+	if err != nil {
+		return fmt.Errorf("could not create TPP connector: %s", err)
+	}
+
+	if cfg.Credentials.AccessToken != "" {
+		resp, err := tppConnector.VerifyAccessToken(&endpoint.Authentication{
+			AccessToken: cfg.Credentials.AccessToken,
+		})
+		if err != nil {
+			return err
+		}
+		if flags.credFormat == "json" {
+			jsonData, err := json.MarshalIndent(resp, "", "    ")
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(jsonData))
+		} else {
+			iso8601fmt := "2006-01-02T15:04:05Z"
+			tm, _ := time.Parse(iso8601fmt, resp.AccessIssuedOn)
+			accessExpires := tm.Add(time.Duration(resp.ValidFor) * time.Second).Format(iso8601fmt)
+			fmt.Println("access_token_issued: ", resp.AccessIssuedOn)
+			fmt.Println("access_token_expires: ", accessExpires)
+			fmt.Println("grant_issued: ", resp.GrantIssuedOn)
+			fmt.Println("grant_expires: ", resp.Expires)
+			fmt.Println("client_id: ", resp.ClientID)
+			fmt.Println("scope: ", resp.Scope)
+		}
+	} else {
+		return fmt.Errorf("Failed to determine credentials set")
+	}
+
+	return nil
+}
+
+func doCommandVoidCred1(c *cli.Context) error {
+	err := validateVoidCredFlags1(c.Command.Name)
+	if err != nil {
+		return err
+	}
+	validateOverWritingEnviromentVariables()
+
+	err = setTLSConfig()
+	if err != nil {
+		return err
+	}
+
+	cfg, err := buildConfig(c, &flags)
+	if err != nil {
+		return fmt.Errorf("Failed to build vcert config: %s", err)
+	}
+
+	var connectionTrustBundle *x509.CertPool
+	if cfg.ConnectionTrust != "" {
+		logf("You specified a trust bundle.")
+		connectionTrustBundle = x509.NewCertPool()
+		if !connectionTrustBundle.AppendCertsFromPEM([]byte(cfg.ConnectionTrust)) {
+			return fmt.Errorf("Failed to parse PEM trust bundle")
+		}
+	}
+	tppConnector, err := tpp.NewConnector(cfg.BaseUrl, "", cfg.LogVerbose, connectionTrustBundle)
+	if err != nil {
+		return fmt.Errorf("could not create TPP connector: %s", err)
+	}
+
+	if cfg.Credentials.AccessToken != "" {
+		err := tppConnector.RevokeAccessToken(&endpoint.Authentication{
+			AccessToken: cfg.Credentials.AccessToken,
+		})
+		if err != nil {
+			return err
+		}
+		logf("Access token successfully revoked")
 	} else {
 		return fmt.Errorf("Failed to determine credentials set")
 	}

--- a/cmd/vcert/config.go
+++ b/cmd/vcert/config.go
@@ -18,10 +18,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/urfave/cli/v2"
 	"io/ioutil"
 	"math/rand"
 	"time"
+
+	"github.com/urfave/cli/v2"
 
 	"github.com/Venafi/vcert/v4"
 	"github.com/Venafi/vcert/v4/pkg/endpoint"
@@ -74,7 +75,7 @@ func buildConfig(c *cli.Context, flags *commandFlags) (cfg vcert.Config, err err
 			}
 
 			if flags.tppToken != "" {
-				if c.Command.Name == commandGetcredName {
+				if c.Command.Name == commandGetCredName {
 					auth.RefreshToken = flags.tppToken
 				} else {
 					auth.AccessToken = flags.tppToken
@@ -85,7 +86,7 @@ func buildConfig(c *cli.Context, flags *commandFlags) (cfg vcert.Config, err err
 			} else {
 				tokenS := getPropertyFromEnvironment(vCertToken)
 				if tokenS != "" {
-					if c.Command.Name == commandGetcredName {
+					if c.Command.Name == commandGetCredName {
 						auth.RefreshToken = tokenS
 					} else {
 						auth.AccessToken = tokenS

--- a/cmd/vcert/flags.go
+++ b/cmd/vcert/flags.go
@@ -1,15 +1,32 @@
+/*
+ * Copyright 2020-2021 Venafi, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package main
 
 import (
-	"github.com/urfave/cli/v2"
 	"sort"
 	"strings"
+
+	"github.com/urfave/cli/v2"
 )
 
 var (
 	flagUrl = &cli.StringFlag{
 		Name:        "u",
-		Usage:       "REQUIRED/TPP. The `URL` of the Trust Protection Platform WebSDK. Example: -u https://tpp.example.com",
+		Usage:       "REQUIRED/TPP. The URL of the Trust Protection Platform WebSDK. Example: -u https://tpp.example.com",
 		Destination: &flags.url,
 	}
 
@@ -23,7 +40,7 @@ var (
 
 	flagKey = &cli.StringFlag{
 		Name:        "k",
-		Usage:       "REQUIRED/CLOUD. Your API `key` for Venafi Cloud.  Example: -k aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		Usage:       "REQUIRED/CLOUD. Your API key for Venafi Cloud.  Example: -k aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
 		Destination: &flags.apiKey,
 	}
 
@@ -56,15 +73,14 @@ var (
 
 	flagTPPToken = &cli.StringFlag{
 		Name: "t",
-		Usage: "REQUIRED/TPP. Your access token (or refresh token if getcred) for Trust Protection Platform. " +
+		Usage: "REQUIRED/TPP. Your access token (or refresh token for getcred) for Trust Protection Platform. " +
 			"Example: -t Ab01Cd23Ef45Uv67Wx89Yz==",
 		Destination: &flags.tppToken,
 	}
 
 	flagTrustBundle = &cli.StringFlag{
-		Name: "trust-bundle",
-		Usage: "Use to specify a PEM `file` name to be used " +
-			"as trust anchors when communicating with the remote server.",
+		Name:        "trust-bundle",
+		Usage:       "Use to specify a PEM file name to be used as trust anchors when communicating with the remote server.",
 		Destination: &flags.trustBundle,
 	}
 	flagZone = &cli.StringFlag{
@@ -84,20 +100,22 @@ var (
 	}
 
 	flagKeyCurve = &cli.StringFlag{
-		Name: "key-curve",
-		Usage: "Use to specify the ECDSA key curve. Options include: p256 | p521 | p384	 (Default: p256)",
+		Name:        "key-curve",
+		Usage:       "Use to specify the ECDSA key curve. Options include: p256 | p521 | p384",
 		Destination: &flags.keyCurveString,
+		DefaultText: "p256",
 	}
 
 	flagKeyType = &cli.StringFlag{
 		Name:        "key-type",
-		Usage:       "Use to specify a key type. Options include: rsa | ecdsa (Default: rsa)",
+		Usage:       "Use to specify a key type. Options include: rsa | ecdsa",
 		Destination: &flags.keyTypeString,
+		DefaultText: "rsa",
 	}
 
 	flagKeySize = &cli.IntFlag{
 		Name:        "key-size",
-		Usage:       "Use to specify a key size (default 2048).",
+		Usage:       "Use to specify a key size.",
 		Destination: &flags.keySize,
 		DefaultText: "2048",
 	}
@@ -145,33 +163,34 @@ var (
 	}
 
 	flagDNSSans = &cli.StringSliceFlag{
-		Name:  "san-dns",
-		Usage: "Use to specify a DNS Subject Alternative Name. To specify more than one, use spaces like this: --san-dns test.abc.xyz --san-dns test1.abc.xyz etc.",
+		Name: "san-dns",
+		Usage: "Use to specify a DNS Subject Alternative Name. " +
+			"This option can be repeated to specify more than one value like this: --san-dns test.abc.xyz --san-dns test1.abc.xyz etc.",
 	}
 
 	flagIPSans = &cli.StringSliceFlag{
 		Name: "san-ip",
 		Usage: "Use to specify an IP Address Subject Alternative Name. " +
-			"This option can be repeated to specify more than one value, like this: --san-ip 1.1.1.1 --san-ip 2.2.2.2.",
+			"This option can be repeated to specify more than one value like this: --san-ip 1.1.1.1 --san-ip 2.2.2.2 etc.",
 	}
 
 	flagEmailSans = &cli.StringSliceFlag{
 		Name: "san-email",
 		Usage: "Use to specify an Email Subject Alternative Name. " +
-			"This option can be repeated to specify more than one value, like this: --san-email me@abc.xyz --san-email you@abc.xyz etc.",
+			"This option can be repeated to specify more than one value like this: --san-email me@abc.xyz --san-email you@abc.xyz etc.",
 	}
 
 	flagURISans = &cli.StringSliceFlag{
 		Name: "san-uri",
 		Usage: "Use to specify a Uniform Resource Identifier (URI) Subject Alternative Name. " +
-			"This option can be repeated to specify more than one value, like this: --san-uri https://www.abc.xyz --san-uri spiffe://node.abc.xyz etc.",
+			"This option can be repeated to specify more than one value like this: --san-uri https://www.abc.xyz --san-uri spiffe://node.abc.xyz etc.",
 		Hidden: true,
 	}
 
 	flagUPNSans = &cli.StringSliceFlag{
 		Name: "san-upn",
 		Usage: "Use to specify a User Principal Name (UPN) Subject Alternative Name. " +
-			"This option can be repeated to specify more than one value, like this: --san-upn me@abc.xyz --san-upn you@abc.xyz etc.",
+			"This option can be repeated to specify more than one value like this: --san-upn me@abc.xyz --san-upn you@abc.xyz etc.",
 		Hidden: true,
 	}
 
@@ -249,7 +268,7 @@ var (
 
 	flagNoPrompt = &cli.BoolFlag{
 		Name: "no-prompt",
-		Usage: "Use to exclude the authentication prompt. If you enable the prompt and you enter incorrect information, " +
+		Usage: "Use to exclude credential and password prompts. If you enable the prompt and you enter incorrect information, " +
 			"an error is displayed. This is useful with scripting.",
 		Destination: &flags.noPrompt,
 	}
@@ -329,7 +348,7 @@ var (
 
 	flagConfig = &cli.StringFlag{
 		Name: "config",
-		Usage: "Use to specify INI configuration `file` containing connection details instead\n" +
+		Usage: "Use to specify INI configuration file containing connection details instead\n" +
 			"\t\tFor TPP: url, access_token, tpp_zone\n" +
 			"\t\tFor Cloud: cloud_apikey, cloud_zone\n" +
 			"\t\tTPP & Cloud: trust_bundle, test_mode",
@@ -597,19 +616,28 @@ var (
 		)),
 	)
 
-	getcredFlags = sortedFlags(flagsApppend(
+	commonCredFlags = []cli.Flag{flagConfig, flagProfile, flagUrl, flagTPPToken, flagTrustBundle}
+
+	getCredFlags = sortedFlags(flagsApppend(
+		commonCredFlags,
 		flagClientP12,
 		flagClientP12PW,
-		flagConfig,
 		flagCredFormat,
-		flagProfile,
 		flagTPPPassword,
-		flagTPPToken,
 		flagTPPUser,
-		flagTrustBundle,
-		flagUrl,
 		flagScope,
 		flagClientId,
+		commonFlags,
+	))
+
+	checkCredFlags = sortedFlags(flagsApppend(
+		commonCredFlags,
+		flagCredFormat,
+		commonFlags,
+	))
+
+	voidCredFlags = sortedFlags(flagsApppend(
+		commonCredFlags,
 		commonFlags,
 	))
 )

--- a/cmd/vcert/flags.go
+++ b/cmd/vcert/flags.go
@@ -101,7 +101,7 @@ var (
 
 	flagKeyCurve = &cli.StringFlag{
 		Name:        "key-curve",
-		Usage:       "Use to specify the ECDSA key curve. Options include: p256 | p521 | p384",
+		Usage:       "Use to specify the ECDSA key curve. Options include: p256 | p384 | p521",
 		Destination: &flags.keyCurveString,
 		DefaultText: "p256",
 	}

--- a/cmd/vcert/main.go
+++ b/cmd/vcert/main.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Venafi, Inc.
+ * Copyright 2018-2021 Venafi, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,13 @@ package main
 
 import (
 	"fmt"
-	"github.com/Venafi/vcert/v4"
-	"github.com/urfave/cli/v2"
 	"log"
 	"os"
 	"sort"
 	"time"
+
+	"github.com/Venafi/vcert/v4"
+	"github.com/urfave/cli/v2"
 )
 
 var (
@@ -61,7 +62,9 @@ func main() {
 		Version:  vcert.GetFormattedVersionString(), //todo: replace with plain version
 		Compiled: time.Now(),                        //todo: replace with parsing vcert.versionBuildTimeStamp
 		Commands: []*cli.Command{
-			commandGetcred,
+			commandGetCred,
+			commandCheckCred,
+			commandVoidCred,
 			commandGenCSR,
 			commandEnroll,
 			commandPickup,
@@ -70,7 +73,7 @@ func main() {
 		},
 		EnableBashCompletion: true, //todo: write BashComplete function for options
 		//HideHelp:             true,
-		Copyright: `2020 Venafi, Inc.
+		Copyright: `2018-2021 Venafi, Inc.
 	 Licensed under the Apache License, Version 2.0`,
 	}
 
@@ -87,12 +90,15 @@ AUTHOR:
    {{range .Authors}}{{ . }}{{end}}
    {{end}}{{if .Commands}}
 ACTIONS:
-   enroll   To enroll a certificate,
-   gencsr   To generate a certificate signing request (CSR)
-   getcred  To obtain a new token for authentication
-   pickup   To retrieve a certificate
-   renew    To renew a certificate
-   revoke   To revoke a certificate
+
+   checkcred  To check the validity of a token
+   enroll     To enroll a certificate
+   gencsr     To generate a certificate signing request (CSR)
+   getcred    To obtain a new token for authentication
+   pickup     To retrieve a certificate
+   renew      To renew a certificate
+   revoke     To revoke a certificate
+   voidcred   To invalidate an authentication token
 
 OPTIONS:
    {{range .VisibleFlags}}{{.}}
@@ -102,7 +108,7 @@ COPYRIGHT:
    {{.Copyright}}
    {{end}}{{if .Version}}
 SUPPORT:
-	opensource@venafi.com
+   opensource@venafi.com
    {{end}}
 `, vcert.GetFormattedVersionString(), vcert.GetFormatedBuildTimeStamp())
 

--- a/cmd/vcert/main.go
+++ b/cmd/vcert/main.go
@@ -91,19 +91,19 @@ AUTHOR:
    {{end}}{{if .Commands}}
 ACTIONS:
 
-   checkcred  To check the validity of a token
-   enroll     To enroll a certificate
    gencsr     To generate a certificate signing request (CSR)
-   getcred    To obtain a new token for authentication
+   enroll     To enroll a certificate
    pickup     To retrieve a certificate
    renew      To renew a certificate
    revoke     To revoke a certificate
-   voidcred   To invalidate an authentication token
+
+   getcred    To obtain a new token for authentication
+   checkcred  To check the validity of a token and grant
+   voidcred   To invalidate an authentication grant
 
 OPTIONS:
    {{range .VisibleFlags}}{{.}}
    {{end}}
-
 COPYRIGHT:
    {{.Copyright}}
    {{end}}{{if .Version}}

--- a/cmd/vcert/main_test.go
+++ b/cmd/vcert/main_test.go
@@ -250,13 +250,13 @@ func TestValidateFlagsForEnrollmentMissingData(t *testing.T) {
 	}
 }
 
-func TestGetcredFlagsNoUrl(t *testing.T) {
+func TestGetCredFlagsNoUrl(t *testing.T) {
 
 	flags = commandFlags{}
 
 	flags.tppToken = "3rlybZwAdV1qo/KpNJ5FWg=="
 
-	err := validateGetcredFlags1(commandGetcredName)
+	err := validateGetCredFlags1(commandGetCredName)
 	if err == nil {
 		t.Fatalf("-u must be specified")
 	}
@@ -450,7 +450,7 @@ func TestValidateFlagsMixedPickupFileOutputs(t *testing.T) {
 	}
 }
 
-func TestGetcredFlagsTrustBundle(t *testing.T) {
+func TestGetCredFlagsTrustBundle(t *testing.T) {
 
 	flags = commandFlags{}
 
@@ -460,13 +460,13 @@ func TestGetcredFlagsTrustBundle(t *testing.T) {
 	flags.url = "https://tpp.example.com"
 	flags.trustBundle = "/opt/venafi/bundle.pem"
 
-	err = validateGetcredFlags1(commandGetcredName)
+	err = validateGetCredFlags1(commandGetCredName)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}
 }
 
-func TestGetcredFlagsNoTrust(t *testing.T) {
+func TestGetCredFlagsNoTrust(t *testing.T) {
 
 	flags = commandFlags{}
 
@@ -475,7 +475,7 @@ func TestGetcredFlagsNoTrust(t *testing.T) {
 	flags.tppToken = "3rlybZwAdV1qo/KpNJ5FWg=="
 	flags.url = "https://tpp.example.com"
 
-	err = validateGetcredFlags1(commandGetcredName)
+	err = validateGetCredFlags1(commandGetCredName)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}

--- a/cmd/vcert/main_test.go
+++ b/cmd/vcert/main_test.go
@@ -256,7 +256,7 @@ func TestGetCredFlagsNoUrl(t *testing.T) {
 
 	flags.tppToken = "3rlybZwAdV1qo/KpNJ5FWg=="
 
-	err := validateGetCredFlags1(commandGetCredName)
+	err := validateCredMgmtFlags1(commandGetCredName)
 	if err == nil {
 		t.Fatalf("-u must be specified")
 	}
@@ -460,7 +460,7 @@ func TestGetCredFlagsTrustBundle(t *testing.T) {
 	flags.url = "https://tpp.example.com"
 	flags.trustBundle = "/opt/venafi/bundle.pem"
 
-	err = validateGetCredFlags1(commandGetCredName)
+	err = validateCredMgmtFlags1(commandGetCredName)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}
@@ -475,7 +475,7 @@ func TestGetCredFlagsNoTrust(t *testing.T) {
 	flags.tppToken = "3rlybZwAdV1qo/KpNJ5FWg=="
 	flags.url = "https://tpp.example.com"
 
-	err = validateGetCredFlags1(commandGetCredName)
+	err = validateCredMgmtFlags1(commandGetCredName)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}

--- a/cmd/vcert/passwords.go
+++ b/cmd/vcert/passwords.go
@@ -19,10 +19,11 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"github.com/howeyc/gopass"
 	"os"
 	"regexp"
 	"strings"
+
+	"github.com/howeyc/gopass"
 )
 
 func readPasswordsFromInputFlags(commandName string, cf *commandFlags) error {
@@ -30,7 +31,7 @@ func readPasswordsFromInputFlags(commandName string, cf *commandFlags) error {
 
 	if (commandName == commandEnrollName && cf.url != "") ||
 		(commandName == commandPickupName && cf.url != "") ||
-		(commandName == commandGetcredName && cf.url != "") {
+		(commandName == commandGetCredName && cf.url != "") {
 		if cf.clientP12 != "" && cf.clientP12PW == "" {
 			fmt.Printf("Enter password for %s:", cf.clientP12)
 			input, err := gopass.GetPasswdMasked()

--- a/cmd/vcert/result_writer.go
+++ b/cmd/vcert/result_writer.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Venafi, Inc.
+ * Copyright 2018-2021 Venafi, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -400,4 +400,12 @@ func writeFile(output *Output, result *Result, filePath string) (err error) {
 		}
 	}
 	return
+}
+
+func outputJSON(resp interface{}) error {
+	jsonData, err := json.MarshalIndent(resp, "", "    ")
+	if err == nil {
+		fmt.Println(string(jsonData))
+	}
+	return err
 }

--- a/cmd/vcert/usage.go
+++ b/cmd/vcert/usage.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Venafi, Inc.
+ * Copyright 2018-2021 Venafi, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,6 +75,8 @@ func wrapArgumentDescriptionText(text string) string {
 
 func showvcertUsage() {
 	fmt.Printf("\tTo obtain a new token for authentication, use the 'getcred' action.\n")
+	fmt.Printf("\tTo check whether an authentication token is valid, use the 'checkcred' action.\n")
+	fmt.Printf("\tTo invalidate an authentication token, use the 'voidcred' action.\n")
 	fmt.Printf("\tTo generate a certificate signing request (CSR), use the 'gencsr' action.\n")
 	fmt.Printf("\tTo enroll a certificate, use the 'enroll' action.\n")
 	fmt.Printf("\tTo retrieve a certificate, use the 'pickup' action.\n")

--- a/cmd/vcert/validators.go
+++ b/cmd/vcert/validators.go
@@ -392,7 +392,7 @@ func validateCredMgmtFlags1(commandName string) error {
 		if flags.testMode {
 			return fmt.Errorf("There is no test mode for %s command", commandName)
 		}
-		if commandName == "getcred" {
+		if commandName == commandGetCredName {
 			if flags.tppUser == "" && tppTokenS == "" && flags.clientP12 == "" {
 				return fmt.Errorf("either --username, --p12-file, or -t must be specified")
 			}

--- a/cmd/vcert/validators.go
+++ b/cmd/vcert/validators.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020-2021 Venafi, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package main
 
 import (
@@ -352,7 +368,7 @@ func validateValidDaysFlag(cn string) bool {
 	return true
 }
 
-func validateGetcredFlags1(commandName string) error {
+func validateGetCredFlags1(commandName string) error {
 	var err error
 
 	tppTokenS := flags.tppToken
@@ -406,6 +422,96 @@ func validateGetcredFlags1(commandName string) error {
 		return fmt.Errorf("either -username, -p12-file, or -t must be specified")
 	}
 
+	err = validatePKCS12Flags(commandName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateCheckCredFlags1(commandName string) error {
+	var err error
+
+	if flags.config != "" {
+		if flags.tppToken != "" ||
+			flags.url != "" ||
+			flags.testMode {
+			return fmt.Errorf("connection details cannot be specified with flags or environment variables when --config is used")
+		}
+	} else {
+		if flags.profile != "" {
+			return fmt.Errorf("--profile option cannot be used without --config option")
+		}
+		if flags.testMode {
+			return fmt.Errorf("There is no test mode for the checkcred command")
+		}
+		if flags.url == "" && getPropertyFromEnvironment(vCertURL) == "" {
+			return fmt.Errorf("missing -u (URL) parameter")
+		}
+		if flags.tppToken == "" && getPropertyFromEnvironment(vCertToken) == "" {
+			return fmt.Errorf("missing -t (access token) parameter")
+		}
+
+		// mutual TLS with TPP service
+		if flags.clientP12 == "" && flags.clientP12PW != "" {
+			return fmt.Errorf("--client-pkcs12-pw can only be specified in combination with --client-pkcs12")
+		}
+	}
+
+	err = validateCommonFlags(commandName)
+	if err != nil {
+		return err
+	}
+	err = readData(commandName)
+	if err != nil {
+		return err
+	}
+	err = validatePKCS12Flags(commandName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateVoidCredFlags1(commandName string) error {
+	var err error
+
+	if flags.config != "" {
+		if flags.tppToken != "" ||
+			flags.url != "" ||
+			flags.testMode {
+			return fmt.Errorf("connection details cannot be specified with flags or environment variables when --config is used")
+		}
+	} else {
+		if flags.profile != "" {
+			return fmt.Errorf("--profile option cannot be used without --config option")
+		}
+		if flags.testMode {
+			return fmt.Errorf("There is no test mode for the voidcred command")
+		}
+		if flags.url == "" && getPropertyFromEnvironment(vCertURL) == "" {
+			return fmt.Errorf("missing -u (URL) parameter")
+		}
+		if flags.tppToken == "" && getPropertyFromEnvironment(vCertToken) == "" {
+			return fmt.Errorf("missing -t (access token) parameter")
+		}
+
+		// mutual TLS with TPP service
+		if flags.clientP12 == "" && flags.clientP12PW != "" {
+			return fmt.Errorf("--client-pkcs12-pw can only be specified in combination with --client-pkcs12")
+		}
+	}
+
+	err = validateCommonFlags(commandName)
+	if err != nil {
+		return err
+	}
+	err = readData(commandName)
+	if err != nil {
+		return err
+	}
 	err = validatePKCS12Flags(commandName)
 	if err != nil {
 		return err

--- a/cmd/vcert/validators.go
+++ b/cmd/vcert/validators.go
@@ -368,7 +368,7 @@ func validateValidDaysFlag(cn string) bool {
 	return true
 }
 
-func validateGetCredFlags1(commandName string) error {
+func validateCredMgmtFlags1(commandName string) error {
 	var err error
 
 	tppTokenS := flags.tppToken
@@ -383,17 +383,23 @@ func validateGetCredFlags1(commandName string) error {
 			tppTokenS != "" ||
 			flags.url != "" ||
 			flags.testMode {
-			return fmt.Errorf("connection details cannot be specified with flags or environment variables when -config is used")
+			return fmt.Errorf("connection details cannot be specified with flags or environment variables when --config is used")
 		}
 	} else {
 		if flags.profile != "" {
-			return fmt.Errorf("-profile option cannot be used without -config option")
+			return fmt.Errorf("--profile option cannot be used without --config option")
 		}
 		if flags.testMode {
-			return fmt.Errorf("There is no test mode for getcred command")
+			return fmt.Errorf("There is no test mode for %s command", commandName)
 		}
-		if flags.tppUser == "" && tppTokenS == "" && flags.clientP12 == "" {
-			return fmt.Errorf("either -username, -p12-file, or -t must be specified")
+		if commandName == "getcred" {
+			if flags.tppUser == "" && tppTokenS == "" && flags.clientP12 == "" {
+				return fmt.Errorf("either --username, --p12-file, or -t must be specified")
+			}
+		} else {
+			if tppTokenS == "" {
+				return fmt.Errorf("missing -t (access token) parameter")
+			}
 		}
 
 		if flags.url == "" && getPropertyFromEnvironment(vCertURL) == "" {
@@ -406,55 +412,6 @@ func validateGetCredFlags1(commandName string) error {
 
 		// mutual TLS with TPP service
 		if flags.clientP12 == "" && flags.clientP12PW != "" {
-			return fmt.Errorf("-client-pkcs12-pw can only be specified in combination with -client-pkcs12")
-		}
-	}
-
-	err = validateCommonFlags(commandName)
-	if err != nil {
-		return err
-	}
-	err = readData(commandName)
-	if err != nil {
-		return err
-	}
-	if tppTokenS == "" && flags.tppUser == "" && flags.clientP12 == "" {
-		return fmt.Errorf("either -username, -p12-file, or -t must be specified")
-	}
-
-	err = validatePKCS12Flags(commandName)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func validateCheckCredFlags1(commandName string) error {
-	var err error
-
-	if flags.config != "" {
-		if flags.tppToken != "" ||
-			flags.url != "" ||
-			flags.testMode {
-			return fmt.Errorf("connection details cannot be specified with flags or environment variables when --config is used")
-		}
-	} else {
-		if flags.profile != "" {
-			return fmt.Errorf("--profile option cannot be used without --config option")
-		}
-		if flags.testMode {
-			return fmt.Errorf("There is no test mode for the checkcred command")
-		}
-		if flags.url == "" && getPropertyFromEnvironment(vCertURL) == "" {
-			return fmt.Errorf("missing -u (URL) parameter")
-		}
-		if flags.tppToken == "" && getPropertyFromEnvironment(vCertToken) == "" {
-			return fmt.Errorf("missing -t (access token) parameter")
-		}
-
-		// mutual TLS with TPP service
-		if flags.clientP12 == "" && flags.clientP12PW != "" {
 			return fmt.Errorf("--client-pkcs12-pw can only be specified in combination with --client-pkcs12")
 		}
 	}
@@ -464,55 +421,6 @@ func validateCheckCredFlags1(commandName string) error {
 		return err
 	}
 	err = readData(commandName)
-	if err != nil {
-		return err
-	}
-	err = validatePKCS12Flags(commandName)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func validateVoidCredFlags1(commandName string) error {
-	var err error
-
-	if flags.config != "" {
-		if flags.tppToken != "" ||
-			flags.url != "" ||
-			flags.testMode {
-			return fmt.Errorf("connection details cannot be specified with flags or environment variables when --config is used")
-		}
-	} else {
-		if flags.profile != "" {
-			return fmt.Errorf("--profile option cannot be used without --config option")
-		}
-		if flags.testMode {
-			return fmt.Errorf("There is no test mode for the voidcred command")
-		}
-		if flags.url == "" && getPropertyFromEnvironment(vCertURL) == "" {
-			return fmt.Errorf("missing -u (URL) parameter")
-		}
-		if flags.tppToken == "" && getPropertyFromEnvironment(vCertToken) == "" {
-			return fmt.Errorf("missing -t (access token) parameter")
-		}
-
-		// mutual TLS with TPP service
-		if flags.clientP12 == "" && flags.clientP12PW != "" {
-			return fmt.Errorf("--client-pkcs12-pw can only be specified in combination with --client-pkcs12")
-		}
-	}
-
-	err = validateCommonFlags(commandName)
-	if err != nil {
-		return err
-	}
-	err = readData(commandName)
-	if err != nil {
-		return err
-	}
-	err = validatePKCS12Flags(commandName)
 	if err != nil {
 		return err
 	}

--- a/pkg/venafi/tpp/search.go
+++ b/pkg/venafi/tpp/search.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Venafi, Inc.
+ * Copyright 2018-2021 Venafi, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/venafi/tpp/search.go
+++ b/pkg/venafi/tpp/search.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 Venafi, Inc.
+ * Copyright 2018 Venafi, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Venafi, Inc.
+ * Copyright 2018-2021 Venafi, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -218,11 +218,23 @@ type OauthRefreshAccessTokenResponse struct {
 	Refresh_token string `json:"refresh_token,omitempty"`
 	Token_type    string `json:"token_type,omitempty"`
 }
+
+type OauthVerifyTokenResponse struct {
+	AccessIssuedOn string `json:"access_issued_on_ISO8601,omitempty"`
+	ClientID       string `json:"application,omitempty"`
+	Expires        string `json:"expires_ISO8601,omitempty"`
+	GrantIssuedOn  string `json:"grant_issued_on_ISO8601,omitempty"`
+	Identity       string `json:"identity,omitempty"`
+	Scope          string `json:"scope,omitempty"`
+	ValidFor       int    `json:"valid_for,omitempty"`
+}
+
 type policyRequest struct {
 	ObjectDN      string `json:",omitempty"`
 	Class         string `json:",omitempty"`
 	AttributeName string `json:",omitempty"`
 }
+
 type metadataItem struct {
 	AllowedValues     []string `json:",omitempty"`
 	Classes           []string `json:",omitempty"`
@@ -275,27 +287,29 @@ type urlResource string
 
 const (
 	urlResourceAuthorize              urlResource = "vedsdk/authorize/"
-	urlResourceAuthorizeCertificate   urlResource = "vedauth/Authorize/Certificate"
+	urlResourceAuthorizeCertificate   urlResource = "vedauth/authorize/certificate"
 	urlResourceAuthorizeOAuth         urlResource = "vedauth/authorize/oauth"
+	urlResourceAuthorizeVerify        urlResource = "vedauth/authorize/verify"
+	urlResourceRefreshAccessToken     urlResource = "vedauth/authorize/token" // #nosec
+	urlResourceRevokeAccessToken      urlResource = "vedauth/revoke/token"    // #nosec
 	urlResourceCertificateImport      urlResource = "vedsdk/certificates/import"
 	urlResourceCertificatePolicy      urlResource = "vedsdk/certificates/checkpolicy"
 	urlResourceCertificateRenew       urlResource = "vedsdk/certificates/renew"
 	urlResourceCertificateRequest     urlResource = "vedsdk/certificates/request"
 	urlResourceCertificateRetrieve    urlResource = "vedsdk/certificates/retrieve"
 	urlResourceCertificateRevoke      urlResource = "vedsdk/certificates/revoke"
-	urlResourceCertificatesAssociate  urlResource = "vedsdk/Certificates/Associate"
-	urlResourceCertificatesDissociate urlResource = "vedsdk/Certificates/Dissociate"
+	urlResourceCertificatesAssociate  urlResource = "vedsdk/certificates/associate"
+	urlResourceCertificatesDissociate urlResource = "vedsdk/certificates/dissociate"
 	urlResourceCertificate            urlResource = "vedsdk/certificates/"
 	urlResourceCertificateSearch                  = urlResourceCertificate
 	urlResourceCertificatesList                   = urlResourceCertificate
-	urlResourceConfigDnToGuid         urlResource = "vedsdk/Config/DnToGuid"
-	urlResourceConfigReadDn           urlResource = "vedsdk/Config/ReadDn"
+	urlResourceConfigDnToGuid         urlResource = "vedsdk/config/dntoguid"
+	urlResourceConfigReadDn           urlResource = "vedsdk/config/readdn"
 	urlResourceFindPolicy             urlResource = "vedsdk/config/findpolicy"
-	urlResourceRefreshAccessToken     urlResource = "vedauth/authorize/token" // #nosec
 	urlResourceMetadataSet            urlResource = "vedsdk/metadata/set"
 	urlResourceAllMetadataGet         urlResource = "vedsdk/metadata/getitems"
 	urlResourceMetadataGet            urlResource = "vedsdk/metadata/get"
-	urlResourceSystemStatusVersion    urlResource = "vedsdk/SystemStatus/Version"
+	urlResourceSystemStatusVersion    urlResource = "vedsdk/systemstatus/version"
 )
 
 const (


### PR DESCRIPTION
This PR adds the functionality requested by https://github.com/Venafi/vcert/issues/150 and https://github.com/Venafi/vcert/issues/151 via new `checkcred` and `voidcred` actions.

```
# ./vcert getcred -u https://tpp.venafi.example --username local:admin --password somePassw0rd!
vCert: 2021/01/24 23:01:21 Getting credentials...
access_token:  KIKro8hL/4EvvSeVuJQVlw==
access_token_expires:  2021-04-24T23:01:23Z
refresh_token:  PqIQ+4KAEFHGkHZM95b3og==
#
# ./vcert checkcred -u https://tpp.venafi.example -t KIKro8hL/4EvvSeVuJQVlw==
vCert: 2021/01/24 23:01:43 Checking credentials...
access_token_expires:  2021-04-24T23:01:22Z
grant_expires:  2022-01-24T23:01:22Z
client_id:  vcert-cli
scope:  certificate:manage,revoke
#
# ./vcert voidcred -u https://tpp.venafi.example -t KIKro8hL/4EvvSeVuJQVlw==
vCert: 2021/01/24 23:02:02 Access token grant successfully revoked
```