### PR TITLE
Fix policy management for VaaS after Org Unit removed

### DIFF
--- a/pkg/policy/policyStructures.go
+++ b/pkg/policy/policyStructures.go
@@ -117,7 +117,6 @@ type Application struct {
 	Ports                                []string          `json:"ports"`
 	CertificateIssuingTemplateAliasIdMap map[string]string `json:"certificateIssuingTemplateAliasIdMap"`
 	StartTargetedDiscovery               bool              `json:"startTargetedDiscovery"`
-	OrganizationalUnitId                 string            `json:"organizationalUnitId"`
 }
 
 type OwnerIdType struct {

--- a/pkg/venafi/cloud/cloud.go
+++ b/pkg/venafi/cloud/cloud.go
@@ -226,7 +226,6 @@ type ApplicationDetails struct {
 	IpRanges                  []string             `json:"ipRanges,omitempty"`
 	Ports                     []string             `json:"ports,omitempty"`
 	FqDns                     []string             `json:"fqDns,omitempty"`
-	OrganizationalUnitId      string               `json:"organizationalUnitId,omitempty"`
 }
 
 //GenerateRequest generates a CertificateRequest based on the zone configuration, and returns the request along with the private key.
@@ -674,7 +673,6 @@ func createAppUpdateRequest(applicationDetails *ApplicationDetails) policy.Appli
 		IpRanges:                             applicationDetails.IpRanges,
 		Ports:                                applicationDetails.Ports,
 		CertificateIssuingTemplateAliasIdMap: applicationDetails.CitAliasToIdMap,
-		OrganizationalUnitId:                 applicationDetails.OrganizationalUnitId,
 	}
 
 	return request

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -455,6 +455,8 @@ func (c *Connector) createApplication(appName string, ps *policy.PolicySpecifica
 
 	var owners []policy.OwnerIdType
 	var error error
+	var statusCode int
+	var status string
 
 	//if users were passed to the PS, then it will needed to resolve the related Owners to set them
 	if len(ps.Users) > 0 {
@@ -480,9 +482,12 @@ func (c *Connector) createApplication(appName string, ps *policy.PolicySpecifica
 
 	url := c.getURL(urlAppRoot)
 
-	_, _, _, error = c.request("POST", url, appReq)
+	statusCode, status, _, error = c.request("POST", url, appReq)
 	if error != nil {
 		return nil, error
+	}
+	if statusCode != 201 {
+		return nil, fmt.Errorf("unexpected result %s attempting to create application %s", status, appName)
 	}
 
 	return &appReq, nil


### PR DESCRIPTION
The Org Unit construct was dropped from Venafi as a Service last week and since then the `setpolicy` action has not worked.  This update addresses that and informs the user if there was a problem creating applications (previously the output made it seem as though it was successful when it wasn't).