### PR TITLE
Rebranding Venafi Cloud to VaaS

### DIFF
--- a/cmd/vcert/commands.go
+++ b/cmd/vcert/commands.go
@@ -54,8 +54,8 @@ var (
 		vcert enroll -k <VaaS API key> -z "<app name>\<CIT alias>" --cn <common name> --key-type rsa --key-size 4096 --san-dns <alt name> --san-dns <alt name2>
 		vcert enroll -u https://tpp.example.com -t <TPP access token> -z "<policy folder DN>" --cn <common name>
 		vcert enroll -u https://tpp.example.com -t <TPP access token> -z "<policy folder DN>" --cn <common name> --key-size 4096 --san-dns <alt name> --san-dns <alt name2>
-		vcert enroll -u https://tpp.example.com -t <TPP access token> -z "<policy folder DN> --cn <common name> --key-type ecdsa --key-curve p384 --san-dns <alt name> -san-dns <alt name2>
-		vcert enroll -u https://tpp.example.com -t <TPP access token> -z "<policy folder DN> --p12-file <PKCS#12 client cert> --p12-password <PKCS#12 password> --cn <common name>`,
+		vcert enroll -u https://tpp.example.com -t <TPP access token> -z "<policy folder DN>" --cn <common name> --key-type ecdsa --key-curve p384 --san-dns <alt name> -san-dns <alt name2>
+		vcert enroll -u https://tpp.example.com -t <TPP access token> -z "<policy folder DN>" --p12-file <PKCS#12 client cert> --p12-password <PKCS#12 password> --cn <common name>`,
 	}
 	commandGetCred = &cli.Command{
 		Before: runBeforeCommand,
@@ -130,7 +130,7 @@ var (
 		Flags:  createPolicyFlags,
 		Action: doCommandCreatePolicy,
 		Usage:  "To apply a certificate policy specification to a zone",
-		UsageText: ` vcert setpolicy <Required Venafi as a Server -OR- Trust Protection Platform Config> <Options>
+		UsageText: ` vcert setpolicy <Required Venafi as a Service -OR- Trust Protection Platform Config> <Options>
 		vcert setpolicy -u https://tpp.example.com -t <TPP access token> -z "<policy folder DN>" --file /path-to/policy.spec
 		vcert setpolicy -k <VaaS API key> -z "<app name>\<CIT alias>" --file /path-to/policy.spec`,
 	}

--- a/cmd/vcert/commands.go
+++ b/cmd/vcert/commands.go
@@ -49,13 +49,13 @@ var (
 		Action: doCommandEnroll1,
 		Name:   commandEnrollName,
 		Usage:  "To enroll a certificate",
-		UsageText: ` vcert enroll <Required Venafi Cloud Config> OR <Required Trust Protection Platform Config> <Options>
-		vcert enroll -k <Venafi Cloud API key> -z <zone> --cn <common name>
-		vcert enroll -k <Venafi Cloud API key> -z <zone> --cn <common name> --key-type rsa --key-size 4096 --san-dns <alt name> --san-dns <alt name2>
-		vcert enroll -u https://tpp.example.com -t <TPP access token> -z <zone> --cn <common name>
-		vcert enroll -u https://tpp.example.com -t <TPP access token> -z <zone> --cn <common name> --key-size 4096 --san-dns <alt name> --san-dns <alt name2>
-		vcert enroll -u https://tpp.example.com -t <TPP access token> -z <zone> --cn <common name> --key-type ecdsa --key-curve p384 --san-dns <alt name> -san-dns <alt name2>
-		vcert enroll -u https://tpp.example.com -t <TPP access token> -z <zone> --p12-file <PKCS#12 client cert> --p12-password <PKCS#12 password> --cn <common name>`,
+		UsageText: ` vcert enroll <Required Venafi as a Service -OR- Trust Protection Platform Config> <Options>
+		vcert enroll -k <VaaS API key> -z "<app name>\<CIT alias>" --cn <common name>
+		vcert enroll -k <VaaS API key> -z "<app name>\<CIT alias>" --cn <common name> --key-type rsa --key-size 4096 --san-dns <alt name> --san-dns <alt name2>
+		vcert enroll -u https://tpp.example.com -t <TPP access token> -z "<policy folder DN>" --cn <common name>
+		vcert enroll -u https://tpp.example.com -t <TPP access token> -z "<policy folder DN>" --cn <common name> --key-size 4096 --san-dns <alt name> --san-dns <alt name2>
+		vcert enroll -u https://tpp.example.com -t <TPP access token> -z "<policy folder DN> --cn <common name> --key-type ecdsa --key-curve p384 --san-dns <alt name> -san-dns <alt name2>
+		vcert enroll -u https://tpp.example.com -t <TPP access token> -z "<policy folder DN> --p12-file <PKCS#12 client cert> --p12-password <PKCS#12 password> --cn <common name>`,
 	}
 	commandGetCred = &cli.Command{
 		Before: runBeforeCommand,
@@ -99,8 +99,8 @@ var (
 		Flags:  pickupFlags,
 		Action: doCommandPickup1,
 		Usage:  "To download a certificate",
-		UsageText: ` vcert pickup <Required Venafi Cloud Config> OR <Required Trust Protection Platform Config> <Options>
-		vcert pickup -k <Venafi Cloud API key> [--pickup-id <ID value> | --pickup-id-file <file containing ID value>]
+		UsageText: ` vcert pickup <Required Venafi as a Service -OR- Trust Protection Platform Config> <Options>
+		vcert pickup -k <VaaS API key> [--pickup-id <ID value> | --pickup-id-file <file containing ID value>]
 		vcert pickup -u https://tpp.example.com -t <TPP access token> --pickup-id <ID value>`,
 	}
 	commandRevoke = &cli.Command{
@@ -119,9 +119,9 @@ var (
 		Flags:  renewFlags,
 		Action: doCommandRenew1,
 		Usage:  "To renew a certificate",
-		UsageText: ` vcert renew <Required Venafi Cloud Config> OR <Required Trust Protection Platform Config> <Options>
+		UsageText: ` vcert renew <Required Venafi as a Service -OR- Trust Protection Platform Config> <Options>
 		vcert renew -u https://tpp.example.com -t <TPP access token> --id <ID value>
-		vcert renew -k <Venafi Cloud API key> --thumbprint <cert SHA1 fingerprint>`,
+		vcert renew -k <VaaS API key> --thumbprint <cert SHA1 fingerprint>`,
 	}
 
 	commandCreatePolicy = &cli.Command{
@@ -130,9 +130,9 @@ var (
 		Flags:  createPolicyFlags,
 		Action: doCommandCreatePolicy,
 		Usage:  "To apply a certificate policy specification to a zone",
-		UsageText: ` vcert setpolicy <Required Venafi Cloud Config> OR <Required Trust Protection Platform Config> <Options>
-		vcert setpolicy -u https://tpp.example.com -t <TPP access token> -z <zone> --file /path-to/policy.spec
-		vcert setpolicy -k <Venafi Cloud API key> -z <zone> --file /path-to/policy.spec`,
+		UsageText: ` vcert setpolicy <Required Venafi as a Server -OR- Trust Protection Platform Config> <Options>
+		vcert setpolicy -u https://tpp.example.com -t <TPP access token> -z "<policy folder DN>" --file /path-to/policy.spec
+		vcert setpolicy -k <VaaS API key> -z "<app name>\<CIT alias>" --file /path-to/policy.spec`,
 	}
 
 	commandGetPolicy = &cli.Command{
@@ -141,9 +141,9 @@ var (
 		Flags:  getPolicyFlags,
 		Action: doCommandGetPolicy,
 		Usage:  "To retrieve the certificate policy of a zone",
-		UsageText: ` vcert getpolicy <Required Venafi Cloud Config> OR <Required Trust Protection Platform Config> <Options>
-		vcert getpolicy -u https://tpp.example.com -t <TPP access token> -z <zone>
-		vcert getpolicy -k <Venafi Cloud API key> -z <zone>`,
+		UsageText: ` vcert getpolicy <Required Venafi as a Service -OR- Trust Protection Platform Config> <Options>
+		vcert getpolicy -u https://tpp.example.com -t <TPP access token> -z "<policy folder DN>"
+		vcert getpolicy -k <VaaS API key> -z "<app name>\<CIT alias>"`,
 	}
 )
 

--- a/cmd/vcert/flags.go
+++ b/cmd/vcert/flags.go
@@ -40,7 +40,7 @@ var (
 
 	flagKey = &cli.StringFlag{
 		Name:        "k",
-		Usage:       "REQUIRED/CLOUD. Your API key for Venafi Cloud.  Example: -k aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		Usage:       "REQUIRED/VAAS. Your API key for Venafi as a Service.  Example: -k aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
 		Destination: &flags.apiKey,
 	}
 
@@ -350,8 +350,8 @@ var (
 		Name: "config",
 		Usage: "Use to specify INI configuration file containing connection details instead\n" +
 			"\t\tFor TPP: url, access_token, tpp_zone\n" +
-			"\t\tFor Cloud: cloud_apikey, cloud_zone\n" +
-			"\t\tTPP & Cloud: trust_bundle, test_mode",
+			"\t\tFor VaaS: cloud_apikey, cloud_zone\n" +
+			"\t\tTPP & VaaS: trust_bundle, test_mode",
 		Destination: &flags.config,
 		TakesFile:   true,
 	}
@@ -493,7 +493,7 @@ var (
 	flagPolicyName = &cli.StringFlag{
 		Name: "z",
 		Usage: "REQUIRED. Use to specify target zone for applying or retrieving certificate policy. " +
-			"In Trust Protection Platform this is the path (DN) of a policy folder and in Venafi Cloud " +
+			"In Trust Protection Platform this is the path (DN) of a policy folder and in Venafi as a Service " +
 			"this is the name of an Application and Issuing Template separated by a backslash. " +
 			"Example: -z Engineering\\Internal Certs",
 		Destination: &flags.policyName,

--- a/cmd/vcert/validators.go
+++ b/cmd/vcert/validators.go
@@ -142,7 +142,7 @@ func validateConnectionFlags(commandName string) error {
 		if flags.tppUser == "" && tppToken == "" {
 			// should be SaaS endpoint
 			if flags.apiKey == "" && getPropertyFromEnvironment(vCertApiKey) == "" {
-				return fmt.Errorf("An API key is required for communicating with Venafi Cloud")
+				return fmt.Errorf("An API key is required for communicating with Venafi as a Service")
 			}
 		} else {
 			// should be TPP service
@@ -281,10 +281,10 @@ func validateEnrollFlags(commandName string) error {
 		if flags.tppUser == "" && tppToken == "" {
 			// should be SaaS endpoint
 			if apiKey == "" {
-				return fmt.Errorf("An API key is required for enrollment with Venafi Cloud")
+				return fmt.Errorf("An API key is required for enrollment with Venafi as a Service")
 			}
 			if zone == "" {
-				return fmt.Errorf("A zone is required for requesting a certificate from Venafi Cloud")
+				return fmt.Errorf("A zone is required for requesting a certificate from Venafi as a Service")
 			}
 		} else {
 			// should be TPP service
@@ -344,7 +344,7 @@ func validateEnrollFlags(commandName string) error {
 	}
 
 	if (flags.tlsAddress != "" || flags.instance != "") && apiKey != "" {
-		return fmt.Errorf("--instance and --tls-address are not applicable to Venafi Cloud")
+		return fmt.Errorf("--instance and --tls-address are not applicable to Venafi as a Service")
 	}
 
 	return nil


### PR DESCRIPTION
Feedback from the release candidate was that the help wasn't clear about whether or not to escape the backslash in the `--z` value.  This is because that behavior varies by operating system and shell.  Given that policy folder DNs in TPP and application names and CIT aliases in VaaS often include spaces, I updated the help to show the zone value being surrounded in double quotes.  I also was more explicit about the actual zone value in the examples since we have them for both TPP and VaaS.