### PR TITLE
404 http status added

### DIFF
--- a/pkg/venafi/cloud/cloud.go
+++ b/pkg/venafi/cloud/cloud.go
@@ -313,7 +313,7 @@ func parseZoneConfigurationResult(httpStatusCode int, httpStatus string, body []
 	switch httpStatusCode {
 	case http.StatusOK:
 		return parseZoneConfigurationData(body)
-	case http.StatusBadRequest:
+	case http.StatusBadRequest, http.StatusNotFound:
 		return nil, verror.ZoneNotFoundError
 	default:
 		respErrors, err := parseResponseErrors(body)


### PR DESCRIPTION
Added status 404 not found  to the cases for a zone not being found.
This is important for AWS plugin to be able to run its test successfully.