### PR TITLE
Get policies for zone prefix

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -75,7 +75,7 @@ type Connector interface {
 	GetType() ConnectorType
 	// SetZone sets a zone (by name) for requests with this connector.
 	SetZone(z string)
-	// GetZonesByParent returns a list of valid zones for a VaaS application specified by parent
+	// GetZonesByParent returns a list of valid zones specified by parent
 	GetZonesByParent(parent string) ([]string, error)
 	Ping() (err error)
 	// Authenticate is usually called by NewClient and it is not required that you manually call it.

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -75,6 +75,8 @@ type Connector interface {
 	GetType() ConnectorType
 	// SetZone sets a zone (by name) for requests with this connector.
 	SetZone(z string)
+	// GetZonesByParent returns a list of valid zones for a VaaS application specified by parent
+	GetZonesByParent(parent string) ([]string, error)
 	Ping() (err error)
 	// Authenticate is usually called by NewClient and it is not required that you manually call it.
 	Authenticate(auth *Authentication) (err error)

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Venafi, Inc.
+ * Copyright 2018-2022 Venafi, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -1482,6 +1482,22 @@ func (c *Connector) getAppDetailsByName(appName string) (*ApplicationDetails, in
 	return details, statusCode, nil
 }
 
+// getZonesStartingWith returns a list of valid zones for a VaaS application specified by zonePrefix
+func (c *Connector) getZonesStartingWith(zonePrefix string) ([]string, error) {
+	var zones []string
+
+	appDetails, _, err := c.getAppDetailsByName(zonePrefix)
+	if err != nil {
+		return nil, err
+	}
+
+	for citAlias := range appDetails.CitAliasToIdMap {
+		zone := fmt.Sprintf("%s\\%s", zonePrefix, citAlias)
+		zones = append(zones, zone)
+	}
+	return zones, nil
+}
+
 func (c *Connector) getTemplateByID() (*certificateTemplate, error) {
 	url := c.getURL(urlResourceTemplate)
 	appNameEncoded := netUrl.PathEscape(c.zone.getApplicationName())

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -1482,8 +1482,8 @@ func (c *Connector) getAppDetailsByName(appName string) (*ApplicationDetails, in
 	return details, statusCode, nil
 }
 
-// getZonesStartingWith returns a list of valid zones for a VaaS application specified by zonePrefix
-func (c *Connector) getZonesStartingWith(zonePrefix string) ([]string, error) {
+// GetZonesStartingWith returns a list of valid zones for a VaaS application specified by zonePrefix
+func (c *Connector) GetZonesStartingWith(zonePrefix string) ([]string, error) {
 	var zones []string
 
 	appDetails, _, err := c.getAppDetailsByName(zonePrefix)

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -1482,17 +1482,17 @@ func (c *Connector) getAppDetailsByName(appName string) (*ApplicationDetails, in
 	return details, statusCode, nil
 }
 
-// GetZonesStartingWith returns a list of valid zones for a VaaS application specified by zonePrefix
-func (c *Connector) GetZonesStartingWith(zonePrefix string) ([]string, error) {
+// GetZonesByParent returns a list of valid zones for a VaaS application specified by parent
+func (c *Connector) GetZonesByParent(parent string) ([]string, error) {
 	var zones []string
 
-	appDetails, _, err := c.getAppDetailsByName(zonePrefix)
+	appDetails, _, err := c.getAppDetailsByName(parent)
 	if err != nil {
 		return nil, err
 	}
 
 	for citAlias := range appDetails.CitAliasToIdMap {
-		zone := fmt.Sprintf("%s\\%s", zonePrefix, citAlias)
+		zone := fmt.Sprintf("%s\\%s", parent, citAlias)
 		zones = append(zones, zone)
 	}
 	return zones, nil

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -1648,8 +1648,8 @@ func (c *Connector) findObjectsOfClass(req *findObjectsOfClassRequest) (*findObj
 	return &response, nil
 }
 
-// getZonesStartingWith returns a list of valid zones for a TPP parent folder specified by zonePrefix
-func (c *Connector) getZonesStartingWith(zonePrefix string) ([]string, error) {
+// GetZonesStartingWith returns a list of valid zones for a TPP parent folder specified by zonePrefix
+func (c *Connector) GetZonesStartingWith(zonePrefix string) ([]string, error) {
 	var zones []string
 
 	parentFolderDn := zonePrefix

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 Venafi, Inc.
+ * Copyright 2018-2022 Venafi, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1661,16 +1661,15 @@ func (c *Connector) getZonesStartingWith(zonePrefix string) ([]string, error) {
 		Class:    "Policy",
 		ObjectDN: parentFolderDn,
 	}
-
 	response, err := c.findObjectsOfClass(&request)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, folder := range response.PolicyObjects {
-		zones = append(zones, folder.DN)
+		// folder.DN will always start with \VED\Policy but short form is preferrable since both are supported
+		zones = append(zones, strings.Replace(folder.DN, "\\VED\\Policy\\", "", 1))
 	}
-
 	return zones, nil
 }
 

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -1648,11 +1648,11 @@ func (c *Connector) findObjectsOfClass(req *findObjectsOfClassRequest) (*findObj
 	return &response, nil
 }
 
-// GetZonesStartingWith returns a list of valid zones for a TPP parent folder specified by zonePrefix
-func (c *Connector) GetZonesStartingWith(zonePrefix string) ([]string, error) {
+// GetZonesByParent returns a list of valid zones for a TPP parent folder specified by parent
+func (c *Connector) GetZonesByParent(parent string) ([]string, error) {
 	var zones []string
 
-	parentFolderDn := zonePrefix
+	parentFolderDn := parent
 	if !strings.HasPrefix(parentFolderDn, "\\VED\\Policy") {
 		parentFolderDn = fmt.Sprintf("\\VED\\Policy\\%s", parentFolderDn)
 	}

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -297,6 +297,27 @@ type DNToGUIDResponse struct {
 type DNToGUIDRequest struct {
 	ObjectDN string `json:"ObjectDN"`
 }
+
+type policyObject struct {
+	AbsoluteGUID string `json:"AbsoluteGUID"`
+	DN           string `json:"DN"`
+	GUID         string `json:"GUID"`
+	ID           int32  `json:"Id"`
+	Name         string `json:"Name"`
+	Parent       string `json:"Parent"`
+	Revision     int64  `json:"Revision"`
+	TypeName     string `json:"TypeName"`
+}
+
+type findObjectsOfClassRequest struct {
+	Class    string `json:"Class"`
+	ObjectDN string `json:"ObjectDN"`
+}
+
+type findObjectsOfClassResponse struct {
+	PolicyObjects []policyObject `json:"Objects,omitempty"`
+}
+
 type systemStatusVersionResponse string
 
 type urlResource string
@@ -341,6 +362,7 @@ const (
 	urlResourceSshCADetails           urlResource = "vedsdk/SSHCertificates/Template/Retrieve"
 	urlResourceSshTemplateAvaliable   urlResource = "vedsdk/SSHCertificates/Template/Available"
 	urlResourceDNToGUID               urlResource = "vedsdk/Config/DnToGuid"
+	urlResourceFindObjectsOfClass     urlResource = "vedsdk/config/findobjectsofclass"
 )
 
 const (
@@ -683,6 +705,20 @@ func parseValidateIdentityResponse(httpStatusCode int, httpStatus string, body [
 func parseValidateIdentityData(b []byte) (data policy.ValidateIdentityResponse, err error) {
 	err = json.Unmarshal(b, &data)
 	return
+}
+
+func parseFindObjectsOfClassResponse(httpStatusCode int, httpStatus string, body []byte) (findObjectsOfClassResponse, error) {
+	var response findObjectsOfClassResponse
+	switch httpStatusCode {
+	case http.StatusOK, http.StatusAccepted:
+		err := json.Unmarshal(body, &response)
+		if err != nil {
+			return response, err
+		}
+		return response, nil
+	default:
+		return response, fmt.Errorf("Unexpected status from FindObjectsOfClass. Status: %s", httpStatus)
+	}
 }
 
 type _strValue struct {

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 Venafi, Inc.
+ * Copyright 2018-2022 Venafi, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Both TPP and VaaS can support situations where multiple policies have been defined for use by a single consumer.  For TPP, this is done by creating multiple child policy folders in a common parent policy folder.  For VaaS, this is done by assigning multiple Issuing Templates to a single application.  The new `GetZonesByParent` methods for TPP and VaaS allow VCert client SDK consumers to enumerate those policies (zones) rather than having to know them individually.