### PR TITLE
Simplify the headless registration output

### DIFF
--- a/cmd/vcert/commands.go
+++ b/cmd/vcert/commands.go
@@ -817,14 +817,8 @@ func getVaaSCredentials(vaasConnector *cloud.Connector, cfg *vcert.Config) error
 			}
 
 			fmt.Println(headerMessage)
-			fmt.Println("key: ", apiKey.Key)
-			fmt.Println("userId: ", apiKey.UserID)
-			fmt.Println("userName: ", apiKey.Username)
-			fmt.Println("companyId: ", apiKey.CompanyID)
-			fmt.Println("apiVersion: ", apiKey.APIVersion)
-			fmt.Println("creationDate: ", apiKey.CreationDateString)
-			fmt.Println("validityStartDate: ", apiKey.ValidityStartDateString)
-			fmt.Println("validityEndDate: ", apiKey.ValidityEndDateString)
+			fmt.Println("api_key: ", apiKey.Key)
+			fmt.Println("api_key_expires: ", apiKey.ValidityEndDateString)
 		}
 	} else {
 		return fmt.Errorf("failed to determine credentials set")

--- a/cmd/vcert/validators.go
+++ b/cmd/vcert/validators.go
@@ -401,7 +401,7 @@ func validateCredMgmtFlags1(commandName string) error {
 			}
 		}
 
-		if flags.url == "" && getPropertyFromEnvironment(vCertURL) == "" {
+		if flags.email == "" && flags.url == "" && getPropertyFromEnvironment(vCertURL) == "" {
 			return fmt.Errorf("missing -u (URL) parameter")
 		}
 


### PR DESCRIPTION
The headless registration output at text format was reduced to display
only the api_key and the api_key_expires(validateEndDate).
Also, it was added the validation to request the -u flag.