### PR TITLE
Minor changes policy management

### DIFF
--- a/pkg/venafi/cloud/connector_test.go
+++ b/pkg/venafi/cloud/connector_test.go
@@ -830,6 +830,8 @@ func TestSetPolicy(t *testing.T) {
 
 func TestGetPolicy(t *testing.T) {
 
+	t.Skip() //this is just for development purpose
+
 	policyName := os.Getenv("CLOUD_POLICY_MANAGEMENT_SAMPLE")
 	conn := getTestConnector(ctx.CloudZone)
 	conn.verbose = true

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -1598,7 +1598,7 @@ func TestOmitSans(t *testing.T) {
 }
 
 func TestSetPolicy(t *testing.T) {
-	policyName := os.Getenv("TPP_POLICY_MANAGEMENT_ROOT") + test.RandTppPolicyName()
+	policyName := os.Getenv("TPP_PM_ROOT") + "\\" + test.RandTppPolicyName()
 	ctx.CloudZone = policyName
 
 	tpp, err := getTestConnector(ctx.TPPurl, ctx.TPPZone)
@@ -1633,6 +1633,7 @@ func TestSetPolicy(t *testing.T) {
 }
 
 func TestGetPolicy(t *testing.T) {
+	t.Skip() //this is just for development purpose
 
 	policyName := os.Getenv("TPP_POLICY_MANAGEMENT_SAMPLE")
 
@@ -1790,7 +1791,7 @@ func TestGetPolicy(t *testing.T) {
 }
 
 func TestSetEmptyPolicy(t *testing.T) {
-	policyName := os.Getenv("TPP_POLICY_MANAGEMENT_ROOT") + test.RandTppPolicyName()
+	policyName := os.Getenv("TPP_PM_ROOT") + "\\" + test.RandTppPolicyName()
 	ctx.CloudZone = policyName
 
 	tpp, err := getTestConnector(ctx.TPPurl, ctx.TPPZone)
@@ -1827,7 +1828,7 @@ func TestSetDefaultPolicyValuesAndValidate(t *testing.T) {
 	serGenerated := true
 	specification.Default.KeyPair.EllipticCurve = &ec
 	specification.Default.KeyPair.ServiceGenerated = &serGenerated
-	policyName := os.Getenv("TPP_POLICY_MANAGEMENT_ROOT") + test.RandTppPolicyName()
+	policyName := os.Getenv("TPP_PM_ROOT") + "\\" + test.RandTppPolicyName()
 	ctx.CloudZone = policyName
 
 	tpp, err := getTestConnector(ctx.TPPurl, ctx.TPPZone)
@@ -1920,7 +1921,7 @@ func TestSetPolicyValuesAndValidate(t *testing.T) {
 
 	specification.Default = nil
 
-	policyName := os.Getenv("TPP_POLICY_MANAGEMENT_ROOT") + test.RandTppPolicyName()
+	policyName := os.Getenv("TPP_PM_ROOT") + "\\" + test.RandTppPolicyName()
 	ctx.CloudZone = policyName
 
 	tpp, err := getTestConnector(ctx.TPPurl, ctx.TPPZone)
@@ -2014,7 +2015,7 @@ func createConfigurationCredentials(c *Connector) {
 	resp, err := c.GetRefreshToken(&endpoint.Authentication{
 		User: ctx.TPPuser, Password: ctx.TPPPassword,
 		Scope:    "certificate:manage;configuration:manage",
-		ClientId: os.Getenv("TPP_POLICY_MANAGEMENT_CLIENT_ID"),
+		ClientId: os.Getenv("CLIENT_ID"),
 	})
 	if err != nil {
 		panic(err)

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -1606,7 +1606,6 @@ func TestSetPolicy(t *testing.T) {
 		t.Fatalf("err is not nil, err: %s url: %s", err, expectedURL)
 	}
 
-
 	tpp.verbose = true
 
 	if tpp.apiKey == "" {
@@ -1623,7 +1622,6 @@ func TestSetPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%s", err)
 	}
-
 
 }
 
@@ -1792,7 +1790,6 @@ func TestSetEmptyPolicy(t *testing.T) {
 	tpp, err := getTestConnector(ctx.TPPurl, ctx.TPPZone)
 	specification := policy.PolicySpecification{}
 
-
 	tpp.verbose = true
 
 	if tpp.apiKey == "" {
@@ -1823,7 +1820,6 @@ func TestSetDefaultPolicyValuesAndValidate(t *testing.T) {
 	ctx.CloudZone = policyName
 
 	tpp, err := getTestConnector(ctx.TPPurl, ctx.TPPZone)
-
 
 	tpp.verbose = true
 
@@ -1900,8 +1896,6 @@ func TestSetDefaultPolicyValuesAndValidate(t *testing.T) {
 		t.Fatalf("policy's default RsaKeySize is different expected: %s but get %s", strconv.Itoa(*(localDefault.KeyPair.RsaKeySize)), strconv.Itoa(*(remoteDefault.KeyPair.RsaKeySize)))
 	}
 
-
-
 }
 
 func TestSetPolicyValuesAndValidate(t *testing.T) {
@@ -1913,7 +1907,6 @@ func TestSetPolicyValuesAndValidate(t *testing.T) {
 	ctx.CloudZone = policyName
 
 	tpp, err := getTestConnector(ctx.TPPurl, ctx.TPPZone)
-
 
 	tpp.verbose = true
 
@@ -1994,4 +1987,3 @@ func TestSetPolicyValuesAndValidate(t *testing.T) {
 	}
 
 }
-

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -62,7 +62,7 @@ func init() {
 
 	resp, err := tpp.GetRefreshToken(&endpoint.Authentication{
 		User: ctx.TPPuser, Password: ctx.TPPPassword,
-		Scope: "certificate:discover,manage,revoke;configuration"})
+		Scope: "certificate:discover,manage,revoke;configuration:manage"})
 	if err != nil {
 		panic(err)
 	}
@@ -1606,9 +1606,6 @@ func TestSetPolicy(t *testing.T) {
 		t.Fatalf("err is not nil, err: %s url: %s", err, expectedURL)
 	}
 
-	//
-	createConfigurationCredentials(tpp)
-	//
 
 	tpp.verbose = true
 
@@ -1627,8 +1624,6 @@ func TestSetPolicy(t *testing.T) {
 		t.Fatalf("%s", err)
 	}
 
-	//revert back to the certificate scope
-	createCertificateCredentials(tpp)
 
 }
 
@@ -1797,7 +1792,6 @@ func TestSetEmptyPolicy(t *testing.T) {
 	tpp, err := getTestConnector(ctx.TPPurl, ctx.TPPZone)
 	specification := policy.PolicySpecification{}
 
-	createConfigurationCredentials(tpp)
 
 	tpp.verbose = true
 
@@ -1811,11 +1805,8 @@ func TestSetEmptyPolicy(t *testing.T) {
 	_, err = tpp.SetPolicy(policyName, &specification)
 
 	if err != nil {
-		createCertificateCredentials(tpp)
 		t.Fatalf("%s", err)
 	}
-	//revert back to the certificate scope
-	createCertificateCredentials(tpp)
 
 }
 
@@ -1833,7 +1824,6 @@ func TestSetDefaultPolicyValuesAndValidate(t *testing.T) {
 
 	tpp, err := getTestConnector(ctx.TPPurl, ctx.TPPZone)
 
-	createConfigurationCredentials(tpp)
 
 	tpp.verbose = true
 
@@ -1847,7 +1837,6 @@ func TestSetDefaultPolicyValuesAndValidate(t *testing.T) {
 	_, err = tpp.SetPolicy(policyName, specification)
 
 	if err != nil {
-		createCertificateCredentials(tpp)
 		t.Fatalf("%s", err)
 	}
 
@@ -1911,8 +1900,7 @@ func TestSetDefaultPolicyValuesAndValidate(t *testing.T) {
 		t.Fatalf("policy's default RsaKeySize is different expected: %s but get %s", strconv.Itoa(*(localDefault.KeyPair.RsaKeySize)), strconv.Itoa(*(remoteDefault.KeyPair.RsaKeySize)))
 	}
 
-	//revert back to the certificate scope
-	createCertificateCredentials(tpp)
+
 
 }
 
@@ -1926,7 +1914,6 @@ func TestSetPolicyValuesAndValidate(t *testing.T) {
 
 	tpp, err := getTestConnector(ctx.TPPurl, ctx.TPPZone)
 
-	createConfigurationCredentials(tpp)
 
 	tpp.verbose = true
 
@@ -1940,7 +1927,6 @@ func TestSetPolicyValuesAndValidate(t *testing.T) {
 	_, err = tpp.SetPolicy(policyName, specification)
 
 	if err != nil {
-		createCertificateCredentials(tpp)
 		t.Fatalf("%s", err)
 	}
 
@@ -2007,32 +1993,5 @@ func TestSetPolicyValuesAndValidate(t *testing.T) {
 		t.Fatalf("policy's RsaKeySizes are different expected:  %+q but get  %+q", localPolicy.KeyPair.RsaKeySizes, remotePolicy.KeyPair.RsaKeySizes)
 	}
 
-	//revert back to the certificate scope
-	createCertificateCredentials(tpp)
 }
 
-func createConfigurationCredentials(c *Connector) {
-	resp, err := c.GetRefreshToken(&endpoint.Authentication{
-		User: ctx.TPPuser, Password: ctx.TPPPassword,
-		Scope:    "certificate:manage;configuration:manage",
-		ClientId: os.Getenv("CLIENT_ID"),
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	ctx.TPPRefreshToken = resp.Refresh_token
-	ctx.TPPaccessToken = resp.Access_token
-}
-
-func createCertificateCredentials(c *Connector) {
-	resp, err := c.GetRefreshToken(&endpoint.Authentication{
-		User: ctx.TPPuser, Password: ctx.TPPPassword,
-		Scope: "certificate:discover,manage,revoke;configuration"})
-	if err != nil {
-		panic(err)
-	}
-
-	ctx.TPPRefreshToken = resp.Refresh_token
-	ctx.TPPaccessToken = resp.Access_token
-}

--- a/test/fixtures.go
+++ b/test/fixtures.go
@@ -43,7 +43,7 @@ func RandCN() string {
 }
 
 func RandAppName() string {
-	return fmt.Sprintf("t%d-%sAppOpenSource", time.Now().Unix(), randRunes(4))
+	return fmt.Sprintf("vcert-go-%d-%sAppOpenSource", time.Now().Unix(), randRunes(4))
 }
 
 func RandCitName() string {
@@ -51,7 +51,7 @@ func RandCitName() string {
 }
 
 func RandTppPolicyName() string {
-	return fmt.Sprintf("t%d-%sPolicyOpenSource", time.Now().Unix(), randRunes(4))
+	return fmt.Sprintf("vcert-go-%d-%sPolicyOpenSource", time.Now().Unix(), randRunes(4))
 }
 
 func GetCloudPolicySpecification() *policy.PolicySpecification {


### PR DESCRIPTION
change the name of environment variables to be coherent with other Vcert implementation 
changes to use "management" folder for policy management tests