### PR TITLE
Include the refresh_until value in the output of vcert getcred

### DIFF
--- a/aruba/features/credmgmt/credmgmt.feature
+++ b/aruba/features/credmgmt/credmgmt.feature
@@ -11,22 +11,26 @@ Feature: Managing credentials tokens from TPP
     And I remember the output
       And it should output access token
       And it should output refresh token
+      And it should output refresh_until
     Then I refresh access token
       And I remember the output
       And it should output access token
       And it should output refresh token
+      And it should output refresh_until
 
   Scenario: request refresh token in json format
     When I get credentials from TPP with -format json
       And I remember the output
       And it should output access token in JSON
       And it should output refresh token in JSON
+      And it should output refresh_until in JSON
 
   Scenario: request with PKCS12 if possible
     When I get credentials from TPP with PKSC12
     And I remember the output
       And it should output access token
       And it should output refresh token
+      And it should output refresh_until
 
   Scenario: request with PKCS12 if possible with no password
     When I interactively get credentials from TPP with PKSC12 and no password
@@ -34,12 +38,14 @@ Feature: Managing credentials tokens from TPP
     And I remember the output
       And it should output access token
       And it should output refresh token
+      And it should output refresh_until
 
   Scenario: request refresh token and refresh access token with username and no password
     When I interactively get credentials from TPP with username and no password
     And I remember the output
       And it should output access token
       And it should output refresh token
+      And it should output refresh_until
 
   Scenario: check access token
     When I get credentials from TPP

--- a/aruba/features/step_definitions/my_steps.rb
+++ b/aruba/features/step_definitions/my_steps.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 Then(/^it should show deprecated warning$/) do
   steps %{
     Given the exit status should be 0
@@ -126,7 +128,7 @@ Then(/^it should( not)? output (access|refresh) token( in JSON)?$/) do |negated,
   end
 end
 
-Then(/^it should( not)? output (application|expires|scope)( in JSON)?$/) do |negated, property, json|
+Then(/^it should( not)? output (application|expires|scope|refresh_until)( in JSON)?$/) do |negated, property, json|
 
   if @previous_command_output.nil?
     fail(ArgumentError.new('@previous_command_output is nil'))
@@ -146,6 +148,9 @@ Then(/^it should( not)? output (application|expires|scope)( in JSON)?$/) do |neg
         @expires = unescape_text(normalize_json(@previous_command_output, "expires_ISO8601")).tr('"', '')
       elsif property === "scope"
         @scope = unescape_text(normalize_json(@previous_command_output, "scope")).tr('"', '')
+      elsif property === "refresh_until"
+        @refresh_until = unescape_text(normalize_json(@previous_command_output, "refresh_until")).tr('"', '')
+        Integer(@refresh_until)
       else
         fail(ArgumentError.new("Cant determine property type for #{property}"))
       end
@@ -159,6 +164,10 @@ Then(/^it should( not)? output (application|expires|scope)( in JSON)?$/) do |neg
       elsif property === "scope"
         m = @previous_command_output.match /^scope:  (.+)$/
         @scope = m[1]
+      elsif property === "refresh_until"
+        m = @previous_command_output.match /^refresh_until:  (.+)$/
+        @refresh_until = m[1]
+        Date.parse(@refresh_until)
       else
         fail(ArgumentError.new("Cant determine property type for #{property}"))
       end

--- a/cmd/vcert/commands.go
+++ b/cmd/vcert/commands.go
@@ -651,6 +651,7 @@ func doCommandCredMgmt1(c *cli.Context) error {
 				fmt.Println("access_token: ", resp.Access_token)
 				fmt.Println("access_token_expires: ", tm)
 				fmt.Println("refresh_token: ", resp.Refresh_token)
+				fmt.Println("refresh_until: ", time.Unix(int64(resp.Refresh_until), 0).UTC().Format(time.RFC3339))
 			}
 		} else if cfg.Credentials.User != "" && cfg.Credentials.Password != "" {
 
@@ -680,6 +681,7 @@ func doCommandCredMgmt1(c *cli.Context) error {
 				fmt.Println("access_token_expires: ", tm)
 				if resp.Refresh_token != "" {
 					fmt.Println("refresh_token: ", resp.Refresh_token)
+					fmt.Println("refresh_until: ", time.Unix(int64(resp.Refresh_until), 0).UTC().Format(time.RFC3339))
 				}
 			}
 		} else if clientP12 {
@@ -700,6 +702,7 @@ func doCommandCredMgmt1(c *cli.Context) error {
 				fmt.Println("access_token_expires: ", tm)
 				if resp.Refresh_token != "" {
 					fmt.Println("refresh_token: ", resp.Refresh_token)
+					fmt.Println("refresh_until: ", time.Unix(int64(resp.Refresh_until), 0).UTC().Format(time.RFC3339))
 				}
 			}
 		} else {

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -198,6 +198,7 @@ type OauthGetRefreshTokenResponse struct {
 	Expires       int    `json:"expires,omitempty"`
 	Identity      string `json:"identity,omitempty"`
 	Refresh_token string `json:"refresh_token,omitempty"`
+	Refresh_until int    `json:"refresh_until,omitempty"`
 	Scope         string `json:"scope,omitempty"`
 	Token_type    string `json:"token_type,omitempty"`
 }
@@ -217,6 +218,7 @@ type OauthRefreshAccessTokenResponse struct {
 	Expires       int    `json:"expires,omitempty"`
 	Identity      string `json:"identity,omitempty"`
 	Refresh_token string `json:"refresh_token,omitempty"`
+	Refresh_until int    `json:"refresh_until,omitempty"`
 	Token_type    string `json:"token_type,omitempty"`
 }
 


### PR DESCRIPTION
I need to get the refresh-token expiry time when I interact with the TPP `Authorize/OAuth` and `Authorize/Token refresh` endpoints.

https://docs.venafi.com/Docs/21.4SDK/TopNav/Content/SDK/AuthSDK/r-SDKa-POST-AuthorizeOAuth.php
https://docs.venafi.com/Docs/21.4SDK/TopNav/Content/SDK/AuthSDK/r-SDKa-POST-AuthorizeToken.php

So I've added that value to the REST API response type and also modified `vcert getcred` to print the value.

Tested with a TPP 21.2 server as follows:

```console
$ make  build_quick cucumber FEATURE=./features/credmgmt/credmgmt.feature
...

8 scenarios (2 skipped, 6 passed)
61 steps (11 skipped, 50 passed)
0m10.152s
```

I have not tested this with PKCS12 client-cert nor with VaaS. 