### PR TITLE
Fix renew pkcs12 - 1

### DIFF
--- a/aruba/features/renew/renew-with-csr-service.feature
+++ b/aruba/features/renew/renew-with-csr-service.feature
@@ -45,7 +45,19 @@ Feature: renew action with `-csr service` option
       Then it should retrieve certificate
       And it should write private key to the file "k1.pem"
       And it should write certificate to the file "c1.pem"
-      And private key in "k1.pem" with passphrase and certificate in "c1.pem" should have the same modulus
+      And private key in "k1.pem" with same passphrase and certificate in "c1.pem" should have the same modulus
+
+  Scenario: renew service-generated-CSR certificate in TPP with `-csr service` option with no passphrase using -no-prompt
+      Given I enroll random certificate using TPP with -csr service -key-file k.pem -cert-file c.pem -no-prompt
+        And it should write private key to the file "k.pem"
+        And it should write certificate to the file "c.pem"
+        And it should output Pickup ID
+      When I renew the certificate in TPP using the same Pickup ID with flags -csr service -no-prompt -no-pickup
+        And it should output Pickup ID
+      And I retrieve the certificate from TPP using the same Pickup ID with --no-prompt -cert-file c1.pem -key-file k1.pem
+        And it should write private key to the file "k1.pem"
+        And it should write certificate to the file "c1.pem"
+        And private key in "k1.pem" and certificate in "c1.pem" should have the same modulus
 
   @TODO # This scenario is not currently working due to reuse csr not being implemented yet in OutagePredict
   Scenario: renew certificate in VaaS with -csr=service which is working only if Zone's policy allows key reuse

--- a/aruba/features/renew/renew-with-csr-service.feature
+++ b/aruba/features/renew/renew-with-csr-service.feature
@@ -45,7 +45,7 @@ Feature: renew action with `-csr service` option
       Then it should retrieve certificate
       And it should write private key to the file "k1.pem"
       And it should write certificate to the file "c1.pem"
-      And private key in "k1.pem" with same passphrase and certificate in "c1.pem" should have the same modulus
+      And private key in "k1.pem" and certificate in "c1.pem" should have the same modulus
 
   Scenario: renew service-generated-CSR certificate in TPP with `-csr service` option with no passphrase using -no-prompt
       Given I enroll random certificate using TPP with -csr service -key-file k.pem -cert-file c.pem -no-prompt
@@ -73,7 +73,7 @@ Feature: renew action with `-csr service` option
       And certificate in "c.pem" and certificate in "c1.pem" should not have the same serial
 
   Scenario: renew service-generated-CSR certificate in TPP with `-csr service` option with PKCS12 flag
-    Given I enroll random certificate using TPP with -csr service -key-password Passcode123! -key-file k.pem -cert-file c.pem -key-password Passcode123!
+    Given I enroll random certificate using TPP with -csr service -key-password Passcode123! -key-file k.pem -cert-file c.pem
       And it should write private key to the file "k.pem"
       And it should write certificate to the file "c.pem"
       And it should output Pickup ID

--- a/aruba/features/renew/renew-with-csr-service.feature
+++ b/aruba/features/renew/renew-with-csr-service.feature
@@ -41,11 +41,11 @@ Feature: renew action with `-csr service` option
       And it should write private key to the file "k.pem"
       And it should write certificate to the file "c.pem"
       And it should output Pickup ID
-    When I renew the certificate in TPP using the same Pickup ID with flags -no-prompt -cert-file c1.pem -key-file k1.pem -csr service -key-password Passcode123!
+    When I renew the certificate in TPP using the same Pickup ID with flags -cert-file c1.pem -key-file k1.pem -csr service -key-password Passcode123!
       Then it should retrieve certificate
       And it should write private key to the file "k1.pem"
       And it should write certificate to the file "c1.pem"
-      And private key in "k1.pem" and certificate in "c1.pem" should have the same modulus
+      And private key in "k1.pem" with passphrase and certificate in "c1.pem" should have the same modulus
 
   @TODO # This scenario is not currently working due to reuse csr not being implemented yet in OutagePredict
   Scenario: renew certificate in VaaS with -csr=service which is working only if Zone's policy allows key reuse
