### PR TITLE
Allow TPP to autodetect the type of certificate objects

### DIFF
--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"github.com/Venafi/vcert/v4/pkg/policy"
 	"log"
 	"net/http"
 	neturl "net/url"
@@ -29,6 +28,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/Venafi/vcert/v4/pkg/policy"
 
 	"github.com/Venafi/vcert/v4/pkg/util"
 
@@ -444,6 +445,8 @@ func prepareRequest(req *certificate.Request, zone string) (tppReq certificateRe
 	default:
 		return tppReq, fmt.Errorf("Unexpected option in PrivateKeyOrigin")
 	}
+
+	tppReq.CertificateType = "AUTO"
 	tppReq.PolicyDN = getPolicyDN(zone)
 	tppReq.CADN = req.CADN
 	tppReq.ObjectName = req.FriendlyName

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -83,6 +83,7 @@ type certificateRequest struct {
 	DisableAutomaticRenewal bool            `json:",omitempty"`
 	CustomFields            []customField   `json:",omitempty"`
 	Devices                 []device        `json:",omitempty"`
+	CertificateType         string          `json:",omitempty"`
 }
 
 type certificateRetrieveRequest struct {


### PR DESCRIPTION
Potential fix for "vCert defaults to Server Certificate Type in TPP regardless of Certificate Template used" https://github.com/Venafi/vcert/issues/183

PS: I have tried the change and it works. However, I have not ran the tests :) I don't have environment.