### PR TITLE
Search valid certificate

### DIFF
--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -343,11 +343,15 @@ type ImportResponse struct {
 }
 
 type Sans struct {
-	DNS, Email, IP, URI, UPN []string
+	DNS   []string
+	Email []string `json:",omitempty"`
+	IP    []string `json:",omitempty"`
+	URI   []string `json:",omitempty"`
+	UPN   []string `json:",omitempty"`
 }
 
 type CertificateInfo struct {
-	ID         string
+	ID         string `json:",omitempty"`
 	CN         string
 	SANS       Sans
 	Serial     string

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -347,9 +347,9 @@ type Sans struct {
 }
 
 type CertificateInfo struct {
-	ID   string
-	CN   string
-	SANS Sans
+	ID         string
+	CN         string
+	SANS       Sans
 	Serial     string
 	Thumbprint string
 	ValidFrom  time.Time

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -34,6 +34,8 @@ import (
 	"time"
 
 	"github.com/Venafi/vcert/v4/pkg/verror"
+	"reflect"
+	"sort"
 )
 
 // EllipticCurve represents the types of supported elliptic curves
@@ -743,4 +745,41 @@ func NewRequest(cert *x509.Certificate) *Request {
 		// vcert only works with RSA & ECDSA
 	}
 	return req
+}
+
+// find a certificate from a list of certificates whose Sans.DNS matches and is
+// the newest
+func FindNewestCertificateWithSans(certificates []*CertificateInfo, sans_ *Sans) (*CertificateInfo, error) {
+	sans := Sans{}
+
+	if sans_ != nil {
+		sans.DNS = sans_.DNS
+	}
+
+	// order provided SANS-DNS
+	sort.Strings(sans.DNS)
+
+	// create local variable to hold the newest certificate
+	var newestCertificate *CertificateInfo
+	for _, certificate := range certificates {
+		// order certificate SANS before comparison
+		if certificate.SANS.DNS != nil {
+			sort.Strings(certificate.SANS.DNS)
+		}
+		// exact match SANs
+		if reflect.DeepEqual(sans.DNS, certificate.SANS.DNS) {
+			// update the certificate to the newest match
+			if newestCertificate == nil || certificate.ValidTo.Unix() > newestCertificate.ValidTo.Unix() {
+				newestCertificate = certificate
+			}
+		}
+	}
+
+	// a valid certificate has been found, return it
+	if newestCertificate != nil {
+		return newestCertificate, nil
+	}
+
+	// fail, since no valid certificate was found at this point
+	return nil, verror.NoCertificateFoundError
 }

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -342,12 +342,14 @@ type ImportResponse struct {
 	PrivateKeyVaultId  int    `json:",omitempty"`
 }
 
+type Sans struct {
+	DNS, Email, IP, URI, UPN []string
+}
+
 type CertificateInfo struct {
 	ID   string
 	CN   string
-	SANS struct {
-		DNS, Email, IP, URI, UPN []string
-	}
+	SANS Sans
 	Serial     string
 	Thumbprint string
 	ValidFrom  time.Time

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -106,8 +106,17 @@ type Connector interface {
 	RetrieveSSHCertificate(req *certificate.SshCertRequest) (response *certificate.SshCertificateObject, err error)
 	RetrieveSshConfig(ca *certificate.SshCaTemplateRequest) (*certificate.SshConfig, error)
 	SearchCertificates(req *certificate.SearchRequest) (*certificate.CertSearchResponse, error)
-	// Returns 1 valid (or nil) certificate
-	SearchCertificate(zone string, cn string, sans *certificate.Sans, valid_for time.Duration) (*certificate.CertificateInfo, error)
+	// Returns a valid certificate
+	//
+	// If it returns no error, the certificate returned should be the latest [1]
+	// exact matching zone [2], CN and sans.DNS [3] provided, with a minimum
+	// validity of `certMinTimeLeft`
+	//
+	// [1] the one with longest validity; field named ValidTo for TPP and
+	// validityEnd for VaaS
+	// [2] application name for VaaS
+	// [3] an array of strings representing the DNS names
+	SearchCertificate(zone string, cn string, sans *certificate.Sans, certMinTimeLeft time.Duration) (*certificate.CertificateInfo, error)
 	RetrieveAvailableSSHTemplates() ([]certificate.SshAvaliableTemplate, error)
 	RetrieveCertificateMetaData(dn string) (*certificate.CertificateMetaData, error)
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"net/http"
 	"regexp"
+	"time"
 
 	"github.com/Venafi/vcert/v4/pkg/policy"
 
@@ -106,7 +107,7 @@ type Connector interface {
 	RetrieveSshConfig(ca *certificate.SshCaTemplateRequest) (*certificate.SshConfig, error)
 	SearchCertificates(req *certificate.SearchRequest) (*certificate.CertSearchResponse, error)
 	// Returns 1 valid (or nil) certificate
-	SearchCertificate(zone string, cn string, sans *certificate.Sans, valid_for int) (*certificate.CertificateInfo, error)
+	SearchCertificate(zone string, cn string, sans *certificate.Sans, valid_for time.Duration) (*certificate.CertificateInfo, error)
 	RetrieveAvailableSSHTemplates() ([]certificate.SshAvaliableTemplate, error)
 	RetrieveCertificateMetaData(dn string) (*certificate.CertificateMetaData, error)
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -105,6 +105,8 @@ type Connector interface {
 	RetrieveSSHCertificate(req *certificate.SshCertRequest) (response *certificate.SshCertificateObject, err error)
 	RetrieveSshConfig(ca *certificate.SshCaTemplateRequest) (*certificate.SshConfig, error)
 	SearchCertificates(req *certificate.SearchRequest) (*certificate.CertSearchResponse, error)
+	// Returns 1 valid (or nil) certificate
+	SearchCertificate(zone string, cn string, sans *certificate.Sans, valid_for int) (*certificate.CertificateInfo, error)
 	RetrieveAvailableSSHTemplates() ([]certificate.SshAvaliableTemplate, error)
 	RetrieveCertificateMetaData(dn string) (*certificate.CertificateMetaData, error)
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -104,3 +104,13 @@ func GetPrivateKeyType(pk, pass string) string {
 
 	return keyType
 }
+
+// TODO: test this function
+func ArrayContainsString(s []string, e string) bool {
+    for _, a := range s {
+        if a == e {
+            return true
+        }
+    }
+    return false
+}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -107,10 +107,10 @@ func GetPrivateKeyType(pk, pass string) string {
 
 // TODO: test this function
 func ArrayContainsString(s []string, e string) bool {
-    for _, a := range s {
-        if a == e {
-            return true
-        }
-    }
-    return false
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -18,7 +18,6 @@ package cloud
 
 import (
 	"archive/zip"
-	"reflect"
 	"bytes"
 	"crypto/rand"
 	"crypto/x509"
@@ -30,6 +29,7 @@ import (
 	"log"
 	"net/http"
 	netUrl "net/url"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -112,19 +112,19 @@ func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.
 			Operator: AND,
 			Operands: []Operand{
 				{
-					Field: "subjectCN",
+					Field:    "subjectCN",
 					Operator: EQ,
-					Value: cn,
+					Value:    cn,
 				},
 				{
-					Field: "subjectAlternativeNameDns",
+					Field:    "subjectAlternativeNameDns",
 					Operator: IN,
-					Values: sans.DNS,
+					Values:   sans.DNS,
 				},
 				{
-					Field: "validityPeriodDays",
+					Field:    "validityPeriodDays",
 					Operator: GTE,
-					Value: valid_for,
+					Value:    valid_for,
 				},
 			},
 		},
@@ -153,11 +153,11 @@ func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.
 			certificates[n].ID = cert.Id
 			certificates[n].CN = strings.Join(cert.SubjectCN, ",")
 			certificates[n].SANS = certificate.Sans{
-				DNS: cert.SubjectAlternativeNamesByType["dNSName"],
+				DNS:   cert.SubjectAlternativeNamesByType["dNSName"],
 				Email: cert.SubjectAlternativeNamesByType["x400Address"],
-				IP: cert.SubjectAlternativeNamesByType["iPAddress"],
-				URI: cert.SubjectAlternativeNamesByType["uniformResourceIdentifier"],
-				UPN: cert.SubjectAlternativeNamesByType["x400Address"],
+				IP:    cert.SubjectAlternativeNamesByType["iPAddress"],
+				URI:   cert.SubjectAlternativeNamesByType["uniformResourceIdentifier"],
+				UPN:   cert.SubjectAlternativeNamesByType["x400Address"],
 			}
 			certificates[n].Serial = cert.SerialNumber
 			certificates[n].Thumbprint = cert.Fingerprint
@@ -1386,9 +1386,9 @@ func (c *Connector) searchCertificatesByFingerprint(fp string) (*CertificateSear
 		Expression: &Expression{
 			Operands: []Operand{
 				{
-					Field: "fingerprint",
+					Field:    "fingerprint",
 					Operator: MATCH,
-					Value: fp,
+					Value:    fp,
 				},
 			},
 		},
@@ -1568,9 +1568,9 @@ func (c *Connector) getCertsBatch(page, pageSize int, withExpired bool) ([]certi
 		Expression: &Expression{
 			Operands: []Operand{
 				{
-					Field: "appstackIds",
+					Field:    "appstackIds",
 					Operator: MATCH,
-					Value: appDetails.ApplicationId,
+					Value:    appDetails.ApplicationId,
 				},
 			},
 			Operator: AND,
@@ -1579,9 +1579,9 @@ func (c *Connector) getCertsBatch(page, pageSize int, withExpired bool) ([]certi
 	}
 	if !withExpired {
 		req.Expression.Operands = append(req.Expression.Operands, Operand{
-			Field: "validityEnd",
+			Field:    "validityEnd",
 			Operator: GTE,
-			Value: time.Now().Format(time.RFC3339),
+			Value:    time.Now().Format(time.RFC3339),
 		})
 	}
 	r, err := c.searchCertificates(req)

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -30,7 +30,6 @@ import (
 	"math"
 	"net/http"
 	netUrl "net/url"
-	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -178,26 +177,8 @@ func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.
 	}
 
 	// at this point all certificates belong to our zone, the next step is
-	// finding the newest valid certificate
-	var newestCertificate *certificate.CertificateInfo
-	for _, certificate := range certificates {
-		// log.Printf("looping %v\n", util.GetJsonAsString(certificate))
-		// exact match SANs
-		if reflect.DeepEqual(sans.DNS, certificate.SANS.DNS) {
-			// update the certificate to the newest match
-			if newestCertificate == nil || certificate.ValidTo.Unix() > newestCertificate.ValidTo.Unix() {
-				newestCertificate = certificate
-			}
-		}
-	}
-
-	// a valid certificate has been found, return it
-	if newestCertificate != nil {
-		return newestCertificate, nil
-	}
-
-	// fail, since no valid certificate was found at this point
-	return nil, verror.NoCertificateFoundError
+	// finding the newest valid certificate matching the provided sans
+	return certificate.FindNewestCertificateWithSans(certificates, sans)
 }
 
 func (c *Connector) IsCSRServiceGenerated(req *certificate.Request) (bool, error) {

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -100,7 +100,7 @@ func (c *Connector) SearchCertificates(req *certificate.SearchRequest) (*certifi
 }
 
 func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.Sans, certMinTimeLeft time.Duration) (certificateInfo *certificate.CertificateInfo, err error) {
-	appName := GetAppNameFromZone(zone)
+	appName := getAppNameFromZone(zone)
 	// get application id
 	app, _, err := c.getAppDetailsByName(appName)
 	if err != nil {

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -98,6 +98,10 @@ func (c *Connector) SearchCertificates(req *certificate.SearchRequest) (*certifi
 	panic("operation is not supported yet")
 }
 
+func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.Sans, valid_for int) (certificateInfo *certificate.CertificateInfo, err error) {
+	panic("operation is not supported yet")
+}
+
 func (c *Connector) IsCSRServiceGenerated(req *certificate.Request) (bool, error) {
 	if c.user == nil || c.user.Company == nil {
 		return false, fmt.Errorf("must be autheticated to retieve certificate")

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -1293,9 +1293,9 @@ func (c *Connector) searchCertificatesByFingerprint(fp string) (*CertificateSear
 		Expression: &Expression{
 			Operands: []Operand{
 				{
-					"fingerprint",
-					MATCH,
-					fp,
+					Field: "fingerprint",
+					Operator: MATCH,
+					Value: fp,
 				},
 			},
 		},
@@ -1474,7 +1474,11 @@ func (c *Connector) getCertsBatch(page, pageSize int, withExpired bool) ([]certi
 	req := &SearchRequest{
 		Expression: &Expression{
 			Operands: []Operand{
-				{"appstackIds", MATCH, appDetails.ApplicationId},
+				{
+					Field: "appstackIds",
+					Operator: MATCH,
+					Value: appDetails.ApplicationId,
+				},
 			},
 			Operator: AND,
 		},
@@ -1482,9 +1486,9 @@ func (c *Connector) getCertsBatch(page, pageSize int, withExpired bool) ([]certi
 	}
 	if !withExpired {
 		req.Expression.Operands = append(req.Expression.Operands, Operand{
-			"validityEnd",
-			GTE,
-			time.Now().Format(time.RFC3339),
+			Field: "validityEnd",
+			Operator: GTE,
+			Value: time.Now().Format(time.RFC3339),
 		})
 	}
 	r, err := c.searchCertificates(req)

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -101,8 +101,9 @@ func (c *Connector) SearchCertificates(req *certificate.SearchRequest) (*certifi
 }
 
 func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.Sans, valid_for time.Duration) (certificateInfo *certificate.CertificateInfo, err error) {
+	appName := GetAppNameFromZone(zone)
 	// get application id
-	app, _, err := c.getAppDetailsByName(zone)
+	app, _, err := c.getAppDetailsByName(appName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -18,7 +18,6 @@ package cloud
 
 import (
 	"archive/zip"
-	"math"
 	"bytes"
 	"crypto/rand"
 	"crypto/x509"
@@ -28,6 +27,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math"
 	"net/http"
 	netUrl "net/url"
 	"reflect"

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -100,7 +100,7 @@ func (c *Connector) SearchCertificates(req *certificate.SearchRequest) (*certifi
 	panic("operation is not supported yet")
 }
 
-func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.Sans, valid_for time.Duration) (certificateInfo *certificate.CertificateInfo, err error) {
+func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.Sans, certMinTimeLeft time.Duration) (certificateInfo *certificate.CertificateInfo, err error) {
 	appName := GetAppNameFromZone(zone)
 	// get application id
 	app, _, err := c.getAppDetailsByName(appName)
@@ -109,7 +109,7 @@ func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.
 	}
 
 	// convert a time.Duration to days
-	valid_for_days := math.Floor(valid_for.Hours() / 24)
+	certMinTimeDays := math.Floor(certMinTimeLeft.Hours() / 24)
 
 	// format arguments for request
 	req := &SearchRequest{
@@ -129,7 +129,7 @@ func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.
 				{
 					Field:    "validityPeriodDays",
 					Operator: GTE,
-					Value:    valid_for_days,
+					Value:    certMinTimeDays,
 				},
 			},
 		},

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -18,6 +18,7 @@ package cloud
 
 import (
 	"archive/zip"
+	"math"
 	"bytes"
 	"crypto/rand"
 	"crypto/x509"
@@ -99,12 +100,15 @@ func (c *Connector) SearchCertificates(req *certificate.SearchRequest) (*certifi
 	panic("operation is not supported yet")
 }
 
-func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.Sans, valid_for int) (certificateInfo *certificate.CertificateInfo, err error) {
+func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.Sans, valid_for time.Duration) (certificateInfo *certificate.CertificateInfo, err error) {
 	// get application id
 	app, _, err := c.getAppDetailsByName(zone)
 	if err != nil {
 		return nil, err
 	}
+
+	// convert a time.Duration to days
+	valid_for_days := math.Floor(valid_for.Hours() / 24)
 
 	// format arguments for request
 	req := &SearchRequest{
@@ -124,7 +128,7 @@ func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.
 				{
 					Field:    "validityPeriodDays",
 					Operator: GTE,
-					Value:    valid_for,
+					Value:    valid_for_days,
 				},
 			},
 		},

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -153,20 +153,8 @@ func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.
 		// log.Printf("looping %v\n", util.GetJsonAsString(cert))
 		// TODO: filter based on applicationId (VaaS equivalent to TPP Zone)
 		if util.ArrayContainsString(cert.ApplicationIds, app.ApplicationId) {
-			certificates = append(certificates, &certificate.CertificateInfo{})
-			certificates[n].ID = cert.Id
-			certificates[n].CN = strings.Join(cert.SubjectCN, ",")
-			certificates[n].SANS = certificate.Sans{
-				DNS:   cert.SubjectAlternativeNamesByType["dNSName"],
-				Email: cert.SubjectAlternativeNamesByType["x400Address"],
-				IP:    cert.SubjectAlternativeNamesByType["iPAddress"],
-				URI:   cert.SubjectAlternativeNamesByType["uniformResourceIdentifier"],
-				UPN:   cert.SubjectAlternativeNamesByType["x400Address"],
-			}
-			certificates[n].Serial = cert.SerialNumber
-			certificates[n].Thumbprint = cert.Fingerprint
-			certificates[n].ValidFrom = cert.ValidityStart
-			certificates[n].ValidTo = cert.ValidityEnd
+			match := cert.ToCertificateInfo()
+			certificates = append(certificates, &match)
 			n = n + 1
 		}
 	}

--- a/pkg/venafi/cloud/connector_test.go
+++ b/pkg/venafi/cloud/connector_test.go
@@ -1876,9 +1876,9 @@ func TestSearchValidCertificate(t *testing.T) {
 
 	// TODO: Filter zone
 	// with this zone you should be able to find those certificates
-	zone := "Open Source Integrations"
+	zone := "Open Source Integrations\\Unrestricted"
 	// but not with this (or any non valid zone)
-	// zone := "Invalid zone"
+	// zone := "Invalid zone\\The CIT"
 
 	// use time.Duration instead of integer
 	day := 24 * time.Hour

--- a/pkg/venafi/cloud/connector_test.go
+++ b/pkg/venafi/cloud/connector_test.go
@@ -1876,7 +1876,7 @@ func TestSearchValidCertificate(t *testing.T) {
 
 	// TODO: Filter zone
 	// with this zone you should be able to find those certificates
-	zone := "Open Source Integrations\\Unrestricted"
+	zone := "Open Source Integrations"
 	// but not with this (or any non valid zone)
 	// zone := "Invalid zone"
 

--- a/pkg/venafi/cloud/connector_test.go
+++ b/pkg/venafi/cloud/connector_test.go
@@ -37,6 +37,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Venafi/vcert/v4/pkg/util"
 	"github.com/Venafi/vcert/v4/pkg/certificate"
 	"github.com/Venafi/vcert/v4/pkg/endpoint"
 	"github.com/Venafi/vcert/v4/pkg/verror"
@@ -785,6 +786,7 @@ func TestSearchCertificate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	req := certificate.Request{}
 	req.Subject.CommonName = test.RandCN()
 	req.Timeout = time.Second * 10
@@ -1856,4 +1858,36 @@ func getBasicRequest() certificate.Request {
 	req.DNSNames = []string{req.Subject.CommonName}
 
 	return req
+}
+
+// TODO: Expand unit tests to cover more cases
+func TestSearchValidCertificate(t *testing.T) {
+	conn := getTestConnector(ctx.CloudZone)
+	err := conn.Authenticate(&endpoint.Authentication{APIKey: ctx.CloudAPIkey})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cn := "one.example.com"
+	// There are 2 certificates here
+	sans := &certificate.Sans{DNS: []string{cn, "two.example.com"}}
+	// and 2 more, certificates here
+	// sans := &certificate.Sans{DNS: []string{cn, "two.example.com", "three.example.com"}}
+
+	// TODO: Filter zone
+	// with this zone you should be able to find those certificates
+	zone := "Open Source Integrations\\Unrestricted"
+	// but not with this (or any non valid zone)
+	// zone := "Invalid zone"
+
+	certificate, err := conn.SearchCertificate(zone, cn, sans, 3)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	if certificate == nil {
+		t.Fatal("Should have found a certificate")
+	}
+
+	fmt.Printf("%v\n", util.GetJsonAsString(*certificate))
 }

--- a/pkg/venafi/cloud/connector_test.go
+++ b/pkg/venafi/cloud/connector_test.go
@@ -1880,7 +1880,11 @@ func TestSearchValidCertificate(t *testing.T) {
 	// but not with this (or any non valid zone)
 	// zone := "Invalid zone"
 
-	certificate, err := conn.SearchCertificate(zone, cn, sans, 3)
+	// use time.Duration instead of integer
+	day := 24 * time.Hour
+	valid_for := 3 * day
+
+	certificate, err := conn.SearchCertificate(zone, cn, sans, valid_for)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/pkg/venafi/cloud/connector_test.go
+++ b/pkg/venafi/cloud/connector_test.go
@@ -1882,9 +1882,9 @@ func TestSearchValidCertificate(t *testing.T) {
 
 	// use time.Duration instead of integer
 	day := 24 * time.Hour
-	valid_for := 3 * day
+	certMinTimeLeft := 3 * day
 
-	certificate, err := conn.SearchCertificate(zone, cn, sans, valid_for)
+	certificate, err := conn.SearchCertificate(zone, cn, sans, certMinTimeLeft)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/pkg/venafi/cloud/connector_test.go
+++ b/pkg/venafi/cloud/connector_test.go
@@ -37,9 +37,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Venafi/vcert/v4/pkg/util"
 	"github.com/Venafi/vcert/v4/pkg/certificate"
 	"github.com/Venafi/vcert/v4/pkg/endpoint"
+	"github.com/Venafi/vcert/v4/pkg/util"
 	"github.com/Venafi/vcert/v4/pkg/verror"
 	"github.com/Venafi/vcert/v4/test"
 )

--- a/pkg/venafi/cloud/search.go
+++ b/pkg/venafi/cloud/search.go
@@ -126,3 +126,8 @@ func ParseCertificateSearchResponse(httpStatusCode int, body []byte) (searchResu
 		return nil, fmt.Errorf("unexpected status code on Venafi Cloud certificate search. Status: %d", httpStatusCode)
 	}
 }
+
+func GetAppNameFromZone(zone string) string {
+	lastSlash := strings.LastIndex(zone, "\\")
+	return zone[:lastSlash]
+}

--- a/pkg/venafi/cloud/search.go
+++ b/pkg/venafi/cloud/search.go
@@ -129,5 +129,12 @@ func ParseCertificateSearchResponse(httpStatusCode int, body []byte) (searchResu
 
 func GetAppNameFromZone(zone string) string {
 	lastSlash := strings.LastIndex(zone, "\\")
+
+	// there is no backslash in zone, meaning it's just the application name,
+	// return it
+	if lastSlash == -1 {
+		return zone
+	}
+
 	return zone[:lastSlash]
 }

--- a/pkg/venafi/cloud/search.go
+++ b/pkg/venafi/cloud/search.go
@@ -80,6 +80,7 @@ type Certificate struct {
 	Fingerprint                   string              `json:"fingerprint"`
 	ValidityStart                 time.Time           `json:"validityStart"`
 	ValidityEnd                   time.Time           `json:"validityEnd"`
+	ApplicationIds                []string            `json:"applicationIds"`
 	/* ... and many more fields ... */
 }
 

--- a/pkg/venafi/cloud/search.go
+++ b/pkg/venafi/cloud/search.go
@@ -127,7 +127,18 @@ func ParseCertificateSearchResponse(httpStatusCode int, body []byte) (searchResu
 	}
 }
 
-func GetAppNameFromZone(zone string) string {
+// returns everything up to the last slash (if any)
+//
+// example:
+// Just The App Name
+// -> Just The App Name
+//
+// The application\\With Cit
+// -> The application
+//
+// The complex application\\name\\and the cit
+// -> The complex application\\name
+func getAppNameFromZone(zone string) string {
 	lastSlash := strings.LastIndex(zone, "\\")
 
 	// there is no backslash in zone, meaning it's just the application name,

--- a/pkg/venafi/cloud/search.go
+++ b/pkg/venafi/cloud/search.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"github.com/Venafi/vcert/v4/pkg/certificate"
 	"net/http"
-	"time"
 	"strings"
+	"time"
 )
 
 type SearchRequest struct {
@@ -92,7 +92,7 @@ func (c Certificate) ToCertificateInfo() certificate.CertificateInfo {
 			// TODO: find correct field names
 			DNS: c.SubjectAlternativeNamesByType["dNSName"],
 			// Email: cert.SubjectAlternativeNamesByType["x400Address"],
-			IP: c.SubjectAlternativeNamesByType["iPAddress"],
+			IP:  c.SubjectAlternativeNamesByType["iPAddress"],
 			URI: c.SubjectAlternativeNamesByType["uniformResourceIdentifier"],
 			// UPN: cert.SubjectAlternativeNamesByType["x400Address"],
 		},

--- a/pkg/venafi/cloud/search_test.go
+++ b/pkg/venafi/cloud/search_test.go
@@ -28,9 +28,9 @@ func TestSearchRequest(t *testing.T) {
 		Expression: &Expression{
 			Operands: []Operand{
 				{
-					Field: "fingerprint",
+					Field:    "fingerprint",
 					Operator: MATCH,
-					Value: "A7BDECDA0B67D5CEF28D6C8C7D7CFA882E3DC9D6",
+					Value:    "A7BDECDA0B67D5CEF28D6C8C7D7CFA882E3DC9D6",
 				},
 			},
 		},
@@ -67,9 +67,9 @@ func TestSearchRequest(t *testing.T) {
 		Expression: &Expression{
 			Operands: []Operand{
 				{
-					Field: "fingerprint",
+					Field:    "fingerprint",
 					Operator: MATCH,
-					Value: "A7BDECDA0B67D5CEF28D6C8C7D7CFA882E3DC9D6",
+					Value:    "A7BDECDA0B67D5CEF28D6C8C7D7CFA882E3DC9D6",
 				},
 			},
 		},

--- a/pkg/venafi/cloud/search_test.go
+++ b/pkg/venafi/cloud/search_test.go
@@ -28,9 +28,9 @@ func TestSearchRequest(t *testing.T) {
 		Expression: &Expression{
 			Operands: []Operand{
 				{
-					"fingerprint",
-					MATCH,
-					"A7BDECDA0B67D5CEF28D6C8C7D7CFA882E3DC9D6",
+					Field: "fingerprint",
+					Operator: MATCH,
+					Value: "A7BDECDA0B67D5CEF28D6C8C7D7CFA882E3DC9D6",
 				},
 			},
 		},
@@ -67,9 +67,9 @@ func TestSearchRequest(t *testing.T) {
 		Expression: &Expression{
 			Operands: []Operand{
 				{
-					"fingerprint",
-					MATCH,
-					"A7BDECDA0B67D5CEF28D6C8C7D7CFA882E3DC9D6",
+					Field: "fingerprint",
+					Operator: MATCH,
+					Value: "A7BDECDA0B67D5CEF28D6C8C7D7CFA882E3DC9D6",
 				},
 			},
 		},

--- a/pkg/venafi/cloud/search_test.go
+++ b/pkg/venafi/cloud/search_test.go
@@ -93,10 +93,109 @@ func TestParseCertificateSearchResponse(t *testing.T) {
 
 	code = 200
 	body = []byte(`
-		{"count":1,"certificates":[
-			{"id":"ab239880-5de9-11e8-bb9b-8d6e819a14f1","companyId":"b5ed6d60-22c4-11e7-ac27-035f0608fd2c","managedCertificateId":"ab239881-5de9-11e8-bb9b-8d6e819a14f1","fingerprint":"73CF2CC98C7DEC4045EDB93151750F5B9609FF44","issuerCertificateIds":["828a2b70-22ce-11e7-ba19-0da4a5ff6335","82734810-22ce-11e7-ba19-0da4a5ff6335"],"certificateRequestId":"8ceb8ad0-5de9-11e8-9c7a-e596bbf80f56","certificateSource":"USER_PROVIDED","certificateStatuses":["NONE"],"certificateType":"END_ENTITY","ownerUsername":"alexander.tarasenko@venafi.com","creationDate":"2018-05-22T17:58:01.480+0000","modificationDate":"2018-05-22T17:58:01.480+0000","totalInstanceCount":0,"validityStart":"2018-05-22T00:00:00.000+0000","validityEnd":"2018-08-20T12:00:00.000+0000","validityPeriodDays":90,"validityPeriodRange":"GT_30_DAYS_LTE_2_YEARS","selfSigned":false,"signatureAlgorithm":"SHA256_WITH_RSA_ENCRYPTION","signatureHashAlgorithm":"SHA256","encryptionType":"RSA","keyStrength":2048,"publicKeyHash":"0048AA1D7E2F0017F9CA2E687D8776A1A340553D","subjectKeyIdentifierHash":"C6E7C18CADE684CB420CA4764A6469086536D08E","authorityKeyIdentifierHash":"AC90A22B9320CE93369173BC3074121005D7F909","serialNumber":"07F3FE39F4E1A4B6075633ECFB748D84","subjectCN":["renew-test.venafi.example.com"],"subjectOU":["SerialNumber"],"subjectST":"California","subjectL":"Palo Alto","subjectC":"US","subjectAlternativeNamesByType":{"otherName":[],"rfc822Name":[],"dNSName":["renew-test.venafi.example.com"],"x400Address":[],"directoryName":[],"ediPartyName":[],"uniformResourceIdentifier":[],"iPAddress":[],"registeredID":[]},"subjectAlternativeNameDns":["renew-test.venafi.example.com"],"issuerCN":["DigiCert Test SHA2 Intermediate CA-1"],"issuerC":"US","keyUsage":["digitalSignature","keyEncipherment"],"ocspNoCheck":false,"compliance":{"score":0.8728395061728398},"instances":[{"id":"ab28c8a0-5de9-11e8-bb9b-8d6e819a14f1","certificateId":"ab239880-5de9-11e8-bb9b-8d6e819a14f1","managedCertificateId":"ab239881-5de9-11e8-bb9b-8d6e819a14f1","companyId":"b5ed6d60-22c4-11e7-ac27-035f0608fd2c","zoneId":"b5f69520-22c4-11e7-ac27-035f0608fd2c","fingerprint":"73CF2CC98C7DEC4045EDB93151750F5B9609FF44","certificateSource":"USER_PROVIDED","certificateStatuses":["NONE"],"ownerUsername":"alexander.tarasenko@venafi.com","creationDate":"2018-05-22T17:58:01.514+0000","modificationDate":"2018-05-22T17:58:01.514+0000","ipAddress":"254.254.254.254","ipAddressAsLong":4278124286,"hostname":" ","port":-1,"sslProtocolsSecurityStatus":"UNKNOWN","cipherSuitesSecurityStatus":"UNKNOWN","compliance":{"score":0.0}}]}
-		]}
-	`)
+{
+  "count": 1,
+  "certificates": [
+    {
+      "id": "ab239880-5de9-11e8-bb9b-8d6e819a14f1",
+      "companyId": "b5ed6d60-22c4-11e7-ac27-035f0608fd2c",
+      "managedCertificateId": "ab239881-5de9-11e8-bb9b-8d6e819a14f1",
+      "fingerprint": "73CF2CC98C7DEC4045EDB93151750F5B9609FF44",
+      "issuerCertificateIds": [
+        "828a2b70-22ce-11e7-ba19-0da4a5ff6335",
+        "82734810-22ce-11e7-ba19-0da4a5ff6335"
+      ],
+      "certificateRequestId": "8ceb8ad0-5de9-11e8-9c7a-e596bbf80f56",
+      "certificateSource": "USER_PROVIDED",
+      "certificateStatuses": [
+        "NONE"
+      ],
+      "certificateType": "END_ENTITY",
+      "ownerUsername": "alexander.tarasenko@venafi.com",
+      "creationDate": "2018-05-22T17:58:01.480+00:00",
+      "modificationDate": "2018-05-22T17:58:01.480+00:00",
+      "totalInstanceCount": 0,
+      "validityStart": "2018-05-22T00:00:00.000+00:00",
+      "validityEnd": "2018-08-20T12:00:00.000+00:00",
+      "validityPeriodDays": 90,
+      "validityPeriodRange": "GT_30_DAYS_LTE_2_YEARS",
+      "selfSigned": false,
+      "signatureAlgorithm": "SHA256_WITH_RSA_ENCRYPTION",
+      "signatureHashAlgorithm": "SHA256",
+      "encryptionType": "RSA",
+      "keyStrength": 2048,
+      "publicKeyHash": "0048AA1D7E2F0017F9CA2E687D8776A1A340553D",
+      "subjectKeyIdentifierHash": "C6E7C18CADE684CB420CA4764A6469086536D08E",
+      "authorityKeyIdentifierHash": "AC90A22B9320CE93369173BC3074121005D7F909",
+      "serialNumber": "07F3FE39F4E1A4B6075633ECFB748D84",
+      "subjectCN": [
+        "renew-test.venafi.example.com"
+      ],
+      "subjectOU": [
+        "SerialNumber"
+      ],
+      "subjectST": "California",
+      "subjectL": "Palo Alto",
+      "subjectC": "US",
+      "subjectAlternativeNamesByType": {
+        "otherName": [],
+        "rfc822Name": [],
+        "dNSName": [
+          "renew-test.venafi.example.com"
+        ],
+        "x400Address": [],
+        "directoryName": [],
+        "ediPartyName": [],
+        "uniformResourceIdentifier": [],
+        "iPAddress": [],
+        "registeredID": []
+      },
+      "subjectAlternativeNameDns": [
+        "renew-test.venafi.example.com"
+      ],
+      "issuerCN": [
+        "DigiCert Test SHA2 Intermediate CA-1"
+      ],
+      "issuerC": "US",
+      "keyUsage": [
+        "digitalSignature",
+        "keyEncipherment"
+      ],
+      "ocspNoCheck": false,
+      "compliance": {
+        "score": 0.8728395061728398
+      },
+      "instances": [
+        {
+	  	"id": "ab28c8a0-5de9-11e8-bb9b-8d6e819a14f1",
+	  	"certificateId": "ab239880-5de9-11e8-bb9b-8d6e819a14f1",
+	  	"managedCertificateId": "ab239881-5de9-11e8-bb9b-8d6e819a14f1",
+	  	"companyId": "b5ed6d60-22c4-11e7-ac27-035f0608fd2c",
+	  	"zoneId": "b5f69520-22c4-11e7-ac27-035f0608fd2c",
+	  	"fingerprint": "73CF2CC98C7DEC4045EDB93151750F5B9609FF44",
+	  	"certificateSource": "USER_PROVIDED",
+	  	"certificateStatuses": [
+	  		"NONE"
+	  	],
+	  	"ownerUsername": "alexander.tarasenko@venafi.com",
+	  	"creationDate": "2018-05-22T17:58:01.514+00:00",
+	  	"modificationDate": "2018-05-22T17:58:01.514+00:00",
+	  	"ipAddress": "254.254.254.254",
+	  	"ipAddressAsLong": 4278124286,
+	  	"hostname": " ",
+	  	"port": -1,
+	  	"sslProtocolsSecurityStatus": "UNKNOWN",
+	  	"cipherSuitesSecurityStatus": "UNKNOWN",
+	  	"compliance": {
+	  		"score": 0.0
+	  	}
+        }
+      ],
+      "applicationIds": []
+    }
+  ]
+}
+`)
 
 	searchResult, err = ParseCertificateSearchResponse(code, body)
 	if err != nil {
@@ -121,7 +220,7 @@ func TestParseCertificateSearchResponse(t *testing.T) {
 
 	code = 400
 	body = []byte(`
-		{	
+		{
 		  "errors": [
 		    {
 		      "code": 1004,

--- a/pkg/venafi/cloud/search_test.go
+++ b/pkg/venafi/cloud/search_test.go
@@ -146,13 +146,12 @@ func TestParseCertificateSearchResponse(t *testing.T) {
 	}
 }
 
-
 func TestGetAppNameFromZone(t *testing.T) {
-	testCases := []struct{
+	testCases := []struct {
 		name     string
 		input    string
 		expected string
-	} {
+	}{
 		{
 			name:     "Empty",
 			input:    "",

--- a/pkg/venafi/cloud/search_test.go
+++ b/pkg/venafi/cloud/search_test.go
@@ -275,7 +275,7 @@ func TestGetAppNameFromZone(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			appName := GetAppNameFromZone(testCase.input)
+			appName := getAppNameFromZone(testCase.input)
 			if testCase.expected != appName {
 				t.Errorf("unmatched application name\nExpected:\n%v\nGot:\n%v", testCase.expected, appName)
 			}

--- a/pkg/venafi/cloud/search_test.go
+++ b/pkg/venafi/cloud/search_test.go
@@ -145,3 +145,42 @@ func TestParseCertificateSearchResponse(t *testing.T) {
 		t.Fatal("JSON body should trigger error")
 	}
 }
+
+
+func TestGetAppNameFromZone(t *testing.T) {
+	testCases := []struct{
+		name     string
+		input    string
+		expected string
+	} {
+		{
+			name:     "Empty",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "App",
+			input:    "Just The App Name",
+			expected: "Just The App Name",
+		},
+		{
+			name:     "App+Cit",
+			input:    "The application\\With Cit",
+			expected: "The application",
+		},
+		{
+			name:     "App+Cit Complex",
+			input:    "The complex application\\name\\and the cit",
+			expected: "The complex application\\name",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			appName := GetAppNameFromZone(testCase.input)
+			if testCase.expected != appName {
+				t.Errorf("unmatched application name\nExpected:\n%v\nGot:\n%v", testCase.expected, appName)
+			}
+		})
+	}
+}

--- a/pkg/venafi/fake/connector.go
+++ b/pkg/venafi/fake/connector.go
@@ -47,6 +47,10 @@ func (c *Connector) SearchCertificates(req *certificate.SearchRequest) (*certifi
 	panic("operation is not supported yet")
 }
 
+func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.Sans, valid_for int) (certificateInfo *certificate.CertificateInfo, err error) {
+	panic("operation is not supported yet")
+}
+
 func (c *Connector) IsCSRServiceGenerated(req *certificate.Request) (bool, error) {
 	panic("operation is not supported yet")
 }

--- a/pkg/venafi/fake/connector.go
+++ b/pkg/venafi/fake/connector.go
@@ -47,7 +47,7 @@ func (c *Connector) SearchCertificates(req *certificate.SearchRequest) (*certifi
 	panic("operation is not supported yet")
 }
 
-func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.Sans, valid_for time.Duration) (certificateInfo *certificate.CertificateInfo, err error) {
+func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.Sans, certMinTimeLeft time.Duration) (certificateInfo *certificate.CertificateInfo, err error) {
 	panic("operation is not supported yet")
 }
 

--- a/pkg/venafi/fake/connector.go
+++ b/pkg/venafi/fake/connector.go
@@ -47,7 +47,7 @@ func (c *Connector) SearchCertificates(req *certificate.SearchRequest) (*certifi
 	panic("operation is not supported yet")
 }
 
-func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.Sans, valid_for int) (certificateInfo *certificate.CertificateInfo, err error) {
+func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.Sans, valid_for time.Duration) (certificateInfo *certificate.CertificateInfo, err error) {
 	panic("operation is not supported yet")
 }
 

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -1489,9 +1489,9 @@ func (c *Connector) SearchCertificates(req *certificate.SearchRequest) (*certifi
 	return searchResult, nil
 }
 
-func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.Sans, valid_for time.Duration) (certificateInfo *certificate.CertificateInfo, err error) {
+func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.Sans, certMinTimeLeft time.Duration) (certificateInfo *certificate.CertificateInfo, err error) {
 	// format arguments for request
-	req := FormatSearchCertificateArguments(cn, sans, valid_for)
+	req := FormatSearchCertificateArguments(cn, sans, certMinTimeLeft)
 
 	// perform request
 	url := fmt.Sprintf("%s?%s", urlResourceCertificateSearch, req)

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -1513,10 +1513,11 @@ func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.
 	// certificates whose Zone matches ours
 	certificates := make([]*certificate.CertificateInfo, 0)
 	n := 0
+	policyDn := getPolicyDN(zone)
 	for _, cert := range searchResult.Certificates {
-		if cert.ParentDn == getPolicyDN(zone) {
-			certificates = append(certificates, &certificate.CertificateInfo{})
-			certificates[n] = &cert.X509
+		if cert.ParentDn == policyDn {
+			match := cert.X509
+			certificates = append(certificates, &match)
 			certificates[n].ID = cert.Guid
 			n = n + 1
 		}

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -1490,7 +1490,7 @@ func (c *Connector) SearchCertificates(req *certificate.SearchRequest) (*certifi
 
 func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.Sans, certMinTimeLeft time.Duration) (certificateInfo *certificate.CertificateInfo, err error) {
 	// format arguments for request
-	req := FormatSearchCertificateArguments(cn, sans, certMinTimeLeft)
+	req := formatSearchCertificateArguments(cn, sans, certMinTimeLeft)
 
 	// perform request
 	url := fmt.Sprintf("%s?%s", urlResourceCertificateSearch, req)
@@ -1498,7 +1498,7 @@ func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.
 	if err != nil {
 		return nil, err
 	}
-	searchResult, err := ParseSearchCertificateResponse(statusCode, body)
+	searchResult, err := parseSearchCertificateResponse(statusCode, body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -28,7 +28,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"errors"
 	"reflect"
 
 	"github.com/Venafi/vcert/v4/pkg/policy"
@@ -1517,7 +1516,7 @@ func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.
 
 	// fail if no certificate is returned from api
 	if searchResult.Count == 0 {
-		return nil, errors.New("No certificate with matching criteria found in api response")
+		return nil, verror.NoCertificateFoundError
 	}
 
 	// map (convert) response to an array of CertificateInfo, only add those
@@ -1535,7 +1534,7 @@ func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.
 
 	// fail if no certificates found with matching zone
 	if n == 0 {
-		return nil, errors.New("No certificate with matching zone found")
+		return nil, verror.NoCertificateWithMatchingZoneFoundError
 	}
 
 	// at this point all certificates belong to our zone, the next step is
@@ -1557,7 +1556,7 @@ func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.
 	}
 
 	// fail, since no valid certificate was found at this point
-	return nil, errors.New("No certificate with matching criteria found")
+	return nil, verror.NoCertificateFoundError
 }
 
 func (c *Connector) SetHTTPClient(client *http.Client) {

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -1491,20 +1491,10 @@ func (c *Connector) SearchCertificates(req *certificate.SearchRequest) (*certifi
 
 func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.Sans, valid_for time.Duration) (certificateInfo *certificate.CertificateInfo, err error) {
 	// format arguments for request
-	//
-	// this might be better replaced by a FormatSearchCertificateArguments
-	// function with respective unit tests for correctness
-	//
-	// get future (or past) date for certificate validation
-	date := time.Now().Add(valid_for)
-	// create request arguments
-	req := make([]string, 0)
-	req = append(req, fmt.Sprintf("CN=%s", cn))
-	req = append(req, fmt.Sprintf("SAN-DNS=%s", strings.Join(sans.DNS, ",")))
-	req = append(req, fmt.Sprintf("&ValidToGreater=%s", neturl.QueryEscape(date.Format(time.RFC3339))))
+	req := FormatSearchCertificateArguments(cn, sans, valid_for)
 
 	// perform request
-	url := fmt.Sprintf("%s?%s", urlResourceCertificateSearch, strings.Join(req, "&"))
+	url := fmt.Sprintf("%s?%s", urlResourceCertificateSearch, req)
 	statusCode, _, body, err := c.request("GET", urlResource(url), nil)
 	if err != nil {
 		return nil, err

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -1489,6 +1489,10 @@ func (c *Connector) SearchCertificates(req *certificate.SearchRequest) (*certifi
 	return searchResult, nil
 }
 
+func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.Sans, valid_for int) (certificateInfo *certificate.CertificateInfo, err error) {
+	panic("operation is not supported yet")
+}
+
 func (c *Connector) SetHTTPClient(client *http.Client) {
 	c.client = client
 }

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -1489,14 +1489,14 @@ func (c *Connector) SearchCertificates(req *certificate.SearchRequest) (*certifi
 	return searchResult, nil
 }
 
-func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.Sans, valid_for int) (certificateInfo *certificate.CertificateInfo, err error) {
+func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.Sans, valid_for time.Duration) (certificateInfo *certificate.CertificateInfo, err error) {
 	// format arguments for request
 	//
 	// this might be better replaced by a FormatSearchCertificateArguments
 	// function with respective unit tests for correctness
 	//
 	// get future (or past) date for certificate validation
-	date := time.Now().Add(time.Duration(valid_for) * 24 * time.Hour)
+	date := time.Now().Add(valid_for)
 	// create request arguments
 	req := make([]string, 0)
 	req = append(req, fmt.Sprintf("CN=%s", cn))

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -24,7 +24,6 @@ import (
 	"log"
 	"net/http"
 	neturl "net/url"
-	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -1529,25 +1528,8 @@ func (c *Connector) SearchCertificate(zone string, cn string, sans *certificate.
 	}
 
 	// at this point all certificates belong to our zone, the next step is
-	// finding the newest valid certificate
-	var newestCertificate *certificate.CertificateInfo
-	for _, certificate := range certificates {
-		// exact match SANs
-		if reflect.DeepEqual(sans.DNS, certificate.SANS.DNS) {
-			// update the certificate to the newest match
-			if newestCertificate == nil || certificate.ValidTo.Unix() > newestCertificate.ValidTo.Unix() {
-				newestCertificate = certificate
-			}
-		}
-	}
-
-	// a valid certificate has been found, return it
-	if newestCertificate != nil {
-		return newestCertificate, nil
-	}
-
-	// fail, since no valid certificate was found at this point
-	return nil, verror.NoCertificateFoundError
+	// finding the newest valid certificate matching the provided sans
+	return certificate.FindNewestCertificateWithSans(certificates, sans)
 }
 
 func (c *Connector) SetHTTPClient(client *http.Client) {

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -24,11 +24,11 @@ import (
 	"log"
 	"net/http"
 	neturl "net/url"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
-	"reflect"
 
 	"github.com/Venafi/vcert/v4/pkg/policy"
 	"github.com/Venafi/vcert/v4/pkg/util"

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -2383,9 +2383,9 @@ func TestSearchValidCertificate(t *testing.T) {
 
 	// use time.Duration instead of integer
 	day := 24 * time.Hour
-	valid_for := 3 * day
+	certMinTimeLeft := 3 * day
 
-	certificate, err := tpp.SearchCertificate(zone, cn, sans, valid_for)
+	certificate, err := tpp.SearchCertificate(zone, cn, sans, certMinTimeLeft)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -2376,7 +2376,10 @@ func TestSearchCertificate(t *testing.T) {
 
 	cn := "one.vfidev.com"
 	sans := &certificate.Sans{DNS: []string{cn, "two.vfidev.com"}}
-	zone := ""
+	// should find certificate with 2030 expiration date
+	zone := "Open Source\\vcert\\Search Certificate"
+	// should not find any certificate
+	// zone := "Open Source\\vcert\\Search Certificate\\Subpolicy"
 	certificate, err := tpp.SearchCertificate(zone, cn, sans, 0)
 	if err != nil {
 		t.Fatalf("%v", err)

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -2361,7 +2361,7 @@ func TestGetCertificateMetaData(t *testing.T) {
 }
 
 // TODO: Expand unit tests to cover more cases
-func TestSearchCertificate(t *testing.T) {
+func TestSearchValidCertificate(t *testing.T) {
 	tpp, err := getTestConnector(ctx.TPPurl, ctx.TPPZone)
 	if err != nil {
 		t.Fatalf("err is not nil, err: %s url: %s", err, expectedURL)

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -2380,7 +2380,12 @@ func TestSearchValidCertificate(t *testing.T) {
 	zone := "Open Source\\vcert\\Search Certificate"
 	// should not find any certificate
 	// zone := "Open Source\\vcert\\Search Certificate\\Subpolicy"
-	certificate, err := tpp.SearchCertificate(zone, cn, sans, 0)
+
+	// use time.Duration instead of integer
+	day := 24 * time.Hour
+	valid_for := 3 * day
+
+	certificate, err := tpp.SearchCertificate(zone, cn, sans, valid_for)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -2359,3 +2359,32 @@ func TestGetCertificateMetaData(t *testing.T) {
 		t.Fatal("meta data is nil")
 	}
 }
+
+// TODO: Expand unit tests to cover more cases
+func TestSearchCertificate(t *testing.T) {
+	tpp, err := getTestConnector(ctx.TPPurl, ctx.TPPZone)
+	if err != nil {
+		t.Fatalf("err is not nil, err: %s url: %s", err, expectedURL)
+	}
+
+	if tpp.apiKey == "" {
+		err = tpp.Authenticate(&endpoint.Authentication{AccessToken: ctx.TPPaccessToken})
+		if err != nil {
+			t.Fatalf("err is not nil, err: %s", err)
+		}
+	}
+
+	cn := "one.vfidev.com"
+	sans := &certificate.Sans{DNS: []string{cn, "two.vfidev.com"}}
+	zone := ""
+	certificate, err := tpp.SearchCertificate(zone, cn, sans, 0)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	if certificate == nil {
+		t.Fatal("Should have found a certificate")
+	}
+
+	fmt.Printf("%v\n", util.GetJsonAsString(*certificate))
+}

--- a/pkg/venafi/tpp/search.go
+++ b/pkg/venafi/tpp/search.go
@@ -126,17 +126,17 @@ func ParseCertificateSearchResponse(httpStatusCode int, body []byte) (searchResu
 
 type CertificateSearchResponse struct {
 	Certificates []CertificateSearchInfo `json:"Certificates"`
-	Count        int             `json:"TotalCount"`
+	Count        int                     `json:"TotalCount"`
 }
 
 type CertificateSearchInfo struct {
-	CreatedOn string
-	DN string
-	Guid string
-	Name string
-	ParentDn string
+	CreatedOn   string
+	DN          string
+	Guid        string
+	Name        string
+	ParentDn    string
 	SchemaClass string
-	X509 certificate.CertificateInfo
+	X509        certificate.CertificateInfo
 }
 
 func ParseSearchCertificateResponse(httpStatusCode int, body []byte) (certificates *CertificateSearchResponse, err error) {

--- a/pkg/venafi/tpp/search.go
+++ b/pkg/venafi/tpp/search.go
@@ -17,6 +17,7 @@
 package tpp
 
 import (
+	"errors"
 	"crypto/sha1"
 	"encoding/json"
 	"encoding/pem"
@@ -45,19 +46,6 @@ type CertificateDetailsResponse struct {
 	}
 	Consumers []string
 	Disabled  bool `json:",omitempty"`
-}
-
-type CertificateSearchResponse struct {
-	Certificates []Certificate `json:"Certificates"`
-	Count        int           `json:"TotalCount"`
-}
-
-type Certificate struct {
-	//Id                   string   `json:"DN"`
-	//ManagedCertificateId string   `json:"DN"`
-	CertificateRequestId   string `json:"DN"`
-	CertificateRequestGuid string `json:"Guid"`
-	/*...and some more fields... */
 }
 
 func (c *Connector) searchCertificatesByFingerprint(fp string) (*certificate.CertSearchResponse, error) {
@@ -128,6 +116,52 @@ func ParseCertificateSearchResponse(httpStatusCode int, body []byte) (searchResu
 			return nil, fmt.Errorf("Failed to parse search results: %s, body: %s", err, body)
 		}
 		return searchResult, nil
+	default:
+		if body != nil {
+			return nil, NewResponseError(body)
+		} else {
+			return nil, fmt.Errorf("Unexpected status code on certificate search. Status: %d", httpStatusCode)
+		}
+	}
+}
+
+type CertificateSearchResponse struct {
+	Certificates []CertificateSearchInfo `json:"Certificates"`
+	Count        int             `json:"TotalCount"`
+}
+
+type CertificateSearchInfo struct {
+	CreatedOn string
+	DN string
+	Guid string
+	Name string
+	ParentDn string
+	SchemaClass string
+	X509 certificate.CertificateInfo
+}
+
+func ParseSearchCertificateResponse(httpStatusCode int, body []byte) (certificates []*certificate.CertificateInfo, err error) {
+	switch httpStatusCode {
+	case http.StatusOK:
+		var searchResult = &CertificateSearchResponse{}
+		err = json.Unmarshal(body, searchResult)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse search results: %s, body: %s", err, body)
+		}
+
+		// fmt.Printf("found %v certificate(s)\n", searchResult.Count)
+		if searchResult.Count == 0 {
+			return nil, errors.New("No certificate with matching criteria found in api response")
+		}
+
+		// map (convert) response to an array of CertificateInfo
+		certificates := make([]*certificate.CertificateInfo, searchResult.Count)
+		for n, cert := range searchResult.Certificates {
+			certificates[n] = &cert.X509
+			certificates[n].ID = cert.Guid
+		}
+
+		return certificates, nil
 	default:
 		if body != nil {
 			return nil, NewResponseError(body)

--- a/pkg/venafi/tpp/search.go
+++ b/pkg/venafi/tpp/search.go
@@ -17,7 +17,6 @@
 package tpp
 
 import (
-	"errors"
 	"crypto/sha1"
 	"encoding/json"
 	"encoding/pem"
@@ -140,7 +139,7 @@ type CertificateSearchInfo struct {
 	X509 certificate.CertificateInfo
 }
 
-func ParseSearchCertificateResponse(httpStatusCode int, body []byte) (certificates []*certificate.CertificateInfo, err error) {
+func ParseSearchCertificateResponse(httpStatusCode int, body []byte) (certificates *CertificateSearchResponse, err error) {
 	switch httpStatusCode {
 	case http.StatusOK:
 		var searchResult = &CertificateSearchResponse{}
@@ -148,20 +147,7 @@ func ParseSearchCertificateResponse(httpStatusCode int, body []byte) (certificat
 		if err != nil {
 			return nil, fmt.Errorf("Failed to parse search results: %s, body: %s", err, body)
 		}
-
-		// fmt.Printf("found %v certificate(s)\n", searchResult.Count)
-		if searchResult.Count == 0 {
-			return nil, errors.New("No certificate with matching criteria found in api response")
-		}
-
-		// map (convert) response to an array of CertificateInfo
-		certificates := make([]*certificate.CertificateInfo, searchResult.Count)
-		for n, cert := range searchResult.Certificates {
-			certificates[n] = &cert.X509
-			certificates[n].ID = cert.Guid
-		}
-
-		return certificates, nil
+		return searchResult, nil
 	default:
 		if body != nil {
 			return nil, NewResponseError(body)

--- a/pkg/venafi/tpp/search.go
+++ b/pkg/venafi/tpp/search.go
@@ -141,7 +141,7 @@ type CertificateSearchInfo struct {
 	X509        certificate.CertificateInfo
 }
 
-func ParseSearchCertificateResponse(httpStatusCode int, body []byte) (certificates *CertificateSearchResponse, err error) {
+func parseSearchCertificateResponse(httpStatusCode int, body []byte) (certificates *CertificateSearchResponse, err error) {
 	switch httpStatusCode {
 	case http.StatusOK:
 		var searchResult = &CertificateSearchResponse{}
@@ -159,9 +159,9 @@ func ParseSearchCertificateResponse(httpStatusCode int, body []byte) (certificat
 	}
 }
 
-func FormatSearchCertificateArguments(cn string, sans *certificate.Sans, valid_for time.Duration) string {
+func formatSearchCertificateArguments(cn string, sans *certificate.Sans, certMinTimeLeft time.Duration) string {
 	// get future (or past) date for certificate validation
-	date := time.Now().Add(valid_for)
+	date := time.Now().Add(certMinTimeLeft)
 	// create request arguments
 	req := make([]string, 0)
 

--- a/pkg/venafi/tpp/search.go
+++ b/pkg/venafi/tpp/search.go
@@ -23,9 +23,9 @@ import (
 	"fmt"
 	"github.com/Venafi/vcert/v4/pkg/certificate"
 	"net/http"
+	neturl "net/url"
 	"strings"
 	"time"
-	neturl "net/url"
 )
 
 type SearchRequest []string

--- a/pkg/venafi/tpp/search_test.go
+++ b/pkg/venafi/tpp/search_test.go
@@ -24,10 +24,10 @@ import (
 	"github.com/Venafi/vcert/v4/pkg/endpoint"
 	"github.com/Venafi/vcert/v4/test"
 	"net/url"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
-	"regexp"
 )
 
 func TestParseCertificateSearchResponse(t *testing.T) {
@@ -375,20 +375,20 @@ func TestSearchDevice(t *testing.T) {
 }
 
 type FormatSearchCertificateArgumentsMock struct {
-	zone string
-	cn string
-	sans *certificate.Sans
+	zone      string
+	cn        string
+	sans      *certificate.Sans
 	valid_for time.Duration
 }
 
 // TODO: find a way to test the correct time
 func TestFormatSearchCertificateArguments(t *testing.T) {
 	timeRegex := "((?:(\\d{4}-\\d{2}-\\d{2})T(\\d{2}%3A\\d{2}%3A\\d{2}(?:\\.\\d+)?))(Z|[\\+-]\\d{2}%3A\\d{2})?)$"
-	testCases := []struct{
+	testCases := []struct {
 		name     string
 		input    FormatSearchCertificateArgumentsMock
 		expected string
-	} {
+	}{
 		{
 			// test empty arguments, should return just the ValidToGreater
 			// argument
@@ -399,8 +399,8 @@ func TestFormatSearchCertificateArguments(t *testing.T) {
 		{
 			// test with just CN, should return Common Name and ValidToGreater
 			// arguments
-			name:     "CN",
-			input:    FormatSearchCertificateArgumentsMock{
+			name: "CN",
+			input: FormatSearchCertificateArgumentsMock{
 				cn: "test.example.com",
 			},
 			expected: "^CN=test\\.example\\.com&ValidToGreater=" + timeRegex,
@@ -408,38 +408,38 @@ func TestFormatSearchCertificateArguments(t *testing.T) {
 		{
 			// test with just 1 DNS, should return SAN-DNS and ValidToGreater
 			// arguments
-			name:     "SANS_1",
-			input:    FormatSearchCertificateArgumentsMock{
-				sans: &certificate.Sans{DNS:[]string{"one.example.com"}},
+			name: "SANS_1",
+			input: FormatSearchCertificateArgumentsMock{
+				sans: &certificate.Sans{DNS: []string{"one.example.com"}},
 			},
 			expected: "^SAN-DNS=one\\.example\\.com&ValidToGreater=" + timeRegex,
 		},
 		{
 			// test with 2 DNS, should return both SAN-DNS and ValidToGreater
 			// arguments
-			name:     "SANS_2",
-			input:    FormatSearchCertificateArgumentsMock{
-				sans: &certificate.Sans{DNS:[]string{"one.example.com", "two.example.com"}},
+			name: "SANS_2",
+			input: FormatSearchCertificateArgumentsMock{
+				sans: &certificate.Sans{DNS: []string{"one.example.com", "two.example.com"}},
 			},
 			expected: "^SAN-DNS=one\\.example\\.com,two\\.example\\.com&ValidToGreater=" + timeRegex,
 		},
 		{
 			// test with CN and 1 DNS, should return the Common Name, DNS and
 			// ValidToGreater arguments
-			name:     "CN SANS_1",
-			input:    FormatSearchCertificateArgumentsMock{
-				cn: "test.example.com",
-				sans: &certificate.Sans{DNS:[]string{"one.example.com"}},
+			name: "CN SANS_1",
+			input: FormatSearchCertificateArgumentsMock{
+				cn:   "test.example.com",
+				sans: &certificate.Sans{DNS: []string{"one.example.com"}},
 			},
 			expected: "^CN=test\\.example\\.com&SAN-DNS=one\\.example\\.com&ValidToGreater=" + timeRegex,
 		},
 		{
 			// test with CN and 2 DNS, should return the Common Name, 2 DNS and
 			// ValidToGreater arguments
-			name:     "CN SANS_2",
-			input:    FormatSearchCertificateArgumentsMock{
-				cn: "test.example.com",
-				sans: &certificate.Sans{DNS:[]string{"one.example.com", "two.example.com"}},
+			name: "CN SANS_2",
+			input: FormatSearchCertificateArgumentsMock{
+				cn:   "test.example.com",
+				sans: &certificate.Sans{DNS: []string{"one.example.com", "two.example.com"}},
 			},
 			expected: "^CN=test\\.example\\.com&SAN-DNS=one\\.example\\.com,two\\.example\\.com&ValidToGreater=" + timeRegex,
 		},

--- a/pkg/venafi/tpp/search_test.go
+++ b/pkg/venafi/tpp/search_test.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"regexp"
 )
 
 func TestParseCertificateSearchResponse(t *testing.T) {
@@ -371,4 +372,90 @@ func TestSearchDevice(t *testing.T) {
 		t.Fatal(err)
 	}
 	fmt.Println(resp)
+}
+
+type FormatSearchCertificateArgumentsMock struct {
+	zone string
+	cn string
+	sans *certificate.Sans
+	valid_for time.Duration
+}
+
+// TODO: find a way to test the correct time
+func TestFormatSearchCertificateArguments(t *testing.T) {
+	timeRegex := "((?:(\\d{4}-\\d{2}-\\d{2})T(\\d{2}%3A\\d{2}%3A\\d{2}(?:\\.\\d+)?))(Z|[\\+-]\\d{2}%3A\\d{2})?)$"
+	testCases := []struct{
+		name     string
+		input    FormatSearchCertificateArgumentsMock
+		expected string
+	} {
+		{
+			// test empty arguments, should return just the ValidToGreater
+			// argument
+			name:     "Empty",
+			input:    FormatSearchCertificateArgumentsMock{},
+			expected: "^ValidToGreater=" + timeRegex,
+		},
+		{
+			// test with just CN, should return Common Name and ValidToGreater
+			// arguments
+			name:     "CN",
+			input:    FormatSearchCertificateArgumentsMock{
+				cn: "test.example.com",
+			},
+			expected: "^CN=test\\.example\\.com&ValidToGreater=" + timeRegex,
+		},
+		{
+			// test with just 1 DNS, should return SAN-DNS and ValidToGreater
+			// arguments
+			name:     "SANS_1",
+			input:    FormatSearchCertificateArgumentsMock{
+				sans: &certificate.Sans{DNS:[]string{"one.example.com"}},
+			},
+			expected: "^SAN-DNS=one\\.example\\.com&ValidToGreater=" + timeRegex,
+		},
+		{
+			// test with 2 DNS, should return both SAN-DNS and ValidToGreater
+			// arguments
+			name:     "SANS_2",
+			input:    FormatSearchCertificateArgumentsMock{
+				sans: &certificate.Sans{DNS:[]string{"one.example.com", "two.example.com"}},
+			},
+			expected: "^SAN-DNS=one\\.example\\.com,two\\.example\\.com&ValidToGreater=" + timeRegex,
+		},
+		{
+			// test with CN and 1 DNS, should return the Common Name, DNS and
+			// ValidToGreater arguments
+			name:     "CN SANS_1",
+			input:    FormatSearchCertificateArgumentsMock{
+				cn: "test.example.com",
+				sans: &certificate.Sans{DNS:[]string{"one.example.com"}},
+			},
+			expected: "^CN=test\\.example\\.com&SAN-DNS=one\\.example\\.com&ValidToGreater=" + timeRegex,
+		},
+		{
+			// test with CN and 2 DNS, should return the Common Name, 2 DNS and
+			// ValidToGreater arguments
+			name:     "CN SANS_2",
+			input:    FormatSearchCertificateArgumentsMock{
+				cn: "test.example.com",
+				sans: &certificate.Sans{DNS:[]string{"one.example.com", "two.example.com"}},
+			},
+			expected: "^CN=test\\.example\\.com&SAN-DNS=one\\.example\\.com,two\\.example\\.com&ValidToGreater=" + timeRegex,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			req := FormatSearchCertificateArguments(testCase.input.cn, testCase.input.sans, testCase.input.valid_for)
+			matches, err := regexp.MatchString(testCase.expected, req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !matches {
+				// might want to send a better error message in case of failure
+				t.Errorf("unmatched regexp\nExpected:\n%v\nGot:\n%v", testCase.expected, req)
+			}
+		})
+	}
 }

--- a/pkg/venafi/tpp/search_test.go
+++ b/pkg/venafi/tpp/search_test.go
@@ -375,9 +375,9 @@ func TestSearchDevice(t *testing.T) {
 }
 
 type FormatSearchCertificateArgumentsMock struct {
-	zone      string
-	cn        string
-	sans      *certificate.Sans
+	zone            string
+	cn              string
+	sans            *certificate.Sans
 	certMinTimeLeft time.Duration
 }
 

--- a/pkg/venafi/tpp/search_test.go
+++ b/pkg/venafi/tpp/search_test.go
@@ -378,7 +378,7 @@ type FormatSearchCertificateArgumentsMock struct {
 	zone      string
 	cn        string
 	sans      *certificate.Sans
-	valid_for time.Duration
+	certMinTimeLeft time.Duration
 }
 
 // TODO: find a way to test the correct time
@@ -447,7 +447,7 @@ func TestFormatSearchCertificateArguments(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			req := FormatSearchCertificateArguments(testCase.input.cn, testCase.input.sans, testCase.input.valid_for)
+			req := formatSearchCertificateArguments(testCase.input.cn, testCase.input.sans, testCase.input.certMinTimeLeft)
 			matches, err := regexp.MatchString(testCase.expected, req)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/verror/errors.go
+++ b/pkg/verror/errors.go
@@ -14,4 +14,7 @@ var (
 	AuthError                       = fmt.Errorf("%w: auth error", UserDataError)
 	ZoneNotFoundError               = fmt.Errorf("%w: zone not found", UserDataError)
 	ApplicationNotFoundError        = fmt.Errorf("%w: application not found", UserDataError)
+	// certificate search errors
+	NoCertificateFoundError                 = fmt.Errorf("no certificate with matching criteria found")
+	NoCertificateWithMatchingZoneFoundError = fmt.Errorf("no certificate with matching zone found")
 )


### PR DESCRIPTION
A function was added for both TPP and VaaS that enables searching for a valid certificate.

```go
SearchCertificate(zone string, cn string, sans *certificate.Sans, valid_for time.Duration) (*certificate.CertificateInfo, error)
```

If it returns no error, the certificate returned should be the latest [1] exact matching **zone** [2], **CN** and **sans.DNS** [3] provided

[1] the one with longest validity; field named **ValidTo** for TPP and **validityEnd** for VaaS
[2] application name for VaaS
[3] an array of strings representing the DNS names


It should address https://github.com/Venafi/vault-pki-backend-venafi/issues/102, preventing duplicate certificates
