### PR TITLE
policy management bug fixes

### DIFF
--- a/pkg/policy/constants.go
+++ b/pkg/policy/constants.go
@@ -3,7 +3,7 @@ package policy
 const (
 	JsonExtension        = ".json"
 	YamlExtension        = ".yaml"
-	RootPath             = "\\VED\\Policy"
+	RootPath             = PathSeparator + "VED" + PathSeparator + "Policy"
 	PathSeparator        = "\\"
 	PolicyClass          = "Policy"
 	PolicyAttributeClass = "X509 Certificate"

--- a/pkg/policy/constants.go
+++ b/pkg/policy/constants.go
@@ -3,7 +3,8 @@ package policy
 const (
 	JsonExtension        = ".json"
 	YamlExtension        = ".yaml"
-	RootPath             = "\\VED\\Policy\\"
+	RootPath             = "\\VED\\Policy"
+	PathSeparator        = "\\"
 	PolicyClass          = "Policy"
 	PolicyAttributeClass = "X509 Certificate"
 

--- a/pkg/policy/policyUtils.go
+++ b/pkg/policy/policyUtils.go
@@ -1100,7 +1100,7 @@ func GetApplicationName(zone string) string {
 
 func GetCitName(zone string) string {
 	data := strings.Split(zone, "\\")
-	if data != nil && data[1] != "" {
+	if len(data) == 2 {
 		return data[1]
 	}
 	return ""

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -669,6 +669,10 @@ func (c *Connector) GetPolicy(name string) (*policy.PolicySpecification, error) 
 
 	log.Println("Collecting policy attributes")
 
+	if !strings.HasPrefix(name, policy.PathSeparator) {
+		name = policy.PathSeparator + name
+	}
+
 	if !strings.HasPrefix(name, policy.RootPath) {
 		name = policy.RootPath + name
 
@@ -745,6 +749,9 @@ func (c *Connector) SetPolicy(name string, ps *policy.PolicySpecification) (stri
 	log.Printf("policy specification is valid")
 	var status = ""
 	tppPolicy := policy.BuildTppPolicy(ps)
+	if !strings.HasPrefix(name, policy.PathSeparator) {
+		name = policy.PathSeparator + name
+	}
 
 	if !strings.HasPrefix(name, policy.RootPath) {
 		name = policy.RootPath + name


### PR DESCRIPTION
when user specify a wrong zone on cloud, vcert fails, the wrong zone is in format like "abbcd", so the parser can't get the cit value and instead get null, so validated that when the name is parsed we get an array size=2
fixed an issue when zone name in policy that contains all DN path but not \ at the beginning fails

test suite ran well