### PR TITLE
Set attribute Reenable=true to Request Cert

### DIFF
--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -532,7 +532,6 @@ func prepareRequest(req *certificate.Request, zone string) (tppReq certificateRe
 			expirationDate.Year(), expirationDate.Month(), expirationDate.Day(), expirationDate.Hour(), expirationDate.Minute(), expirationDate.Second())
 
 		tppReq.CASpecificAttributes = append(tppReq.CASpecificAttributes, nameValuePair{Name: expirationDateAttribute, Value: formattedExpirationDate})
-
 	}
 
 	for name, value := range customFieldsMap {
@@ -576,6 +575,14 @@ func prepareRequest(req *certificate.Request, zone string) (tppReq certificateRe
 		tppReq.KeyAlgorithm = "ECC"
 		tppReq.EllipticCurve = req.KeyCurve.String()
 	}
+
+	//Setting the certificate will be re-enabled.
+	//From https://docs.venafi.com/Docs/currentSDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-request.php
+	//Reenable (Optional) The action to control a previously disabled certificate:
+	//
+	//    - false: Default. Do not renew a previously disabled certificate.
+	//    - true: Clear the Disabled attribute, reenable, and then renew the certificate (in this request). Reuse the same CertificateDN, that is also known as a Certificate object.
+	tppReq.Reenable = true
 
 	return tppReq, err
 }

--- a/pkg/venafi/tpp/search.go
+++ b/pkg/venafi/tpp/search.go
@@ -44,6 +44,7 @@ type CertificateDetailsResponse struct {
 		Value []string
 	}
 	Consumers []string
+	Disabled  bool `json:",omitempty"`
 }
 
 type CertificateSearchResponse struct {

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -85,6 +85,7 @@ type certificateRequest struct {
 	CustomFields            []customField   `json:",omitempty"`
 	Devices                 []device        `json:",omitempty"`
 	CertificateType         string          `json:",omitempty"`
+	Reenable                bool            `json:",omitempty"`
 }
 
 type certificateRetrieveRequest struct {


### PR DESCRIPTION
Fix for https://github.com/Venafi/vcert/issues/199
With this fix now the Certificates which are disabled will be
reenabled and renewed, this is the behavior expected to pass
the attribute "Reenable=true" into the request for
"POST Certificates/Request".