### PR TITLE
Auto-create VaaS apps for headless registration

### DIFF
--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -685,25 +685,29 @@ func (c *Connector) ReadPolicyConfiguration() (policy *endpoint.Policy, err erro
 // ReadZoneConfiguration reads the Zone information needed for generating and requesting a certificate from Venafi Cloud
 func (c *Connector) ReadZoneConfiguration() (config *endpoint.ZoneConfiguration, err error) {
 	var template *certificateTemplate
+	var statusCode int
 
 	// to fully support the "headless registration" use case...
 	// if application does not exist and is for the default CIT, create the application
 	citAlias := c.zone.getTemplateAlias()
-	appName := c.zone.getApplicationName()
-	_, statusCode, err := c.getAppDetailsByName(appName)
-	if err != nil && 404 == statusCode && "Default" == citAlias {
-		log.Printf("creating application %s for issuing template %s", appName, citAlias)
+	if citAlias == "Default" {
+		appName := c.zone.getApplicationName()
+		_, statusCode, err = c.getAppDetailsByName(appName)
+		if err != nil && statusCode == 404 {
+			log.Printf("creating application %s for issuing template %s", appName, citAlias)
 
-		ps := policy.PolicySpecification{}
-		template, err = getCit(c, citAlias)
-		if err != nil {
-			return
+			ps := policy.PolicySpecification{}
+			template, err = getCit(c, citAlias)
+			if err != nil {
+				return
+			}
+			_, err = c.createApplication(appName, &ps, template)
+			if err != nil {
+				return
+			}
 		}
-		_, err = c.createApplication(appName, &ps, template)
-		if err != nil {
-			return
-		}
-	} else {
+	}
+	if template == nil {
 		template, err = c.getTemplateByID()
 		if err != nil {
 			return


### PR DESCRIPTION
VCert recently added support for VaaS headless registration but that user can't immediately begin requesting test certificates after they've registered because a VaaS application is required.  They could accomplish this by logging into the VaaS UI or use the `setpolicy` action but that is an undesirable extra step and the latter assumes they have administrative access to VaaS.  To simplify things and meet the objective of headless registration, VCert will be enhanced by this PR to automatically create VaaS applications if they are for the Default issuing template.  As such a new user would only need to invoke two actions to obtain a test certificate, `getcred` and `enroll`:
```
vcert getcred --email zach.jackson@venafi.example
vcert enroll -k xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx -z "Headless\Default" --cn test.venafi.example
```