### PR TITLE
Changes to handle SSH Protect 21.4 (Updated)

### DIFF
--- a/cmd/vcert/args.go
+++ b/cmd/vcert/args.go
@@ -128,5 +128,6 @@ type commandFlags struct {
 	sshCertExtension     stringSlice
 	sshCertPrincipal     stringSlice
 	sshCertWindows       bool
-	sshFile              string
+	sshFileCertEnroll    string
+	sshFileGetConfig     string
 }

--- a/cmd/vcert/flags.go
+++ b/cmd/vcert/flags.go
@@ -623,12 +623,19 @@ var (
 		Usage: "The requested principals. If no value is specified, then the default principals from the certificate template will be used.",
 	}
 
-	flagSshFile = &cli.StringFlag{
+	flagSshFileCertEnroll = &cli.StringFlag{
 		Name: "file",
-		Usage: "Use to specify a file name and a location where the resulting file should be written. " +
-			"If this option is used the key, certificate, and chain will be written to the same file. " +
-			"Example: --file /path-to/ssh_pub.cer",
-		Destination: &flags.sshFile,
+		Usage: "Use to specify a file name and a location for the resulting private key, public key, certificate. " +
+			"Example: --file /path-to/id_rsa",
+		Destination: &flags.sshFileCertEnroll,
+		TakesFile:   true,
+	}
+
+	flagSshFileGetConfig = &cli.StringFlag{
+		Name: "file",
+		Usage: "Use to specify a file name and a location for the resulting CA public key. " +
+			"Example: --file /path-to/trusted_ca.pub",
+		Destination: &flags.sshFileGetConfig,
 		TakesFile:   true,
 	}
 
@@ -835,8 +842,9 @@ var (
 		flagSshPubKey,
 		flagSshKeySize,
 		flagSshPassPhrase,
-		commonFlags,
 		flagSshCertWindows,
+		flagSshFileCertEnroll,
+		commonFlags,
 	))
 
 	sshGetConfigFlags = sortedFlags(flagsApppend(
@@ -844,7 +852,7 @@ var (
 		flagTPPToken,
 		flagSshCertCa,
 		flagSshCertGuid,
-		flagSshFile,
+		flagSshFileGetConfig,
 		commonFlags,
 	))
 )

--- a/cmd/vcert/result_writer.go
+++ b/cmd/vcert/result_writer.go
@@ -23,13 +23,14 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"github.com/Venafi/vcert/v4/pkg/certificate"
-	"github.com/pavel-v-chernykh/keystore-go/v4"
 	"io/ioutil"
 	"os"
-	"software.sslmate.com/src/go-pkcs12"
 	"strings"
 	"time"