@@ -59,7 +59,6 @@ Feature: renew action with `-csr service` option
       And it should write certificate to the file "c1.pem"
       And certificate in "k.pem" and certificate in "k1.pem" should have the same modulus
       And certificate in "c.pem" and certificate in "c1.pem" should not have the same serial
-
 
   Scenario: renew service-generated-CSR certificate in TPP with `-csr service` option with PKCS12 flag
     Given I enroll random certificate using TPP with -csr service -key-password Passcode123! -key-file k.pem -cert-file c.pem -key-password Passcode123!

--- a/aruba/features/renew/renew-with-csr-service.feature
+++ b/aruba/features/renew/renew-with-csr-service.feature
@@ -37,7 +37,7 @@ Feature: renew action with `-csr service` option
     Then it should fail with "Status: 400"
 
   Scenario: renew service-generated-CSR certificate in TPP with `-csr service` option
-    Given I enroll random certificate using TPP with -csr service -key-file k.pem -cert-file c.pem --key-password Passcode123!
+    Given I enroll random certificate using TPP with -csr service -key-file k.pem -cert-file c.pem -key-password Passcode123!
       And it should write private key to the file "k.pem"
       And it should write certificate to the file "c.pem"
       And it should output Pickup ID

--- a/aruba/features/step_definitions/actions.rb
+++ b/aruba/features/step_definitions/actions.rb
@@ -84,7 +84,7 @@ When(/^I renew(?: the)? certificate (?:from|in|using) (\S+) using the same (Pick
         # flags = "-cert-file c1.pem -key-file k1.pem -csr service -key-password -new pass"
         # then, keypass_split[1] will be null
         if keypass_split[1]
-            @key_password
+            @key_password = keypass_split[1]
         end
     end
   end

--- a/aruba/features/step_definitions/actions.rb
+++ b/aruba/features/step_definitions/actions.rb
@@ -69,10 +69,14 @@ When(/^I renew(?: the)? certificate (?:from|in|using) (\S+) using the same (Pick
   end
   if flags != ""
     # we try to get key-password
-    # This regex basically tries to get everything including "-key-password " (note the space in the string)
-    # And takes anything after previous string and stops until find either a whitespace character or a dash
-    # (meaning we have a next flag in the line)
-    keypass = flags[/-key-password [^[\s|-]]*/]
+    # This regex basically tries to get everything after and including "-key-password " (note the space in the string)
+    # stops until it finds either (a whitespace character and a dash) or (end of line)
+    # without including it
+    # TODO: this can be improved by adding every flag known for the action using a regex like the following:
+    # /-key-password .+?(?= \-key\-file| \-cert\-file)/gm
+    # where can be translated to:
+    # /key_in_flags .+?(?= flag1| flag2 | flag3|... flagN|$)/gm
+    keypass = flags[/-key-password .+?(?=\s-|$)/]
     # For example, the following value:
     # flags = "-cert-file c1.pem -key-file k1.pem -csr service -key-password"
     # Won't enter the following "if" statement.

--- a/aruba/features/step_definitions/actions.rb
+++ b/aruba/features/step_definitions/actions.rb
@@ -67,6 +67,27 @@ When(/^I renew(?: the)? certificate (?:from|in|using) (\S+) using the same (Pick
   if field == "Thumbprint"
     cmd = "vcert renew #{ENDPOINTS[endpoint]} -thumbprint '#{@certificate_fingerprint}' #{flags}"
   end
+  if flags != ""
+    # we try to get key-password
+    # This regex basically tries to get everything including "-key-password " (note the space in the string)
+    # And takes anything after previous string and stops until find either a whitespace character or a dash
+    # (meaning we have a next flag in the line)
+    keypass = flags[/-key-password [^[\s|-]]*/]
+    # For example, the following value:
+    # flags = "-cert-file c1.pem -key-file k1.pem -csr service -key-password"
+    # Won't enter the following "if" statement.
+    # In general, if there's no match then variable keypass will be undefined
+    if keypass
+        # if it does exist, we split it to try to get the keypassword (default delimiter is whitspace)
+        keypass_split = keypass.split
+        # If we get an empty string like the following example:
+        # flags = "-cert-file c1.pem -key-file k1.pem -csr service -key-password -new pass"
+        # then, keypass_split[1] will be null
+        if keypass_split[1]
+            @key_password
+        end
+    end
+  end
   steps %{Then I try to run `#{cmd}`}
 end
 

--- a/aruba/features/step_definitions/openssl.rb
+++ b/aruba/features/step_definitions/openssl.rb
@@ -92,8 +92,8 @@ When(/^CSR in "([^"]*)" and private key in "([^"]*)" and certificate in "([^"]*)
   }
 end
 
-When(/^private key in "([^"]*)"( with same passphrase)? and certificate in "([^"]*)" should have the same modulus$/) do |key_file, passphrase_set, cert_file|
-  if passphrase_set != ""
+When(/^private key in "([^"]*)" and certificate in "([^"]*)" should have the same modulus$/) do |key_file, cert_file|
+  if @key_password != ""
     steps %{ Then I run `openssl rsa -modulus -noout -passin pass:#{@key_password} -in #{key_file}` }
   else
     steps %{ Then I run `openssl rsa -modulus -noout -in #{key_file}` }

--- a/aruba/features/step_definitions/openssl.rb
+++ b/aruba/features/step_definitions/openssl.rb
@@ -92,15 +92,17 @@ When(/^CSR in "([^"]*)" and private key in "([^"]*)" and certificate in "([^"]*)
   }
 end
 
-When(/^private key in "([^"]*)"( with passphrase)? and certificate in "([^"]*)" should have the same modulus$/) do |key_file, passphrase_set, cert_file|
-  unless passphrase_set
-    steps %{
-      Then I run `openssl rsa -modulus -noout -passin pass:#{@key_password} -in #{key_file}`
-      And I remember the output
-      And I run `openssl x509 -modulus -noout -in #{cert_file}`
-      Then the outputs should be the same
-    }
+When(/^private key in "([^"]*)"( with same passphrase)? and certificate in "([^"]*)" should have the same modulus$/) do |key_file, passphrase_set, cert_file|
+  if passphrase_set != ""
+    steps %{ Then I run `openssl rsa -modulus -noout -passin pass:#{@key_password} -in #{key_file}` }
+  else
+    steps %{ Then I run `openssl rsa -modulus -noout -in #{key_file}` }
   end
+  steps %{
+    And I remember the output
+    And I run `openssl x509 -modulus -noout -in #{cert_file}`
+    Then the outputs should be the same
+  }
 end
 
 When(/^certificate in "([^"]*)" and certificate in "([^"]*)" should( not)? have the same (modulus|serial)$/) do |cert1_file, cert2_file, negated, field|

--- a/aruba/features/step_definitions/openssl.rb
+++ b/aruba/features/step_definitions/openssl.rb
@@ -92,13 +92,15 @@ When(/^CSR in "([^"]*)" and private key in "([^"]*)" and certificate in "([^"]*)
   }
 end
 
-When(/^private key in "([^"]*)" and certificate in "([^"]*)" should have the same modulus$/) do |key_file, cert_file|
-  steps %{
-    Then I run `openssl rsa -modulus -noout -passin pass:newPassw0rd! -in #{key_file}`
-    And I remember the output
-    And I run `openssl x509 -modulus -noout -in #{cert_file}`
-    Then the outputs should be the same
-  }
+When(/^private key in "([^"]*)"( with passphrase)? and certificate in "([^"]*)" should have the same modulus$/) do |key_file, passphrase_set, cert_file|
+  unless passphrase_set
+    steps %{
+      Then I run `openssl rsa -modulus -noout -passin pass:#{@key_password} -in #{key_file}`
+      And I remember the output
+      And I run `openssl x509 -modulus -noout -in #{cert_file}`
+      Then the outputs should be the same
+    }
+  end
 end
 
 When(/^certificate in "([^"]*)" and certificate in "([^"]*)" should( not)? have the same (modulus|serial)$/) do |cert1_file, cert2_file, negated, field|


### PR DESCRIPTION
- Adds missing logic in aruba test cases to handle passphrases dynamically for `renew` method for service generated csr test suite
- Adds corresponding `--no-prompt` use case for previous mentioned test suite