### PR TITLE
Signing Linux and Darwin binaries. Gitignores vendor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ aruba/log.log
 /exec
 credentials
 *.DS_Store
+vendor

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build: get
 	env GOOS=linux   GOARCH=amd64 go build $(GO_LDFLAGS) -o bin/linux/vcert         ./cmd/vcert
 	env GOOS=linux   GOARCH=386   go build $(GO_LDFLAGS) -o bin/linux/vcert86       ./cmd/vcert
 	env GOOS=darwin  GOARCH=amd64 go build $(GO_LDFLAGS) -o bin/darwin/vcert        ./cmd/vcert
-	env GOOS=darwin  GOARCH=arm64 go build $(GO_LDFLAGS) -o bin/darwin/vcert_arm        ./cmd/vcert
+	env GOOS=darwin  GOARCH=arm64 go build $(GO_LDFLAGS) -o bin/darwin/vcert_arm    ./cmd/vcert
 	env GOOS=windows GOARCH=amd64 go build $(GO_LDFLAGS) -o bin/windows/vcert.exe   ./cmd/vcert
 	env GOOS=windows GOARCH=386   go build $(GO_LDFLAGS) -o bin/windows/vcert86.exe ./cmd/vcert
 
@@ -80,6 +80,10 @@ collect_artifacts:
 	zip -j "artifacts/vcert_$(VERSION)_darwin_arm.zip" "bin/darwin/vcert_arm" || exit 1
 	zip -j "artifacts/vcert_$(VERSION)_windows.zip" "bin/windows/vcert.exe" || exit 1
 	zip -j "artifacts/vcert_$(VERSION)_windows86.zip" "bin/windows/vcert86.exe" || exit 1
+	cp vcert_linux.sig artifacts/
+	cp vcert_linux86.sig artifacts/
+	cp vcert_darwin.sig artifacts/
+	cp vcert_darwin_arm.sig artifacts/
 
 release:
 	echo '```' > release.txt


### PR DESCRIPTION
- Adds commands to collect Linux and Darwin signatures during artifact process
- Adds vendor folder to git-ignore file