### PR TITLE
Fix for subjectless CSRs not complying with RFC 5280

### DIFF
--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Venafi, Inc.
+ * Copyright 2022 Venafi, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -478,14 +478,7 @@ func (request *Request) GenerateCSR() error {
 	certificateRequest := x509.CertificateRequest{}
 	certificateRequest.Subject = request.Subject
 	if !request.OmitSANs {
-		certificateRequest.DNSNames = request.DNSNames
-		certificateRequest.EmailAddresses = request.EmailAddresses
-		certificateRequest.IPAddresses = request.IPAddresses
-		certificateRequest.URIs = request.URIs
-
-		if len(request.UPNs) > 0 {
-			addUserPrincipalNameSANs(&certificateRequest, request.UPNs)
-		}
+		addSubjectAltNames(&certificateRequest, request.DNSNames, request.EmailAddresses, request.IPAddresses, request.URIs, request.UPNs)
 	}
 	certificateRequest.Attributes = request.Attributes
 


### PR DESCRIPTION
Although it is primarily the responsibility of the issuing CA, for some use cases where the CA honors what has been requested in the CSR it is necessary to mark the SAN extension critical when there is no Subject so the issued certificate is compliant with [RFC 5280 Section 4.1.2.6](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6).  In order to accomplish this we must construct the SAN extension ourselves and add it to the crypto/x509 CertificateRequest object rather than making use of the "helper" properties that usually simplify the task of adding SANs to a certificate request.  We were already doing that when we needed to add user principal name (UPN) SANs to a certificate request since they're not supported by the crypto/x509 package.