### PR TITLE
From pkcs1 to pcks8

### DIFF
--- a/aruba/features/enroll/enroll-with-csr.feature
+++ b/aruba/features/enroll/enroll-with-csr.feature
@@ -55,15 +55,7 @@ Feature: enrolling certificates with -csr option (VEN-40652)
       | TPP       |
       | Cloud     |
 
-  Scenario Outline: where it returns an error on enrolling a certificate with -csr service and empty -key-password
-    When I enroll random certificate using <endpoint> with -csr service -no-prompt
-    Then the exit status should not be 0
-    And the output should contain "-key-password cannot be empty in -csr service mode unless -no-pickup specified"
-    Examples:
-      | endpoint  |
-      | test-mode |
-      | TPP       |
-      | Cloud     |
+
 
   Scenario Outline: where it should however enroll a certificate with -csr service, empty -key-password and -no-pickup
     When I enroll random certificate using <endpoint> with -csr service -no-prompt -no-pickup

--- a/aruba/features/step_definitions/my_steps.rb
+++ b/aruba/features/step_definitions/my_steps.rb
@@ -20,9 +20,17 @@ Then(/^it should post certificate request$/) do
 end
 
 Then(/^it should( not)? output( encrypted)? private key$/) do |negated, encrypted|
-  steps %{Then the output should#{negated} contain "-----BEGIN RSA PRIVATE KEY-----"}
   if encrypted
-    steps %{Then the output should#{negated} contain "ENCRYPTED"}
+    steps %{Then the output should#{negated} contain "-----BEGIN ENCRYPTED PRIVATE KEY-----"}
+   else
+    steps %{Then the output should#{negated} contain "-----BEGIN PRIVATE KEY-----"}
+  end
+end
+
+Then(/^it should( not)? output( encrypted)? RSA private key$/) do |negated, encrypted|
+ steps %{Then the output should#{negated} contain "-----BEGIN RSA PRIVATE KEY-----"}
+  if encrypted
+    steps %{Then the output should#{negated} contain "-----ENCRYPTED-----"}
   end
 end
 

--- a/cmd/vcert/commands.go
+++ b/cmd/vcert/commands.go
@@ -356,7 +356,7 @@ func doCommandEnroll1(c *cli.Context) error {
 		privKey, err := util.DecryptPkcs8PrivateKey(pcc.PrivateKey, flags.keyPassword)
 		if err != nil {
 			if err.Error() == "pkcs8: only PBES2 supported" && connector.GetType() == endpoint.ConnectorTypeTPP {
-				return fmt.Errorf("for Trust Protection Platform, you need to select one of the following private key PBE algorithms: SHA 3DES or SHA256 AES256")
+				return fmt.Errorf("ERROR: To continue, you must select either the SHA1 3DES or SHA256 AES256 private key PBE algorithm. In a web browser, log in to TLS Protect and go to Configuration > Folders, select your zone, then click Certificate Policy and expand Show Advanced Options to make the change.")
 			}
 			return err
 		}
@@ -844,7 +844,7 @@ func doCommandPickup1(c *cli.Context) error {
 		privKey, err := util.DecryptPkcs8PrivateKey(pcc.PrivateKey, flags.keyPassword)
 		if err != nil {
 			if err.Error() == "pkcs8: only PBES2 supported" && connector.GetType() == endpoint.ConnectorTypeTPP {
-				return fmt.Errorf("for Trust Protection Platform, you need to select one of the following private key PBE algorithms: SHA 3DES or SHA256 AES256")
+				return fmt.Errorf("ERROR: To continue, you must select either the SHA1 3DES or SHA256 AES256 private key PBE algorithm. In a web browser, log in to TLS Protect and go to Configuration > Folders, select your zone, then click Certificate Policy and expand Show Advanced Options to make the change.")
 			}
 			return err
 		}

--- a/cmd/vcert/commands.go
+++ b/cmd/vcert/commands.go
@@ -320,7 +320,7 @@ func doCommandEnroll1(c *cli.Context) error {
 	logf("Successfully posted request for %s, will pick up by %s", requestedFor, flags.pickupID)
 
 	if flags.noPickup {
-		pcc, err = certificate.NewPEMCollection(nil, req.PrivateKey, []byte(flags.keyPassword))
+		pcc, err = certificate.NewPEMCollection(nil, req.PrivateKey, []byte(flags.keyPassword), flags.format)
 		if err != nil {
 			return err
 		}
@@ -338,14 +338,14 @@ func doCommandEnroll1(c *cli.Context) error {
 
 		if req.CsrOrigin == certificate.LocalGeneratedCSR {
 			// otherwise private key can be taken from *req
-			err := pcc.AddPrivateKey(req.PrivateKey, []byte(flags.keyPassword))
+			err := pcc.AddPrivateKey(req.PrivateKey, []byte(flags.keyPassword), flags.format)
 			if err != nil {
 				log.Fatal(err)
 			}
 		}
 	}
 
-	if connector.GetType() == endpoint.ConnectorTypeCloud && (flags.format == Pkcs12 || flags.format == JKSFormat) && flags.csrOption == "service" {
+	if flags.format == Pkcs12 || flags.format == JKSFormat {
 		privKey, err := util.DecryptPkcs8PrivateKey(pcc.PrivateKey, flags.keyPassword)
 		if err != nil {
 			return err
@@ -797,7 +797,7 @@ func doCommandPickup1(c *cli.Context) error {
 	}
 	logf("Successfully retrieved request for %s", flags.pickupID)
 
-	if connector.GetType() == endpoint.ConnectorTypeCloud && (flags.format == Pkcs12 || flags.format == JKSFormat) && IsCSRServiceVaaSGenerated(c.Command.Name) {
+	if connector.GetType() == endpoint.ConnectorTypeCloud && (flags.format == Pkcs12 || flags.format == JKSFormat) && IsCSRServiceVaaSGenerated(c.Command.Name) || (connector.GetType() == endpoint.ConnectorTypeTPP && (flags.format == Pkcs12 || flags.format == JKSFormat) && pcc.PrivateKey != "") {
 		privKey, err := util.DecryptPkcs8PrivateKey(pcc.PrivateKey, flags.keyPassword)
 		if err != nil {
 			return err

--- a/cmd/vcert/commands.go
+++ b/cmd/vcert/commands.go
@@ -355,6 +355,9 @@ func doCommandEnroll1(c *cli.Context) error {
 	if (pcc.PrivateKey != "" && req.KeyType == certificate.KeyTypeRSA && (flags.format == Pkcs12 || flags.format == JKSFormat)) || (flags.format == util.LegacyPem && flags.csrOption == "service") || flags.noPrompt && wasPasswordEmpty && (req.KeyType == certificate.KeyTypeRSA) {
 		privKey, err := util.DecryptPkcs8PrivateKey(pcc.PrivateKey, flags.keyPassword)
 		if err != nil {
+			if err.Error() == "pkcs8: only PBES2 supported" && connector.GetType() == endpoint.ConnectorTypeTPP {
+				return fmt.Errorf("for Trust Protection Platform, you need to select one of the following private key PBE algorithms: SHA 3DES or SHA256 AES256")
+			}
 			return err
 		}
 		pcc.PrivateKey = privKey
@@ -840,6 +843,9 @@ func doCommandPickup1(c *cli.Context) error {
 	if pcc.PrivateKey != "" && (flags.format == Pkcs12 || flags.format == JKSFormat || flags.format == util.LegacyPem) || (flags.noPrompt && wasPasswordEmpty && pcc.PrivateKey != "") {
 		privKey, err := util.DecryptPkcs8PrivateKey(pcc.PrivateKey, flags.keyPassword)
 		if err != nil {
+			if err.Error() == "pkcs8: only PBES2 supported" && connector.GetType() == endpoint.ConnectorTypeTPP {
+				return fmt.Errorf("for Trust Protection Platform, you need to select one of the following private key PBE algorithms: SHA 3DES or SHA256 AES256")
+			}
 			return err
 		}
 		pcc.PrivateKey = privKey

--- a/cmd/vcert/commands.go
+++ b/cmd/vcert/commands.go
@@ -352,7 +352,7 @@ func doCommandEnroll1(c *cli.Context) error {
 		}
 	}
 
-	if (pcc.PrivateKey != "" && req.KeyType == certificate.KeyTypeRSA && (flags.format == Pkcs12 || flags.format == JKSFormat)) || (flags.format == util.LegacyPem && IsCSRServiceVaaSGenerated(commandPickupName)) || flags.noPrompt && wasPasswordEmpty && (req.KeyType == certificate.KeyTypeRSA) {
+	if (pcc.PrivateKey != "" && req.KeyType == certificate.KeyTypeRSA && (flags.format == Pkcs12 || flags.format == JKSFormat)) || (flags.format == util.LegacyPem && flags.csrOption == "service") || flags.noPrompt && wasPasswordEmpty && (req.KeyType == certificate.KeyTypeRSA) {
 		privKey, err := util.DecryptPkcs8PrivateKey(pcc.PrivateKey, flags.keyPassword)
 		if err != nil {
 			return err

--- a/cmd/vcert/flags.go
+++ b/cmd/vcert/flags.go
@@ -844,6 +844,7 @@ var (
 		flagSshPassPhrase,
 		flagSshCertWindows,
 		flagSshFileCertEnroll,
+		flagFormat,
 		commonFlags,
 	))
 

--- a/cmd/vcert/result_writer.go
+++ b/cmd/vcert/result_writer.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"github.com/Venafi/vcert/v4/pkg/util"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -64,7 +65,6 @@ type Output struct {
 	PickupId    string   `json:",omitempty"`
 }
 
-//nolint
 func (o *Output) AsPKCS12(c *Config) ([]byte, error) {
 	if len(o.Certificate) == 0 || len(o.PrivateKey) == 0 {
 		return nil, fmt.Errorf("at least certificate and private key are required")
@@ -95,8 +95,8 @@ func (o *Output) AsPKCS12(c *Config) ([]byte, error) {
 		return nil, fmt.Errorf("missing private key PEM")
 	}
 	var privDER []byte
-	if x509.IsEncryptedPEMBlock(p) {
-		privDER, err = x509.DecryptPEMBlock(p, []byte(c.KeyPassword))
+	if util.X509IsEncryptedPEMBlock(p) {
+		privDER, err = util.X509DecryptPEMBlock(p, []byte(c.KeyPassword))
 		if err != nil {
 			return nil, fmt.Errorf("private key PEM decryption error: %s", err)
 		}
@@ -127,7 +127,6 @@ func (o *Output) AsPKCS12(c *Config) ([]byte, error) {
 	return bytes, nil
 }
 
-//nolint
 func (o *Output) AsJKS(c *Config) ([]byte, error) {
 
 	var err interface{}
@@ -170,8 +169,8 @@ func (o *Output) AsJKS(c *Config) ([]byte, error) {
 	//decrypting the PK because due the restriction that always will be requested the key password
 	//to the user(--key-password or pass phrase value from prompt) for jks format then the PK always
 	//will be encrypted with the key password provided
-	if x509.IsEncryptedPEMBlock(p) {
-		privDER, err = x509.DecryptPEMBlock(p, []byte(c.KeyPassword))
+	if util.X509IsEncryptedPEMBlock(p) {
+		privDER, err = util.X509DecryptPEMBlock(p, []byte(c.KeyPassword))
 		if err != nil {
 			return nil, fmt.Errorf("private key PEM decryption error: %s", err)
 		}

--- a/cmd/vcert/utils.go
+++ b/cmd/vcert/utils.go
@@ -60,6 +60,7 @@ const (
 	SshCertPubKeyLocal     = "local"
 	sshCertFileExt         = "-cert.pub"
 	sshPubKeyFileExt       = ".pub"
+	LegacyPem              = "legacy-pem"
 )
 
 func parseCustomField(s string) (key, value string, err error) {

--- a/cmd/vcert/utils.go
+++ b/cmd/vcert/utils.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"os"
 	"regexp"
 	"strconv"
@@ -60,7 +61,6 @@ const (
 	SshCertPubKeyLocal     = "local"
 	sshCertFileExt         = "-cert.pub"
 	sshPubKeyFileExt       = ".pub"
-	LegacyPem              = "legacy-pem"
 )
 
 func parseCustomField(s string) (key, value string, err error) {
@@ -695,4 +695,35 @@ func IsCSRServiceVaaSGenerated(commandName string) bool {
 		}
 	}
 	return cloudSerViceGenerated
+}
+
+func isTppConnector(commandName string) bool {
+
+	if commandName == commandPickupName {
+		context := &cli.Context{
+			Command: &cli.Command{
+				Name: commandPickupName,
+			},
+		}
+
+		cfg, err := buildConfig(context, &flags)
+
+		if err == nil {
+			connector, err := vcert.NewClient(&cfg)
+			if err == nil && endpoint.ConnectorTypeTPP == connector.GetType() {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func randRunes(n int) string {
+	var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz")
+	b := make([]rune, n)
+	for i := range b {
+		/* #nosec */
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
 }

--- a/cmd/vcert/validators.go
+++ b/cmd/vcert/validators.go
@@ -19,6 +19,7 @@ package main
 import (
 	"bufio"
 	"fmt"
+	"github.com/Venafi/vcert/v4/pkg/util"
 	"io/ioutil"
 	"os"
 	"regexp"
@@ -73,7 +74,7 @@ func readData(commandName string) error {
 }
 
 func validateCommonFlags(commandName string) error {
-	if flags.format != "" && flags.format != "pem" && flags.format != "json" && flags.format != "pkcs12" && flags.format != JKSFormat && flags.format != LegacyPem {
+	if flags.format != "" && flags.format != "pem" && flags.format != "json" && flags.format != "pkcs12" && flags.format != JKSFormat && flags.format != util.LegacyPem {
 		return fmt.Errorf("Unexpected output format: %s", flags.format)
 	}
 	if flags.file != "" && (flags.certFile != "" || flags.chainFile != "" || flags.keyFile != "") {
@@ -322,11 +323,7 @@ func validateEnrollFlags(commandName string) error {
 	if flags.csrOption == "file" && flags.keyFile != "" { // Do not specify -key-file with -csr file as VCert cannot access the private key
 		return fmt.Errorf("-key-file cannot be used with -csr file as VCert cannot access the private key")
 	}
-	if flags.csrOption == "service" && (!flags.noPickup) { // Key password is required here
-		if flags.noPrompt && len(flags.keyPassword) == 0 {
-			return fmt.Errorf("-key-password cannot be empty in -csr service mode unless -no-pickup specified")
-		}
-	}
+
 	err = validatePKCS12Flags(commandName)
 	if err != nil {
 		return err

--- a/cmd/vcert/validators.go
+++ b/cmd/vcert/validators.go
@@ -73,7 +73,7 @@ func readData(commandName string) error {
 }
 
 func validateCommonFlags(commandName string) error {
-	if flags.format != "" && flags.format != "pem" && flags.format != "json" && flags.format != "pkcs12" && flags.format != JKSFormat {
+	if flags.format != "" && flags.format != "pem" && flags.format != "json" && flags.format != "pkcs12" && flags.format != JKSFormat && flags.format != LegacyPem {
 		return fmt.Errorf("Unexpected output format: %s", flags.format)
 	}
 	if flags.file != "" && (flags.certFile != "" || flags.chainFile != "" || flags.keyFile != "") {

--- a/listener.go
+++ b/listener.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/Venafi/vcert/v4/pkg/certificate"
 	"github.com/Venafi/vcert/v4/pkg/endpoint"
+	"github.com/Venafi/vcert/v4/pkg/util"
 	"log"
 	"net"
 	"time"
@@ -90,6 +91,17 @@ func getSimpleCertificate(conn endpoint.Connector, cn string) (tls.Certificate, 
 		return tls.Certificate{}, err
 	}
 	err = certCollection.AddPrivateKey(req.PrivateKey, nil)
+
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	privKey, err := util.DecryptPkcs8PrivateKey(certCollection.PrivateKey, "")
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	certCollection.PrivateKey = privKey
+
 	return certCollection.ToTLSCertificate(), err
 }
 

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -354,6 +354,18 @@ type CertificateInfo struct {
 	ValidTo    time.Time
 }
 
+type SearchRequest []string
+
+type CertSearchResponse struct {
+	Certificates []CertSeachInfo `json:"Certificates"`
+	Count        int             `json:"TotalCount"`
+}
+
+type CertSeachInfo struct {
+	CertificateRequestId   string `json:"DN"`
+	CertificateRequestGuid string `json:"Guid"`
+}
+
 // SetCSR sets CSR from PEM or DER format
 func (request *Request) SetCSR(csr []byte) error {
 	pemBlock, _ := pem.Decode(csr)

--- a/pkg/certificate/certificateCollection_test.go
+++ b/pkg/certificate/certificateCollection_test.go
@@ -331,7 +331,7 @@ func TestAddPrivateKey(t *testing.T) {
 
 	pcc, _ := NewPEMCollection(nil, nil, nil)
 	err := pcc.AddPrivateKey(pk, []byte("newPassw0rd!"))
-	if !strings.Contains(pcc.PrivateKey, "BEGIN RSA PRIVATE KEY") || err != nil {
+	if !strings.Contains(pcc.PrivateKey, "PRIVATE KEY") || err != nil {
 		t.Fatalf("collection should have PEM encoded private key")
 	}
 	if !strings.Contains(pcc.PrivateKey, "ENCRYPTED") {

--- a/pkg/certificate/certificate_test.go
+++ b/pkg/certificate/certificate_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"github.com/Venafi/vcert/v4/pkg/util"
 	"math/big"
 	"net"
 	"os"
@@ -322,11 +323,18 @@ func TestGetEncryptedPrivateKeyPEMBock(t *testing.T) {
 		t.Fatalf("GetPrivateKeyPEMBock returned nil for RSA key")
 	}
 
-	b, err := x509.DecryptPEMBlock(p, []byte("something"))
+	encoded := pem.EncodeToMemory(p)
+	str, err := util.DecryptPkcs8PrivateKey(string(encoded), "something")
 	if err != nil {
 		t.Fatalf("Error: %s", err)
 	}
-	_, err = x509.ParsePKCS1PrivateKey(b)
+
+	p, _ = pem.Decode([]byte(str))
+	if p == nil {
+		t.Fatalf("missing private key PEM")
+	}
+
+	_, err = x509.ParsePKCS8PrivateKey(p.Bytes)
 	if err != nil {
 		t.Fatalf("Error: %s", err)
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -61,9 +61,9 @@ func (t ConnectorType) String() string {
 	case ConnectorTypeFake:
 		return "Fake Endpoint"
 	case ConnectorTypeCloud:
-		return "Venafi Cloud"
+		return "Venafi as a Service"
 	case ConnectorTypeTPP:
-		return "TPP"
+		return "Trust Protection Platform"
 	default:
 		return fmt.Sprintf("unexpected connector type: %d", t)
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -102,6 +102,7 @@ type Connector interface {
 	RequestSSHCertificate(req *certificate.SshCertRequest) (response *certificate.SshCertificateObject, err error)
 	RetrieveSSHCertificate(req *certificate.SshCertRequest) (response *certificate.SshCertificateObject, err error)
 	RetrieveSshConfig(ca *certificate.SshCaTemplateRequest) (*certificate.SshConfig, error)
+	SearchCertificates(req *certificate.SearchRequest) (*certificate.CertSearchResponse, error)
 }
 
 type Filter struct {

--- a/pkg/util/pemUtil.go
+++ b/pkg/util/pemUtil.go
@@ -1,0 +1,240 @@
+//This file contains functions that were copied from x509.pem_decrypt.go
+//in order to keep supporting X509EncryptPEMBlock and x509DecryptPEMBlock
+//the use of this is not recommended, this is just to continue supporting old
+//applications.
+package util
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	//#nosec
+	"crypto/des"
+	//#nosec
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"strings"
+)
+
+type PEMCipher int
+
+const (
+	_ PEMCipher = iota
+	PEMCipherDES
+	PEMCipher3DES
+	PEMCipherAES128
+	PEMCipherAES192
+	PEMCipherAES256
+)
+
+// rfc1423Algo holds a method for enciphering a PEM block.
+type rfc1423Algo struct {
+	cipher     PEMCipher
+	name       string
+	cipherFunc func(key []byte) (cipher.Block, error)
+	keySize    int
+	blockSize  int
+}
+
+// rfc1423Algos holds a slice of the possible ways to encrypt a PEM
+// block. The ivSize numbers were taken from the OpenSSL source.
+var rfc1423Algos = []rfc1423Algo{{
+	cipher:     PEMCipherDES,
+	name:       "DES-CBC",
+	cipherFunc: des.NewCipher,
+	keySize:    8,
+	blockSize:  des.BlockSize,
+}, {
+	cipher:     PEMCipher3DES,
+	name:       "DES-EDE3-CBC",
+	cipherFunc: des.NewTripleDESCipher,
+	keySize:    24,
+	blockSize:  des.BlockSize,
+}, {
+	cipher:     PEMCipherAES128,
+	name:       "AES-128-CBC",
+	cipherFunc: aes.NewCipher,
+	keySize:    16,
+	blockSize:  aes.BlockSize,
+}, {
+	cipher:     PEMCipherAES192,
+	name:       "AES-192-CBC",
+	cipherFunc: aes.NewCipher,
+	keySize:    24,
+	blockSize:  aes.BlockSize,
+}, {
+	cipher:     PEMCipherAES256,
+	name:       "AES-256-CBC",
+	cipherFunc: aes.NewCipher,
+	keySize:    32,
+	blockSize:  aes.BlockSize,
+},
+}
+
+// IncorrectPasswordError is returned when an incorrect password is detected.
+var IncorrectPasswordError = fmt.Errorf("x509: decryption password incorrect")
+
+func cipherByName(name string) *rfc1423Algo {
+	for i := range rfc1423Algos {
+		alg := &rfc1423Algos[i]
+		if alg.name == name {
+			return alg
+		}
+	}
+	return nil
+}
+
+// DecryptPEMBlock takes a password encrypted PEM block and the password used to
+// encrypt it and returns a slice of decrypted DER encoded bytes. It inspects
+// the DEK-Info header to determine the algorithm used for decryption. If no
+// DEK-Info header is present, an error is returned. If an incorrect password
+// is detected an IncorrectPasswordError is returned. Because of deficiencies
+// in the encrypted-PEM format, it's not always possible to detect an incorrect
+// password. In these cases no error will be returned but the decrypted DER
+// bytes will be random noise.
+func X509DecryptPEMBlock(b *pem.Block, password []byte) ([]byte, error) {
+	dek, ok := b.Headers["DEK-Info"]
+	if !ok {
+		return nil, fmt.Errorf("x509: no DEK-Info header in block")
+	}
+
+	idx := strings.Index(dek, ",")
+	if idx == -1 {
+		return nil, fmt.Errorf("x509: malformed DEK-Info header")
+	}
+
+	mode, hexIV := dek[:idx], dek[idx+1:]
+	ciph := cipherByName(mode)
+	if ciph == nil {
+		return nil, fmt.Errorf("x509: unknown encryption mode")
+	}
+	iv, err := hex.DecodeString(hexIV)
+	if err != nil {
+		return nil, err
+	}
+	if len(iv) != ciph.blockSize {
+		return nil, fmt.Errorf("x509: incorrect IV size")
+	}
+
+	// Based on the OpenSSL implementation. The salt is the first 8 bytes
+	// of the initialization vector.
+	key := ciph.deriveKey(password, iv[:8])
+	block, err := ciph.cipherFunc(key)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(b.Bytes)%block.BlockSize() != 0 {
+		return nil, fmt.Errorf("x509: encrypted PEM data is not a multiple of the block size")
+	}
+
+	data := make([]byte, len(b.Bytes))
+	dec := cipher.NewCBCDecrypter(block, iv)
+	dec.CryptBlocks(data, b.Bytes)
+
+	// Blocks are padded using a scheme where the last n bytes of padding are all
+	// equal to n. It can pad from 1 to blocksize bytes inclusive. See RFC 1423.
+	// For example:
+	//	[x y z 2 2]
+	//	[x y 7 7 7 7 7 7 7]
+	// If we detect a bad padding, we assume it is an invalid password.
+	dlen := len(data)
+	if dlen == 0 || dlen%ciph.blockSize != 0 {
+		return nil, fmt.Errorf("x509: invalid padding")
+	}
+	last := int(data[dlen-1])
+	if dlen < last {
+		return nil, IncorrectPasswordError
+	}
+	if last == 0 || last > ciph.blockSize {
+		return nil, IncorrectPasswordError
+	}
+	for _, val := range data[dlen-last:] {
+		if int(val) != last {
+			return nil, IncorrectPasswordError
+		}
+	}
+	return data[:dlen-last], nil
+}
+
+// EncryptPEMBlock returns a PEM block of the specified type holding the
+// given DER-encoded data encrypted with the specified algorithm and
+// password.
+func X509EncryptPEMBlock(rand io.Reader, blockType string, data, password []byte, alg PEMCipher) (*pem.Block, error) {
+	ciph := cipherByKey(alg)
+	if ciph == nil {
+		return nil, fmt.Errorf("x509: unknown encryption mode")
+	}
+	iv := make([]byte, ciph.blockSize)
+	if _, err := io.ReadFull(rand, iv); err != nil {
+		return nil, fmt.Errorf("x509: cannot generate IV: " + err.Error())
+	}
+	// The salt is the first 8 bytes of the initialization vector,
+	// matching the key derivation in DecryptPEMBlock.
+	key := ciph.deriveKey(password, iv[:8])
+	block, err := ciph.cipherFunc(key)
+	if err != nil {
+		return nil, err
+	}
+	enc := cipher.NewCBCEncrypter(block, iv)
+	pad := ciph.blockSize - len(data)%ciph.blockSize
+	encrypted := make([]byte, len(data), len(data)+pad)
+	// We could save this copy by encrypting all the whole blocks in
+	// the data separately, but it doesn't seem worth the additional
+	// code.
+	copy(encrypted, data)
+	// See RFC 1423, Section 1.1.
+	for i := 0; i < pad; i++ {
+		encrypted = append(encrypted, byte(pad))
+	}
+	enc.CryptBlocks(encrypted, encrypted)
+
+	return &pem.Block{
+		Type: blockType,
+		Headers: map[string]string{
+			"Proc-Type": "4,ENCRYPTED",
+			"DEK-Info":  ciph.name + "," + hex.EncodeToString(iv),
+		},
+		Bytes: encrypted,
+	}, nil
+}
+
+// deriveKey uses a key derivation function to stretch the password into a key
+// with the number of bits our cipher requires. This algorithm was derived from
+// the OpenSSL source.
+func (c rfc1423Algo) deriveKey(password, salt []byte) []byte {
+	hash := md5.New()
+	out := make([]byte, c.keySize)
+	var digest []byte
+
+	for i := 0; i < len(out); i += len(digest) {
+		hash.Reset()
+		hash.Write(digest)
+		hash.Write(password)
+		hash.Write(salt)
+		digest = hash.Sum(digest[:0])
+		copy(out[i:], digest)
+	}
+	return out
+}
+
+func cipherByKey(key PEMCipher) *rfc1423Algo {
+	for i := range rfc1423Algos {
+		alg := &rfc1423Algos[i]
+		if alg.cipher == key {
+			return alg
+		}
+	}
+	return nil
+}
+
+// IsEncryptedPEMBlock returns whether the PEM block is password encrypted
+// according to RFC 1423.
+// design. Since it does not authenticate the ciphertext, it is vulnerable to
+// padding oracle attacks that can let an attacker recover the plaintext.
+func X509IsEncryptedPEMBlock(b *pem.Block) bool {
+	_, ok := b.Headers["DEK-Info"]
+	return ok
+}

--- a/pkg/util/sshKeyGenerator.go
+++ b/pkg/util/sshKeyGenerator.go
@@ -3,6 +3,7 @@ package util
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
 	"encoding/pem"
 	"fmt"
 	"github.com/youmark/pkcs8"
@@ -32,30 +33,47 @@ func generatePrivKey(bitSize int) (*rsa.PrivateKey, error) {
 	return privKey, nil
 }
 
-func encodePrivKeyToPEM(privateKey *rsa.PrivateKey, keyPassword string) ([]byte, error) {
+func encodePrivKeyToPEM(privateKey *rsa.PrivateKey, keyPassword string, format ...string) ([]byte, error) {
 
 	var err error
 	var privBlock *pem.Block
 	var privDER []byte
 	if keyPassword != "" {
-		privDER, err = pkcs8.MarshalPrivateKey(privateKey, []byte(keyPassword), nil)
-		if err != nil {
-			return nil, err
-		}
-		privBlock = &pem.Block{
-			Type:    "ENCRYPTED PRIVATE KEY",
-			Headers: nil,
-			Bytes:   privDER,
+		if format[0] == LegacyPem {
+			privDER := x509.MarshalPKCS1PrivateKey(privateKey)
+			privBlock, err = X509EncryptPEMBlock(rand.Reader, RsaPrivKeyType, privDER, []byte(keyPassword), PEMCipherDES)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			privDER, err = pkcs8.MarshalPrivateKey(privateKey, []byte(keyPassword), nil)
+			if err != nil {
+				return nil, err
+			}
+			privBlock = &pem.Block{
+				Type:    "ENCRYPTED PRIVATE KEY",
+				Headers: nil,
+				Bytes:   privDER,
+			}
 		}
 	} else {
-		privDER, err := pkcs8.MarshalPrivateKey(privateKey, nil, nil)
-		if err != nil {
-			return nil, err
-		}
-		privBlock = &pem.Block{
-			Type:    "PRIVATE KEY",
-			Headers: nil,
-			Bytes:   privDER,
+		if format[0] == LegacyPem {
+			privDER = x509.MarshalPKCS1PrivateKey(privateKey)
+			privBlock = &pem.Block{
+				Type:    RsaPrivKeyType,
+				Headers: nil,
+				Bytes:   privDER,
+			}
+		} else {
+			privDER, err := pkcs8.MarshalPrivateKey(privateKey, nil, nil)
+			if err != nil {
+				return nil, err
+			}
+			privBlock = &pem.Block{
+				Type:    "PRIVATE KEY",
+				Headers: nil,
+				Bytes:   privDER,
+			}
 		}
 	}
 
@@ -78,7 +96,12 @@ func generatePublicKey(key *rsa.PublicKey) ([]byte, error) {
 
 }
 
-func GenerateSshKeyPair(bitSize int, keyPassword, certId string) ([]byte, []byte, error) {
+func GenerateSshKeyPair(bitSize int, keyPassword, certId string, format ...string) ([]byte, []byte, error) {
+
+	currentFormat := ""
+	if len(format) > 0 && format[0] != "" {
+		currentFormat = format[0]
+	}
 
 	privateKey, err := generatePrivKey(bitSize)
 
@@ -92,7 +115,7 @@ func GenerateSshKeyPair(bitSize int, keyPassword, certId string) ([]byte, []byte
 		return nil, nil, err
 	}
 
-	privateKeyBytes, err := encodePrivKeyToPEM(privateKey, keyPassword)
+	privateKeyBytes, err := encodePrivKeyToPEM(privateKey, keyPassword, currentFormat)
 
 	if err != nil {
 		return nil, nil, err

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -3,14 +3,16 @@ package util
 import (
 	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"github.com/youmark/pkcs8"
-	"os"
 	"time"
 )
+
+const LegacyPem = "legacy-pem"
 
 func ConvertSecondsToTime(t int64) time.Time {
 	return time.Unix(0, t*int64(time.Second))
@@ -20,25 +22,6 @@ func GetJsonAsString(i interface{}) (s string) {
 	byte, _ := json.MarshalIndent(i, "", "  ")
 	s = string(byte)
 	return
-}
-
-func SaveZipFile(path string, dataByte []byte) error {
-
-	file, err := os.OpenFile(path+".zip", os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0666)
-
-	if err != nil {
-		return err
-	}
-
-	defer file.Close()
-
-	_, err = file.Write(dataByte)
-
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func DecryptPkcs8PrivateKey(privateKey, password string) (string, error) {
@@ -71,4 +54,16 @@ func DecryptPkcs8PrivateKey(privateKey, password string) (string, error) {
 	pemBytes := pem.EncodeToMemory(&pem.Block{Type: pemType, Bytes: privateKeyBytes})
 
 	return string(pemBytes), nil
+}
+
+func EncryptPkcs1PrivateKey(privateKey, password string) (string, error) {
+
+	block, _ := pem.Decode([]byte(privateKey))
+
+	encrypted, err := X509EncryptPEMBlock(rand.Reader, "RSA PRIVATE KEY", block.Bytes, []byte(password), PEMCipherAES256)
+
+	if err != nil {
+		return "", nil
+	}
+	return string(pem.EncodeToMemory(encrypted)), nil
 }

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -86,6 +86,10 @@ type Connector struct {
 	client  *http.Client
 }
 
+func (c *Connector) SearchCertificates(req *certificate.SearchRequest) (*certificate.CertSearchResponse, error) {
+	panic("implement me")
+}
+
 func (c *Connector) IsCSRServiceGenerated(req *certificate.Request) (bool, error) {
 	if c.user == nil || c.user.Company == nil {
 		return false, fmt.Errorf("must be autheticated to retieve certificate")

--- a/pkg/venafi/fake/connector.go
+++ b/pkg/venafi/fake/connector.go
@@ -39,6 +39,10 @@ type Connector struct {
 	verbose bool
 }
 
+func (c *Connector) SearchCertificates(req *certificate.SearchRequest) (*certificate.CertSearchResponse, error) {
+	panic("implement me")
+}
+
 func (c *Connector) IsCSRServiceGenerated(req *certificate.Request) (bool, error) {
 	panic("operation is not supported yet")
 }

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -999,7 +999,9 @@ func (c *Connector) RetrieveCertificate(req *certificate.Request) (certificates 
 	}
 	if req.CsrOrigin == certificate.ServiceGeneratedCSR || req.FetchPrivateKey {
 		certReq.IncludePrivateKey = true
-		certReq.Format = "Base64 (PKCS #8)"
+		if req.KeyType == certificate.KeyTypeRSA {
+			certReq.Format = "Base64 (PKCS #8)"
+		}
 		certReq.Password = req.KeyPassword
 	}
 

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -1294,6 +1294,22 @@ func (c *Connector) ImportCertificate(req *certificate.ImportRequest) (*certific
 	}
 }
 
+func (c *Connector) SearchCertificates(req *certificate.SearchRequest) (*certificate.CertSearchResponse, error) {
+
+	var err error
+
+	url := fmt.Sprintf("%s?%s", urlResourceCertificateSearch, strings.Join(*req, "&"))
+	statusCode, _, body, err := c.request("GET", urlResource(url), nil)
+	if err != nil {
+		return nil, err
+	}
+	searchResult, err := ParseCertificateSearchResponse(statusCode, body)
+	if err != nil {
+		return nil, err
+	}
+	return searchResult, nil
+}
+
 func (c *Connector) SetHTTPClient(client *http.Client) {
 	c.client = client
 }

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -999,6 +999,7 @@ func (c *Connector) RetrieveCertificate(req *certificate.Request) (certificates 
 	}
 	if req.CsrOrigin == certificate.ServiceGeneratedCSR || req.FetchPrivateKey {
 		certReq.IncludePrivateKey = true
+		certReq.Format = "Base64 (PKCS #8)"
 		certReq.Password = req.KeyPassword
 	}
 

--- a/pkg/venafi/tpp/search.go
+++ b/pkg/venafi/tpp/search.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"github.com/Venafi/vcert/v4/pkg/certificate"
 	"net/http"
 	"strings"
 )
@@ -58,15 +59,15 @@ type Certificate struct {
 	/*...and some more fields... */
 }
 
-func (c *Connector) searchCertificatesByFingerprint(fp string) (*CertificateSearchResponse, error) {
+func (c *Connector) searchCertificatesByFingerprint(fp string) (*certificate.CertSearchResponse, error) {
 	fp = strings.Replace(fp, ":", "", -1)
 	fp = strings.Replace(fp, ".", "", -1)
 	fp = strings.ToUpper(fp)
 
-	var req SearchRequest
+	var req certificate.SearchRequest
 	req = append(req, fmt.Sprintf("Thumbprint=%s", fp))
 
-	return c.searchCertificates(&req)
+	return c.SearchCertificates(&req)
 }
 
 func (c *Connector) configReadDN(req ConfigReadDNRequest) (resp ConfigReadDNResponse, err error) {
@@ -86,22 +87,6 @@ func (c *Connector) configReadDN(req ConfigReadDNRequest) (resp ConfigReadDNResp
 	}
 
 	return resp, nil
-}
-
-func (c *Connector) searchCertificates(req *SearchRequest) (*CertificateSearchResponse, error) {
-
-	var err error
-
-	url := fmt.Sprintf("%s?%s", urlResourceCertificateSearch, strings.Join(*req, "&"))
-	statusCode, _, body, err := c.request("GET", urlResource(url), nil)
-	if err != nil {
-		return nil, err
-	}
-	searchResult, err := ParseCertificateSearchResponse(statusCode, body)
-	if err != nil {
-		return nil, err
-	}
-	return searchResult, nil
 }
 
 func (c *Connector) searchCertificateDetails(guid string) (*CertificateDetailsResponse, error) {
@@ -133,10 +118,10 @@ func parseCertificateDetailsResponse(statusCode int, body []byte) (searchResult 
 	}
 }
 
-func ParseCertificateSearchResponse(httpStatusCode int, body []byte) (searchResult *CertificateSearchResponse, err error) {
+func ParseCertificateSearchResponse(httpStatusCode int, body []byte) (searchResult *certificate.CertSearchResponse, err error) {
 	switch httpStatusCode {
 	case http.StatusOK:
-		var searchResult = &CertificateSearchResponse{}
+		var searchResult = &certificate.CertSearchResponse{}
 		err = json.Unmarshal(body, searchResult)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to parse search results: %s, body: %s", err, body)


### PR DESCRIPTION


VCERT Transition from PKCS1 to PKCS8 

Now private key are generated in PKCS8 format on csr local option.
format=legacy-pem was added so user can use this for generating PKCS1 key format on csr local option.
warning, for TPP user need to select one of the following private key PBE algorithms: SHA 3DES or SHA256 AES256