### PR TITLE
Fix linter err G601

### DIFF
--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -1120,7 +1120,8 @@ func (c *Connector) getIdentity(userName string) (*policy.IdentityEntry, error) 
 func (c *Connector) getIdentityMatching(identities []policy.IdentityEntry, identityName string) *policy.IdentityEntry {
 	var identityEntryMatching *policy.IdentityEntry
 
-	for _, identityEntry := range identities {
+	for i, _ := range identities {
+		identityEntry := identities[i]
 		if identityEntry.Name == identityName {
 			identityEntryMatching = &identityEntry
 			break


### PR DESCRIPTION
Linter is throwing error G601: Implicit memory aliasing in for loop.