### PR TITLE
added support for new cit attributes: csrUploadAllowed and KeyGeneratedByVenafiAllowed

### DIFF
--- a/pkg/policy/policyStructures.go
+++ b/pkg/policy/policyStructures.go
@@ -57,6 +57,8 @@ type CloudPolicyRequest struct {
 	KeyTypes                            []KeyTypes           `json:"keyTypes"`
 	KeyReuse                            *bool                `json:"keyReuse"`
 	RecommendedSettings                 *RecommendedSettings `json:"recommendedSettings"`
+	CsrUploadAllowed                    bool                 `json:"csrUploadAllowed"`
+	KeyGeneratedByVenafiAllowed         bool                 `json:"keyGeneratedByVenafiAllowed"`
 }
 
 type Product struct {

--- a/pkg/policy/policyUtils.go
+++ b/pkg/policy/policyUtils.go
@@ -1067,6 +1067,14 @@ func BuildCloudCitRequest(ps *PolicySpecification, ca *CADetails) (*CloudPolicyR
 		cloudPolicyRequest.RecommendedSettings = &recommendedSettings
 	}
 
+	if ps.Policy != nil && ps.Policy.KeyPair != nil && ps.Policy.KeyPair.ServiceGenerated != nil {
+		cloudPolicyRequest.CsrUploadAllowed = !*(ps.Policy.KeyPair.ServiceGenerated)
+		cloudPolicyRequest.KeyGeneratedByVenafiAllowed = *(ps.Policy.KeyPair.ServiceGenerated)
+	} else {
+		cloudPolicyRequest.CsrUploadAllowed = true
+		cloudPolicyRequest.KeyGeneratedByVenafiAllowed = true
+	}
+
 	return &cloudPolicyRequest, nil
 }
 

--- a/pkg/venafi/cloud/certificatePolicies.go
+++ b/pkg/venafi/cloud/certificatePolicies.go
@@ -60,9 +60,9 @@ type certificateTemplate struct {
 		}
 		keyReuse bool
 	}
-	ValidityPeriod string `json:"validityPeriod,omitempty"`
-	CsrUploadAllowed bool  `json:"csrUploadAllowed"`
-	KeyGeneratedByVenafiAllowed bool  `json:"keyGeneratedByVenafiAllowed"`
+	ValidityPeriod              string `json:"validityPeriod,omitempty"`
+	CsrUploadAllowed            bool   `json:"csrUploadAllowed"`
+	KeyGeneratedByVenafiAllowed bool   `json:"keyGeneratedByVenafiAllowed"`
 }
 
 type CertificateTemplates struct {

--- a/pkg/venafi/cloud/certificatePolicies.go
+++ b/pkg/venafi/cloud/certificatePolicies.go
@@ -61,6 +61,8 @@ type certificateTemplate struct {
 		keyReuse bool
 	}
 	ValidityPeriod string `json:"validityPeriod,omitempty"`
+	CsrUploadAllowed bool  `json:"csrUploadAllowed"`
+	KeyGeneratedByVenafiAllowed bool  `json:"keyGeneratedByVenafiAllowed"`
 }
 
 type CertificateTemplates struct {

--- a/pkg/venafi/cloud/cloud.go
+++ b/pkg/venafi/cloud/cloud.go
@@ -664,6 +664,17 @@ func buildPolicySpecification(cit *certificateTemplate, info *policy.Certificate
 		keyPair.RsaKeySizes = keySizes
 	}
 
+	if cit.KeyGeneratedByVenafiAllowed && cit.CsrUploadAllowed {
+		keyPair.ServiceGenerated = nil
+	} else if cit.KeyGeneratedByVenafiAllowed {
+		keyPair.ServiceGenerated = &cit.KeyGeneratedByVenafiAllowed
+		shouldCreateKeyPair = true
+	} else if cit.CsrUploadAllowed {
+		falseVal := false
+		keyPair.ServiceGenerated = &falseVal
+		shouldCreateKeyPair = true
+	}
+
 	if shouldCreateKeyPair {
 		pol.KeyPair = &keyPair
 		pol.KeyPair.ReuseAllowed = &cit.KeyReuse


### PR DESCRIPTION
Added support for new cit attributes: csrUploadAllowed and KeyGeneratedByVenafiAllowed:

When creating a new policy on VaaS using a policy specification, if policy specification's serviceGenerated attribute is true then KeyGeneratedByVenafiAllowed will be true  and  csrUploadAllowed will be false And if serviceGenerated is false then csrUploadAllowed will be true and KeyGeneratedByVenafiAllowed will be false 
if  policy specification's serviceGenerated attribute is not specified, then csrUploadAllowed and KeyGeneratedByVenafiAllowed values will be true 