+
+	"github.com/Venafi/vcert/v4/pkg/certificate"
+	"github.com/pavel-v-chernykh/keystore-go/v4"
+	"software.sslmate.com/src/go-pkcs12"
 )
 
 type Config struct {
@@ -63,6 +64,7 @@ type Output struct {
 	PickupId    string   `json:",omitempty"`
 }
 
+//nolint
 func (o *Output) AsPKCS12(c *Config) ([]byte, error) {
 	if len(o.Certificate) == 0 || len(o.PrivateKey) == 0 {
 		return nil, fmt.Errorf("at least certificate and private key are required")
@@ -122,6 +124,7 @@ func (o *Output) AsPKCS12(c *Config) ([]byte, error) {
 	return bytes, nil
 }
 
+//nolint
 func (o *Output) AsJKS(c *Config) ([]byte, error) {
 
 	var err interface{}

--- a/cmd/vcert/utils.go
+++ b/cmd/vcert/utils.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Venafi, Inc.
+ * Copyright 2018-2021 Venafi, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -551,7 +551,7 @@ func printPrincipals(p []string) {
 func printCriticalOptions(fc string, sa []string) {
 	logf("\tCritical Options: ")
 	if fc == "" && len(sa) == 0 {
-		logf("\t\t", "None")
+		logf("\t\tNone")
 	} else {
 		if fc != "" {
 			logf("\t\tForce command: %s", fc)

--- a/cmd/vcert/utils.go
+++ b/cmd/vcert/utils.go
@@ -23,11 +23,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"github.com/Venafi/vcert/v4"
-	"github.com/Venafi/vcert/v4/pkg/policy"
-	"github.com/spf13/viper"
-	"github.com/urfave/cli/v2"
-	"gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
 	"log"
@@ -37,13 +32,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Venafi/vcert/v4/pkg/policy"
-	"github.com/spf13/viper"
-	"gopkg.in/yaml.v2"
-
+	"github.com/Venafi/vcert/v4"
 	"github.com/Venafi/vcert/v4/pkg/certificate"
 	"github.com/Venafi/vcert/v4/pkg/endpoint"
+	"github.com/Venafi/vcert/v4/pkg/policy"
 	"github.com/Venafi/vcert/v4/pkg/util"
+
+	"github.com/spf13/viper"
+	"github.com/urfave/cli/v2"
+	"gopkg.in/yaml.v2"
 )
 
 const (

--- a/cmd/vcert/utils.go
+++ b/cmd/vcert/utils.go
@@ -23,9 +23,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"github.com/Venafi/vcert/v4/pkg/policy"
-	"github.com/spf13/viper"
-	"gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
 	"log"
@@ -34,6 +31,10 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/Venafi/vcert/v4/pkg/policy"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v2"
 
 	"github.com/Venafi/vcert/v4/pkg/certificate"
 	"github.com/Venafi/vcert/v4/pkg/endpoint"
@@ -480,9 +481,9 @@ func writeToFile(content []byte, fileName string, perm os.FileMode) error {
 	return nil
 }
 
-func writeSshFiles(id string, privKey, pubKey, cert []byte) error {
+func writeSshFiles(privateKeyFileName string, privKey, pubKey, cert []byte) error {
 
-	fileName, err := normalizeSshCertFileName(id)
+	fileName, err := normalizeSshCertFileName(privateKeyFileName)
 
 	if err != nil {
 		return err
@@ -493,7 +494,7 @@ func writeSshFiles(id string, privKey, pubKey, cert []byte) error {
 		if err != nil {
 			return err
 		}
-		log.Println("Private key file was saved:  " + fileName)
+		log.Println("Private key has been written to: " + fileName)
 	}
 
 	//only write public key into a file if is not provided.
@@ -503,7 +504,7 @@ func writeSshFiles(id string, privKey, pubKey, cert []byte) error {
 		if err != nil {
 			return err
 		}
-		log.Println("Public key file was saved:   " + pubFileName)
+		log.Println("Public key has been written to:  " + pubFileName)
 
 	}
 
@@ -512,48 +513,48 @@ func writeSshFiles(id string, privKey, pubKey, cert []byte) error {
 	if err != nil {
 		return err
 	}
-	log.Println("Certificate file was saved:  " + certFileName)
+	log.Println("Certificate has been written to: " + certFileName)
 
 	return nil
 
 }
 
 func printExtensions(e map[string]interface{}) {
-	fmt.Println("Extensions: ")
+	logf("\tExtensions: ")
 	if len(e) > 0 {
 		for k, v := range e {
 			if v != "" {
 				kv := fmt.Sprintf("%s:%v", k, v)
 
-				fmt.Println("\t", kv)
+				logf("\t\t%s", kv)
 			} else {
-				fmt.Println("\t", k)
+				logf("\t\t%s", k)
 			}
 		}
 	} else {
-		fmt.Println("\t", "None")
+		logf("\t\t", "None")
 	}
 }
 
 func printPrincipals(p []string) {
-	fmt.Println("Principals: ")
+	logf("\tPrincipals: ")
 	if len(p) > 0 {
 		for _, v := range p {
-			fmt.Println("\t", v)
+			logf("\t\t%s", v)
 		}
 	} else {
-		fmt.Println("\t", "None")
+		logf("\t\t", "None")
 	}
 
 }
 
 func printCriticalOptions(fc string, sa []string) {
-	fmt.Println("Critical Options: ")
+	logf("\tCritical Options: ")
 	if fc == "" && len(sa) == 0 {
-		fmt.Println("\t", "None")
+		logf("\t\t", "None")
 	} else {
 		if fc != "" {
-			fmt.Println("\tForce command:", fc)
+			logf("\t\tForce command: %s", fc)
 		}
 		if len(sa) > 0 {
 			sourceAddsStr := ""
@@ -564,23 +565,23 @@ func printCriticalOptions(fc string, sa []string) {
 					sourceAddsStr = sourceAddsStr + ","
 				}
 			}
-			fmt.Println("\tSource addresses:", sourceAddsStr)
+			logf("\t\tSource addresses: %s", sourceAddsStr)
 		}
 	}
 }
 
-func printSshMetadata(data *certificate.SshCertRetrieveDetails) {
-	logf("certificate meta data:")
+func printSshMetadata(data *certificate.SshCertificateObject) {
+	logf("SSH certificate:")
 
-	fmt.Println("Certificate Type: ", data.CertificateDetails.CertificateType)
+	logf("\tCertificate Type: %s", data.CertificateDetails.CertificateType)
 	pubKey := fmt.Sprintf("%s:%s", Sha256, data.CertificateDetails.PublicKeyFingerprintSHA256)
-	fmt.Println("Public key: ", pubKey)
+	logf("\tPublic key: %s", pubKey)
 	signingCa := fmt.Sprintf("%s:%s", Sha256, data.CertificateDetails.CAFingerprintSHA256)
-	fmt.Println("Signing CA: ", signingCa)
-	fmt.Println("Certificate Identifier: ", data.CertificateDetails.KeyID)
-	fmt.Println("Serial: ", data.CertificateDetails.SerialNumber)
-	fmt.Println("Valid From: ", util.ConvertSecondsToTime(data.CertificateDetails.ValidFrom).String())
-	fmt.Println("Valid To: ", util.ConvertSecondsToTime(data.CertificateDetails.ValidTo).String())
+	logf("\tSigning CA: %s", signingCa)
+	logf("\tCertificate Identifier: %s", data.CertificateDetails.KeyID)
+	logf("\tSerial: %s", data.CertificateDetails.SerialNumber)
+	logf("\tValid From: %s", util.ConvertSecondsToTime(data.CertificateDetails.ValidFrom).String())
+	logf("\tValid To: %s", util.ConvertSecondsToTime(data.CertificateDetails.ValidTo).String())
 	printPrincipals(data.CertificateDetails.Principals)
 	printCriticalOptions(data.CertificateDetails.ForceCommand, data.CertificateDetails.SourceAddresses)
 	printExtensions(data.CertificateDetails.Extensions)

--- a/cmd/vcert/utils.go
+++ b/cmd/vcert/utils.go
@@ -532,7 +532,7 @@ func printExtensions(e map[string]interface{}) {
 			}
 		}
 	} else {
-		logf("\t\t", "None")
+		logf("\t\tNone")
 	}
 }
 
@@ -543,7 +543,7 @@ func printPrincipals(p []string) {
 			logf("\t\t%s", v)
 		}
 	} else {
-		logf("\t\t", "None")
+		logf("\t\tNone")
 	}
 
 }

--- a/cmd/vcert/validators.go
+++ b/cmd/vcert/validators.go
@@ -695,17 +695,7 @@ func validateSetPolicyFlags(commandName string) error {
 }
 
 func validateSshEnrollFlags(commandName string) error {
-
 	err := validateConnectionFlags(commandName)
-	if err != nil {
-		return err
-	}
-
-	if flags.sshCertKeyId == "" {
-		return fmt.Errorf("ID is required for the SSH certificate (--id)")
-	}
-
-	err = validateExistingFile(flags.sshCertKeyId)
 	if err != nil {
 		return err
 	}

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -26,11 +26,12 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"github.com/Venafi/vcert/v4/pkg/verror"
 	"net"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/Venafi/vcert/v4/pkg/verror"
 )
 
 // EllipticCurve represents the types of supported elliptic curves
@@ -229,24 +230,21 @@ type SshCertRequest struct {
 }
 
 type TPPSshCertRequest struct {
-	CADN                 string                 `json:"CADN,omitempty"`
-	PolicyDN             string                 `json:"PolicyDN,omitempty"`
-	ObjectName           string                 `json:"ObjectName,omitempty"`
-	DestinationAddresses []string               `json:"DestinationAddresses,omitempty"`
-	KeyId                string                 `json:"KeyId,omitempty"`
-	Principals           []string               `json:"Principals,omitempty"`
-	ValidityPeriod       string                 `json:"ValidityPeriod,omitempty"`
-	PublicKeyData        string                 `json:"PublicKeyData,omitempty"`
-	Extensions           map[string]interface{} `json:"Extensions,omitempty"`
-	ForceCommand         string                 `json:"ForceCommand,omitempty"`
-	SourceAddresses      []string               `json:"SourceAddresses,omitempty"`
-}
-
-type TppSshCertRequestResponse struct {
-	DN                string
-	Guid              string
-	ProcessingDetails ProcessingDetails
-	Response          TppSshCertResponseInfo `json:"Response,omitempty"`
+	CADN                      string                 `json:"CADN,omitempty"`
+	PolicyDN                  string                 `json:"PolicyDN,omitempty"`
+	ObjectName                string                 `json:"ObjectName,omitempty"`
+	DestinationAddresses      []string               `json:"DestinationAddresses,omitempty"`
+	KeyId                     string                 `json:"KeyId,omitempty"`
+	Principals                []string               `json:"Principals,omitempty"`
+	ValidityPeriod            string                 `json:"ValidityPeriod,omitempty"`
+	PublicKeyData             string                 `json:"PublicKeyData,omitempty"`
+	Extensions                map[string]interface{} `json:"Extensions,omitempty"`
+	ForceCommand              string                 `json:"ForceCommand,omitempty"`
+	SourceAddresses           []string               `json:"SourceAddresses,omitempty"`
+	IncludePrivateKeyData     bool                   `json:"IncludePrivateKeyData,omitempty"`
+	PrivateKeyPassphrase      string                 `json:"PrivateKeyPassphrase,omitempty"`
+	IncludeCertificateDetails bool                   `json:"IncludeCertificateDetails,omitempty"`
+	ProcessingTimeout         string                 `json:"ProcessingTimeout,omitempty"`
 }
 
 type TppSshCertResponseInfo struct {
@@ -264,7 +262,7 @@ type TppSshCertRetrieveRequest struct {
 	IncludeCertificateDetails bool
 }
 
-type TppSshCertRetrieveResponse struct {
+type TppSshCertOperationResponse struct {
 	ProcessingDetails  ProcessingDetails
 	Guid               string
 	DN                 string
@@ -277,7 +275,7 @@ type TppSshCertRetrieveResponse struct {
 	Response           TppSshCertResponseInfo
 }
 
-type SshCertRetrieveDetails struct {
+type SshCertificateObject struct {
 	Guid               string
 	DN                 string
 	CAGuid             string
@@ -286,6 +284,7 @@ type SshCertRetrieveDetails struct {
 	PrivateKeyData     string
 	PublicKeyData      string
 	CertificateDetails SshCertificateDetails
+	ProcessingDetails  ProcessingDetails
 }
 
 type SshCertificateDetails struct {
@@ -536,6 +535,7 @@ func GetPrivateKeyPEMBock(key crypto.Signer) (*pem.Block, error) {
 	}
 }
 
+//nolint
 // GetEncryptedPrivateKeyPEMBock gets the private key as an encrypted PEM data block
 func GetEncryptedPrivateKeyPEMBock(key crypto.Signer, password []byte) (*pem.Block, error) {
 	switch k := key.(type) {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -22,11 +22,12 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"github.com/Venafi/vcert/v4/pkg/policy"
 	"log"
 	"net"
 	"net/http"
 	"regexp"
+
+	"github.com/Venafi/vcert/v4/pkg/policy"
 
 	"github.com/Venafi/vcert/v4/pkg/certificate"
 )
@@ -97,8 +98,8 @@ type Connector interface {
 	ListCertificates(filter Filter) ([]certificate.CertificateInfo, error)
 	SetPolicy(name string, ps *policy.PolicySpecification) (string, error)
 	GetPolicy(name string) (*policy.PolicySpecification, error)
-	RequestSSHCertificate(req *certificate.SshCertRequest) (requestID string, err error)
-	RetrieveSSHCertificate(req *certificate.SshCertRequest) (response *certificate.SshCertRetrieveDetails, err error)
+	RequestSSHCertificate(req *certificate.SshCertRequest) (response *certificate.SshCertificateObject, err error)
+	RetrieveSSHCertificate(req *certificate.SshCertRequest) (response *certificate.SshCertificateObject, err error)
 	RetrieveSshConfig(ca *certificate.SshCaTemplateRequest) (*certificate.SshConfig, error)
 }
 

--- a/pkg/util/sshKeyGenerator.go
+++ b/pkg/util/sshKeyGenerator.go
@@ -6,9 +6,10 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"golang.org/x/crypto/ssh"
 	"log"
 	"strings"
+
+	"golang.org/x/crypto/ssh"
 )
 
 const (
@@ -31,6 +32,7 @@ func generatePrivKey(bitSize int) (*rsa.PrivateKey, error) {
 	return privKey, nil
 }
 
+//nolint
 func encodePrivKeyToPEM(privateKey *rsa.PrivateKey, keyPassword string) ([]byte, error) {
 
 	var err error

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -25,9 +25,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"github.com/Venafi/vcert/v4/pkg/policy"
-	"github.com/Venafi/vcert/v4/pkg/util"
-	"golang.org/x/crypto/nacl/box"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -37,12 +34,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Venafi/vcert/v4/pkg/policy"
-
-	"github.com/Venafi/vcert/v4/pkg/verror"
-
 	"github.com/Venafi/vcert/v4/pkg/certificate"
 	"github.com/Venafi/vcert/v4/pkg/endpoint"
+	"github.com/Venafi/vcert/v4/pkg/policy"
+	"github.com/Venafi/vcert/v4/pkg/util"
+	"github.com/Venafi/vcert/v4/pkg/verror"
+
+	"golang.org/x/crypto/nacl/box"
 )
 
 type urlResource string

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"github.com/Venafi/vcert/v4/pkg/policy"
 	"log"
 	"net/http"
 	netUrl "net/url"
@@ -30,6 +29,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/Venafi/vcert/v4/pkg/policy"
 
 	"github.com/Venafi/vcert/v4/pkg/verror"
 
@@ -79,14 +80,14 @@ type Connector struct {
 }
 
 func (c *Connector) RetrieveSshConfig(ca *certificate.SshCaTemplateRequest) (*certificate.SshConfig, error) {
-	panic("implement me")
-}
-
-func (c *Connector) RetrieveSSHCertificate(req *certificate.SshCertRequest) (response *certificate.SshCertRetrieveDetails, err error) {
 	panic("operation is not supported yet")
 }
 
-func (c *Connector) RequestSSHCertificate(req *certificate.SshCertRequest) (requestID string, err error) {
+func (c *Connector) RetrieveSSHCertificate(req *certificate.SshCertRequest) (response *certificate.SshCertificateObject, err error) {
+	panic("operation is not supported yet")
+}
+
+func (c *Connector) RequestSSHCertificate(req *certificate.SshCertRequest) (response *certificate.SshCertificateObject, err error) {
 	panic("operation is not supported yet")
 }
 

--- a/pkg/venafi/fake/connector.go
+++ b/pkg/venafi/fake/connector.go
@@ -24,11 +24,12 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"github.com/Venafi/vcert/v4/pkg/policy"
 	"math/big"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/Venafi/vcert/v4/pkg/policy"
 
 	"github.com/Venafi/vcert/v4/pkg/certificate"
 	"github.com/Venafi/vcert/v4/pkg/endpoint"
@@ -39,14 +40,14 @@ type Connector struct {
 }
 
 func (c *Connector) RetrieveSshConfig(ca *certificate.SshCaTemplateRequest) (*certificate.SshConfig, error) {
-	panic("implement me")
-}
-
-func (c *Connector) RetrieveSSHCertificate(req *certificate.SshCertRequest) (response *certificate.SshCertRetrieveDetails, err error) {
 	panic("operation is not supported yet")
 }
 
-func (c *Connector) RequestSSHCertificate(req *certificate.SshCertRequest) (requestID string, err error) {
+func (c *Connector) RetrieveSSHCertificate(req *certificate.SshCertRequest) (response *certificate.SshCertificateObject, err error) {
+	panic("operation is not supported yet")
+}
+
+func (c *Connector) RequestSSHCertificate(req *certificate.SshCertRequest) (response *certificate.SshCertificateObject, err error) {
 	panic("operation is not supported yet")
 }
 

--- a/pkg/venafi/tpp/authenticationError.go
+++ b/pkg/venafi/tpp/authenticationError.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Venafi, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tpp
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type authenticationError struct {
+	ErrorId          string `json:"error,omitempty"`
+	ErrorDescription string `json:"error_description,omitempty"`
+}
+
+func NewAuthenticationError(b []byte) error {
+	if len(b) == 0 {
+		return fmt.Errorf("no error message")
+	}
+	var data = &authenticationError{}
+	err := json.Unmarshal(b, data)
+	if err != nil {
+		return fmt.Errorf("failed to parser server error: %s", err)
+	}
+	return data
+}
+
+func (e *authenticationError) Error() string {
+	return fmt.Sprintf("Authentication error. Error ID: %s Description: %s", e.ErrorId, e.ErrorDescription)
+}

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"github.com/Venafi/vcert/v4/pkg/policy"
 	"log"
 	"net/http"
 	neturl "net/url"
@@ -29,6 +28,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/Venafi/vcert/v4/pkg/policy"
 
 	"github.com/Venafi/vcert/v4/pkg/util"
 
@@ -444,6 +445,8 @@ func prepareRequest(req *certificate.Request, zone string) (tppReq certificateRe
 	default:
 		return tppReq, fmt.Errorf("Unexpected option in PrivateKeyOrigin")
 	}
+
+	tppReq.CertificateType = "AUTO"
 	tppReq.PolicyDN = getPolicyDN(zone)
 	tppReq.CADN = req.CADN
 	tppReq.ObjectName = req.FriendlyName

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -1657,12 +1657,12 @@ func resetTPPAttribute(c *Connector, at, zone string) error {
 	return nil
 }
 
-func (c *Connector) RequestSSHCertificate(req *certificate.SshCertRequest) (requestID string, err error) {
+func (c *Connector) RequestSSHCertificate(req *certificate.SshCertRequest) (response *certificate.SshCertificateObject, err error) {
 
 	return RequestSshCertificate(c, req)
 
 }
 
-func (c *Connector) RetrieveSSHCertificate(req *certificate.SshCertRequest) (response *certificate.SshCertRetrieveDetails, err error) {
+func (c *Connector) RetrieveSSHCertificate(req *certificate.SshCertRequest) (response *certificate.SshCertificateObject, err error) {
 	return RetrieveSshCertificate(c, req)
 }

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -26,8 +26,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"github.com/Venafi/vcert/v4/pkg/policy"
-	"github.com/Venafi/vcert/v4/pkg/util"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -38,6 +36,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Venafi/vcert/v4/pkg/policy"
+	"github.com/Venafi/vcert/v4/pkg/util"
 
 	"github.com/Venafi/vcert/v4/pkg/certificate"
 	"github.com/Venafi/vcert/v4/pkg/endpoint"
@@ -2013,14 +2014,14 @@ func TestCreateSshCertServiceGeneratedKP(t *testing.T) {
 	req.Template = os.Getenv("TPP_SSH_CA")
 	req.SourceAddresses = []string{"test.com"}
 
-	id, err := tpp.RequestSSHCertificate(req)
+	respData, err := tpp.RequestSSHCertificate(req)
 
 	if err != nil {
 		t.Fatalf("err is not nil, err: %s", err)
 	}
 
 	retReq := &certificate.SshCertRequest{
-		PickupID:                  id,
+		PickupID:                  respData.DN,
 		IncludeCertificateDetails: true,
 		Timeout:                   time.Duration(10) * time.Second,
 	}
@@ -2095,14 +2096,14 @@ func TestCreateSshCertLocalGeneratedKP(t *testing.T) {
 
 	req.PublicKeyData = sPubKey
 
-	id, err := tpp.RequestSSHCertificate(req)
+	respData, err := tpp.RequestSSHCertificate(req)
 
 	if err != nil {
 		t.Fatalf("err is not nil, err: %s", err)
 	}
 
 	retReq := &certificate.SshCertRequest{
-		PickupID:                  id,
+		PickupID:                  respData.DN,
 		IncludeCertificateDetails: true,
 		Timeout:                   time.Duration(10) * time.Second,
 	}
@@ -2184,14 +2185,14 @@ func TestCreateSshCertProvidedPubKey(t *testing.T) {
 	req.PublicKeyData = content
 	req.SourceAddresses = []string{"test.com"}
 
-	id, err := tpp.RequestSSHCertificate(req)
+	respData, err := tpp.RequestSSHCertificate(req)
 
 	if err != nil {
 		t.Fatalf("err is not nil, err: %s", err)
 	}
 
 	retReq := &certificate.SshCertRequest{
-		PickupID:                  id,
+		PickupID:                  respData.DN,
 		IncludeCertificateDetails: true,
 		Timeout:                   time.Duration(10) * time.Second,
 	}

--- a/pkg/venafi/tpp/sshCertUtils.go
+++ b/pkg/venafi/tpp/sshCertUtils.go
@@ -3,44 +3,55 @@ package tpp
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/Venafi/vcert/v4/pkg/certificate"
-	"github.com/Venafi/vcert/v4/pkg/endpoint"
-	"github.com/Venafi/vcert/v4/pkg/util"
 	"log"
 	"net/http"
 	netUrl "net/url"
 	"strings"
 	"time"
+
+	"github.com/Venafi/vcert/v4/pkg/certificate"
+	"github.com/Venafi/vcert/v4/pkg/endpoint"
+	"github.com/Venafi/vcert/v4/pkg/util"
 )
 
 const (
 	SSHCaRootPath = util.PathSeparator + "VED" + util.PathSeparator + "Certificate Authority" + util.PathSeparator + "SSH" + util.PathSeparator + "Templates"
 )
 
-func RequestSshCertificate(c *Connector, req *certificate.SshCertRequest) (requestID string, err error) {
+func RequestSshCertificate(c *Connector, req *certificate.SshCertRequest) (*certificate.SshCertificateObject, error) {
 
 	sshCertReq := convertToSshCertReq(req)
 
-	fmt.Println("Requesting certificate with certificate identifier: ", sshCertReq.KeyId)
-
-	statusCode, status, body, err := c.request("POST", urlResourceSshCertReq, sshCertReq)
-	if err != nil {
-		return "", err
+	if sshCertReq.KeyId == "" {
+		log.Println("Requesting SSH certificate from ", sshCertReq.CADN)
+	} else {
+		log.Println("Requesting SSH certificate with certificate identifier: ", sshCertReq.KeyId)
 	}
 
-	response, err := parseSshCertRequestResult(statusCode, status, body)
+	//TODO: Maybe, there is a better way to set the timeout.
+	c.client.Timeout = time.Duration(req.Timeout) * time.Second
+	statusCode, status, body, err := c.request("POST", urlResourceSshCertReq, sshCertReq)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := parseSshCertOperationResponse(statusCode, status, body)
+
+	log.Println("SSH certificate DN: ", response.DN)
+	log.Println("GUID: ", response.Guid)
 
 	if err != nil {
 		if response.Response.ErrorMessage != "" && c.verbose {
 			log.Println(util.GetJsonAsString(response.Response))
 		}
-		return "", err
+		return nil, err
 	}
 
-	fmt.Println("SSH cert DN: ", response.DN)
-	fmt.Println("GUID: ", response.Guid)
+	if response.Response.Success && response.ProcessingDetails.Status == "Rejected" {
+		return nil, endpoint.ErrCertificateRejected{CertificateID: req.PickupID, Status: response.ProcessingDetails.StatusDescription}
+	}
 
-	return response.DN, nil
+	return convertToGenericRetrieveResponse(&response), nil
 }
 
 func convertToSshCertReq(req *certificate.SshCertRequest) certificate.TPPSshCertRequest {
@@ -101,19 +112,20 @@ func convertToSshCertReq(req *certificate.SshCertRequest) certificate.TPPSshCert
 	}
 
 	if req.Template != "" {
-
 		tppSshCertReq.CADN = getSshCaDN(req.Template)
-
 	}
 
 	if req.ForceCommand != "" {
 		tppSshCertReq.ForceCommand = req.ForceCommand
 	}
 
+	tppSshCertReq.IncludePrivateKeyData = true
+	tppSshCertReq.IncludeCertificateDetails = true
+
 	return tppSshCertReq
 }
 
-func RetrieveSshCertificate(c *Connector, req *certificate.SshCertRequest) (*certificate.SshCertRetrieveDetails, error) {
+func RetrieveSshCertificate(c *Connector, req *certificate.SshCertRequest) (*certificate.SshCertificateObject, error) {
 	var reqRetrieve certificate.TppSshCertRetrieveRequest
 
 	if req.PickupID != "" {
@@ -134,7 +146,7 @@ func RetrieveSshCertificate(c *Connector, req *certificate.SshCertRequest) (*cer
 
 	startTime := time.Now()
 	for {
-		var retrieveResponse *certificate.TppSshCertRetrieveResponse
+		var retrieveResponse *certificate.TppSshCertOperationResponse
 		retrieveResponse, err := retrieveSshCerOnce(reqRetrieve, c)
 		if err != nil {
 			return nil, err
@@ -157,70 +169,52 @@ func RetrieveSshCertificate(c *Connector, req *certificate.SshCertRequest) (*cer
 	}
 }
 
-func retrieveSshCerOnce(sshRetrieveReq certificate.TppSshCertRetrieveRequest, c *Connector) (*certificate.TppSshCertRetrieveResponse, error) {
+func retrieveSshCerOnce(sshRetrieveReq certificate.TppSshCertRetrieveRequest, c *Connector) (*certificate.TppSshCertOperationResponse, error) {
 	statusCode, status, body, err := c.request("POST", urlResourceSshCertRet, sshRetrieveReq)
 	if err != nil {
 		return nil, err
 	}
-	retrieveResponse, err := parseSshCertRetrieveResult(statusCode, status, body)
+	retrieveResponse, err := parseSshCertOperationResponse(statusCode, status, body)
 	if err != nil {
 		return nil, err
 	}
 	return &retrieveResponse, nil
 }
 
-func parseSshCertRetrieveResult(httpStatusCode int, httpStatus string, body []byte) (certificate.TppSshCertRetrieveResponse, error) {
-	var retrieveResponse certificate.TppSshCertRetrieveResponse
+func parseSshCertOperationResponse(httpStatusCode int, httpStatus string, body []byte) (certificate.TppSshCertOperationResponse, error) {
+	var retrieveResponse certificate.TppSshCertOperationResponse
 	switch httpStatusCode {
 	case http.StatusOK, http.StatusAccepted:
-		retrieveResponse, err := parseSshCertRetrieveData(body)
+		response, err := parseSshCertData(body)
 		if err != nil {
-			return retrieveResponse, err
+			return response, err
 		}
-		if !retrieveResponse.Response.Success {
-			return retrieveResponse, fmt.Errorf("error getting certificate, error status: %s, error description: %s", retrieveResponse.ProcessingDetails.Status, retrieveResponse.ProcessingDetails.StatusDescription)
+		if response.Response.Success && response.ProcessingDetails.Status == "Rejected" {
+			return response, fmt.Errorf("error getting certificate object, error status: %s, error description: %s", response.ProcessingDetails.Status, response.ProcessingDetails.StatusDescription)
 		}
-		return retrieveResponse, nil
+		return response, nil
+	case http.StatusBadRequest:
+		response, err := parseSshCertData(body)
+		if err != nil {
+			return response, err
+		}
+		if !response.Response.Success {
+			return response, fmt.Errorf("error getting certificate object, error status: %d, error description: %s", response.Response.ErrorCode, response.Response.ErrorMessage)
+		}
+		return response, nil
 	default:
-		return retrieveResponse, fmt.Errorf("unexpected status code on TPP SSH Certificate Retrieval. Status: %s", httpStatus)
+		return retrieveResponse, fmt.Errorf("unexpected status code. Status: %s", httpStatus)
 	}
 }
 
-func parseSshCertRetrieveData(b []byte) (data certificate.TppSshCertRetrieveResponse, err error) {
+func parseSshCertData(b []byte) (data certificate.TppSshCertOperationResponse, err error) {
 	err = json.Unmarshal(b, &data)
 	return
 }
 
-func parseSshCertRequestResult(httpStatusCode int, httpStatus string, body []byte) (certificate.TppSshCertRequestResponse, error) {
-	var requestResponse certificate.TppSshCertRequestResponse
-	var err error
-	switch httpStatusCode {
-	case http.StatusOK, http.StatusAccepted:
-		requestResponse, err = parseSshCertRequestData(body)
-		if err != nil {
-			return requestResponse, err
-		}
-		if !requestResponse.Response.Success {
-			return requestResponse, fmt.Errorf("error requesting certificate, error code: %d, error description: %s", requestResponse.Response.ErrorCode, requestResponse.Response.ErrorMessage)
-		}
-		return requestResponse, nil
-	default:
-		requestResponse, err = parseSshCertRequestData(body)
-		if err != nil {
-			return requestResponse, err
-		}
-		return requestResponse, fmt.Errorf("unexpected status code on TPP SSH Certificate Request. Status code: %s, %s", httpStatus, requestResponse.Response.ErrorMessage)
-	}
-}
+func convertToGenericRetrieveResponse(data *certificate.TppSshCertOperationResponse) *certificate.SshCertificateObject {
 
-func parseSshCertRequestData(b []byte) (data certificate.TppSshCertRequestResponse, err error) {
-	err = json.Unmarshal(b, &data)
-	return
-}
-
-func convertToGenericRetrieveResponse(data *certificate.TppSshCertRetrieveResponse) *certificate.SshCertRetrieveDetails {
-
-	response := &certificate.SshCertRetrieveDetails{}
+	response := &certificate.SshCertificateObject{}
 
 	response.CertificateDetails = data.CertificateDetails
 	response.PrivateKeyData = data.PrivateKeyData
@@ -230,9 +224,9 @@ func convertToGenericRetrieveResponse(data *certificate.TppSshCertRetrieveRespon
 	response.DN = data.DN
 	response.CAGuid = data.CAGuid
 	response.CADN = data.CADN
+	response.ProcessingDetails = data.ProcessingDetails
 
 	return response
-
 }
 
 func getSshConfigUrl(key, value string) string {

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -83,6 +83,7 @@ type certificateRequest struct {
 	DisableAutomaticRenewal bool            `json:",omitempty"`
 	CustomFields            []customField   `json:",omitempty"`
 	Devices                 []device        `json:",omitempty"`
+	CertificateType         string          `json:",omitempty"`
 }
 
 type certificateRetrieveRequest struct {


### PR DESCRIPTION
The PR contains changes which will make vCert comparable with SSH Protect 21.4 and prior. The high-level changes are:

- Ability to consume the issued certificates returned as response of the SSHCertificate/Request API method.
- Fix the logic which handles errors returned by SSH Protect.
- Ability to store CA public keys to file using '--file' flag.
- '--no-prompt' flag will be considered when asking to overwrite existing files (--file flag). When the flag is used, it will overwrite the existing files.
- '--id' (Key ID) is not required anymore as SSH Protect may have default value. This works for both SSH Protect 21.3 and 21.4
/- /nolint added to some methods to prevent failed builds. This will be discussed with the maintainer.

PS: Apologues for the previous PR. 