### PR TITLE
Adding support for arm64 architecture on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ build_quick: get
 
 build: get
 	env GOOS=linux   GOARCH=amd64 go build $(GO_LDFLAGS) -o bin/linux/vcert         ./cmd/vcert
+	env GOOS=linux   GOARCH=arm64 go build $(GO_LDFLAGS) -o bin/linux/vcert_arm     ./cmd/vcert
 	env GOOS=linux   GOARCH=386   go build $(GO_LDFLAGS) -o bin/linux/vcert86       ./cmd/vcert
 	env GOOS=darwin  GOARCH=amd64 go build $(GO_LDFLAGS) -o bin/darwin/vcert        ./cmd/vcert
 	env GOOS=darwin  GOARCH=arm64 go build $(GO_LDFLAGS) -o bin/darwin/vcert_arm    ./cmd/vcert
@@ -75,12 +76,14 @@ collect_artifacts:
 	rm -rf artifacts
 	mkdir -p artifacts
 	zip -j "artifacts/vcert_$(VERSION)_linux.zip" "bin/linux/vcert" || exit 1
+	zip -j "artifacts/vcert_$(VERSION)_linux_arm.zip" "bin/linux/vcert_arm" || exit 1
 	zip -j "artifacts/vcert_$(VERSION)_linux86.zip" "bin/linux/vcert86" || exit 1
 	zip -j "artifacts/vcert_$(VERSION)_darwin.zip" "bin/darwin/vcert" || exit 1
 	zip -j "artifacts/vcert_$(VERSION)_darwin_arm.zip" "bin/darwin/vcert_arm" || exit 1
 	zip -j "artifacts/vcert_$(VERSION)_windows.zip" "bin/windows/vcert.exe" || exit 1
 	zip -j "artifacts/vcert_$(VERSION)_windows86.zip" "bin/windows/vcert86.exe" || exit 1
 	cp vcert_linux.sig artifacts/
+	cp vcert_linux_arm.sig artifacts/
 	cp vcert_linux86.sig artifacts/
 	cp vcert_darwin.sig artifacts/
 	cp vcert_darwin_arm.sig artifacts/


### PR DESCRIPTION
This commit adds support for arm64 on Linux.  I can't install on AWS Graviton instances without this.