### PR TITLE
Adds EC Curves for VaaS's certificatePolicies utils certificate's method "toPolicy" and connector's "buildPolicySpecification" function, as well as adds support for ED25519 curve

### DIFF
--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -49,6 +49,8 @@ func (ec *EllipticCurve) String() string {
 		return "P384"
 	case EllipticCurveP256:
 		return "P256"
+	case EllipticCurveED25519:
+		return "ED25519"
 	default:
 		return ""
 	}
@@ -63,6 +65,8 @@ func (ec *EllipticCurve) Set(value string) error {
 		*ec = EllipticCurveP384
 	case "p256", "p-256":
 		*ec = EllipticCurveP256
+	case "ed25519":
+		*ec = EllipticCurveED25519
 	default:
 		*ec = EllipticCurveDefault
 	}
@@ -78,13 +82,15 @@ const (
 	EllipticCurveP256
 	// EllipticCurveP384 represents the P384 curve
 	EllipticCurveP384
+	// EllipticED25519 represents the ED25519 curve
+	EllipticCurveED25519
 	EllipticCurveDefault = EllipticCurveP256
 
 	defaultRSAlength int = 2048
 )
 
 func AllSupportedCurves() []EllipticCurve {
-	return []EllipticCurve{EllipticCurveP521, EllipticCurveP256, EllipticCurveP384}
+	return []EllipticCurve{EllipticCurveP521, EllipticCurveP256, EllipticCurveP384, EllipticCurveED25519}
 }
 func AllSupportedKeySizes() []int {
 	return []int{1024, 2048, 4096, 8192}

--- a/pkg/venafi/cloud/certificatePolicies.go
+++ b/pkg/venafi/cloud/certificatePolicies.go
@@ -62,6 +62,7 @@ type certificateTemplate struct {
 		Key struct {
 			Type   string
 			Length int
+			Curve  string
 		}
 		keyReuse bool
 	}

--- a/pkg/venafi/cloud/certificatePolicies.go
+++ b/pkg/venafi/cloud/certificatePolicies.go
@@ -17,9 +17,11 @@
 package cloud
 
 import (
-	"github.com/Venafi/vcert/v4/pkg/endpoint"
 	"strings"
 	"time"
+
+	"github.com/Venafi/vcert/v4/pkg/certificate"
+	"github.com/Venafi/vcert/v4/pkg/endpoint"
 )
 
 type certificateTemplate struct {
@@ -121,6 +123,13 @@ func (ct certificateTemplate) toPolicy() (p endpoint.Policy) {
 			panic(err)
 		}
 		keyConfiguration.KeySizes = kt.KeyLengths[:]
+		for _, keyCurve := range kt.KeyCurves {
+			v := certificate.EllipticCurve(0)
+			if err := (&v).Set(keyCurve); err != nil {
+				panic(err)
+			}
+			keyConfiguration.KeyCurves = append(keyConfiguration.KeyCurves, v)
+		}
 		p.AllowedKeyConfigurations = append(p.AllowedKeyConfigurations, keyConfiguration)
 	}
 	return

--- a/pkg/venafi/cloud/cloud.go
+++ b/pkg/venafi/cloud/cloud.go
@@ -894,6 +894,11 @@ func buildPolicySpecification(cit *certificateTemplate, info *policy.Certificate
 		shouldCreateDefaultKeyPAir = true
 	}
 
+	if cit.RecommendedSettings.Key.Curve != "" {
+		defaultKP.EllipticCurve = &cit.RecommendedSettings.Key.Curve
+		shouldCreateDefaultKeyPAir = true
+	}
+
 	if shouldCreateDefaultKeyPAir {
 		if ps.Default == nil {
 			ps.Default = &policy.Default{}

--- a/pkg/venafi/cloud/connector_test.go
+++ b/pkg/venafi/cloud/connector_test.go
@@ -622,6 +622,36 @@ func TestReadPolicyConfiguration(t *testing.T) {
 	}
 }
 
+func TestReadPolicyConfigurationOnlyEC(t *testing.T) {
+	//todo: add more zones
+	conn := getTestConnector(ctx.VAASzoneEC)
+	err := conn.Authenticate(&endpoint.Authentication{APIKey: ctx.CloudAPIkey})
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	// This calls at the end of everything: policy.toPolicy() which is the function we wanted to test the KeyCurves
+	policy, err := conn.ReadPolicyConfiguration()
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	expectedPolice := endpoint.Policy{
+		SubjectCNRegexes:         []string{"^[a-z]{1}[a-z0-9.-]*\\.vfidev\\.com$"},
+		SubjectORegexes:          []string{"^Venafi Inc.$"},
+		SubjectOURegexes:         []string{"^Integrations$", "^Integration$"},
+		SubjectSTRegexes:         []string{"^Utah$"},
+		SubjectLRegexes:          []string{"^Salt Lake$"},
+		SubjectCRegexes:          []string{"^US$"},
+		AllowedKeyConfigurations: []endpoint.AllowedKeyConfiguration{{certificate.KeyTypeECDSA, nil, []certificate.EllipticCurve{certificate.EllipticCurveP256, certificate.EllipticCurveP384, certificate.EllipticCurveP521, certificate.EllipticCurveED25519}}},
+		DnsSanRegExs:             []string{"^[a-z]{1}[a-z0-9.-]*\\.vfidev\\.com$"},
+		AllowWildcards:           false,
+		AllowKeyReuse:            false,
+	}
+
+	if !reflect.DeepEqual(*policy, expectedPolice) {
+		t.Fatalf("policy for zone %s is not as expected \nget:    %+v \nexpect: %+v", ctx.CloudZone, *policy, expectedPolice)
+	}
+}
+
 func newSelfSignedCert() (string, error) {
 	rootKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -1298,6 +1328,235 @@ func TestGetPolicy(t *testing.T) {
 			t.Fatalf("policy default key type is not specified ")
 		}
 		if *(ps.Default.KeyPair.KeyType) != *(specifiedPS.Default.KeyPair.KeyType) {
+			t.Fatalf("specified policy default key type is different")
+		}
+	}
+
+	if specifiedPS.Default.KeyPair.RsaKeySize != nil {
+		if ps.Default.KeyPair.RsaKeySize == nil {
+			t.Fatalf("policy default rsa key size is not specified")
+		}
+		if *(ps.Default.KeyPair.RsaKeySize) != *(specifiedPS.Default.KeyPair.RsaKeySize) {
+			t.Fatalf("specified policy default rsa key size is different")
+		}
+	}
+
+}
+
+func TestGetPolicyOnlyEC(t *testing.T) {
+
+	// This test covers GetPolicy function from connector to test EC curves are return correctly for all the values,
+	// including RecommendSettings
+
+	policyName := os.Getenv("VAAS_ZONE_EC")
+	conn := getTestConnector(ctx.VAASzoneEC)
+	conn.verbose = true
+
+	err := conn.Authenticate(&endpoint.Authentication{APIKey: ctx.CloudAPIkey})
+
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	specifiedPS := test.GetVAASpolicySpecificationEC()
+
+	ps, err := conn.GetPolicy(policyName)
+
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	//validate each attribute
+	//validate subject attributes
+
+	if ps == nil {
+		t.Fatalf("specified Policy wasn't found")
+	}
+
+	if ps.Policy.Domains != nil && specifiedPS.Policy.Domains != nil {
+		valid := test.IsArrayStringEqual(specifiedPS.Policy.Domains, ps.Policy.Domains)
+		if !valid {
+			t.Fatalf("specified domains are different")
+		}
+	}
+
+	if *(ps.Policy.MaxValidDays) != *(specifiedPS.Policy.MaxValidDays) {
+		t.Fatalf("specified validity period is different")
+	}
+
+	//validate cert authority
+	if ps.Policy.CertificateAuthority == nil || *(ps.Policy.CertificateAuthority) == "" {
+		t.Fatalf("venafi policy doesn't have a certificate authority")
+	}
+	if *(ps.Policy.CertificateAuthority) != *(specifiedPS.Policy.CertificateAuthority) {
+		t.Fatalf("certificate authority value doesn't match, get: %s but expected: %s", *(ps.Policy.CertificateAuthority), *(specifiedPS.Policy.CertificateAuthority))
+	}
+
+	if specifiedPS.Policy.Subject.Orgs != nil {
+
+		if ps.Policy.Subject.Orgs == nil {
+			t.Fatalf("specified policy orgs are not specified")
+		}
+
+		valid := test.IsArrayStringEqual(specifiedPS.Policy.Subject.Orgs, ps.Policy.Subject.Orgs)
+		if !valid {
+			t.Fatalf("specified policy orgs are different")
+		}
+
+	}
+
+	if specifiedPS.Policy.Subject.OrgUnits != nil {
+
+		if ps.Policy.Subject.OrgUnits == nil {
+			t.Fatalf("specified policy orgs units are not specified")
+		}
+
+		valid := test.IsArrayStringEqual(specifiedPS.Policy.Subject.OrgUnits, ps.Policy.Subject.OrgUnits)
+		if !valid {
+			t.Fatalf("specified policy orgs units are different")
+		}
+
+	}
+
+	if specifiedPS.Policy.Subject.Localities != nil {
+
+		if ps.Policy.Subject.Localities == nil {
+			t.Fatalf("specified policy localities are not specified")
+		}
+
+		valid := test.IsArrayStringEqual(specifiedPS.Policy.Subject.Localities, ps.Policy.Subject.Localities)
+		if !valid {
+			t.Fatalf("specified policy localities are different")
+		}
+
+	}
+
+	if specifiedPS.Policy.Subject.States != nil {
+
+		if ps.Policy.Subject.States == nil {
+			t.Fatalf("specified policy states are not specified")
+		}
+
+		valid := test.IsArrayStringEqual(specifiedPS.Policy.Subject.States, ps.Policy.Subject.States)
+		if !valid {
+			t.Fatalf("specified policy states are different")
+		}
+
+	}
+
+	if specifiedPS.Policy.Subject.Countries != nil {
+
+		if ps.Policy.Subject.Countries == nil {
+			t.Fatalf("specified policy countries are not specified")
+		}
+
+		valid := test.IsArrayStringEqual(specifiedPS.Policy.Subject.Countries, ps.Policy.Subject.Countries)
+		if !valid {
+			t.Fatalf("specified policy countries are different")
+		}
+
+	}
+
+	//validate key pair values.
+
+	if specifiedPS.Policy.KeyPair.KeyTypes != nil {
+
+		if ps.Policy.KeyPair.KeyTypes == nil {
+			t.Fatalf("specified policy key types are not specified")
+		}
+
+		valid := test.IsArrayStringEqual(specifiedPS.Policy.KeyPair.KeyTypes, ps.Policy.KeyPair.KeyTypes)
+		if !valid {
+			t.Fatalf("specified policy key types are different")
+		}
+
+	}
+
+	if specifiedPS.Policy.KeyPair.RsaKeySizes != nil {
+
+		if ps.Policy.KeyPair.RsaKeySizes == nil {
+			t.Fatalf("specified policy rsa key sizes are not specified")
+		}
+
+		valid := test.IsArrayIntEqual(specifiedPS.Policy.KeyPair.RsaKeySizes, ps.Policy.KeyPair.RsaKeySizes)
+		if !valid {
+			t.Fatalf("specified policy rsa key sizes are different")
+		}
+
+	}
+
+	if specifiedPS.Policy.KeyPair.ReuseAllowed != nil {
+
+		if ps.Policy.KeyPair.ReuseAllowed == nil {
+			t.Fatalf("specified policy rsa key sizes are not specified")
+		}
+
+		if *(ps.Policy.KeyPair.ReuseAllowed) != *(specifiedPS.Policy.KeyPair.ReuseAllowed) {
+			t.Fatalf("specified policy rsa key sizes are different")
+		}
+
+	}
+
+	//validate default values.
+	if specifiedPS.Default.Subject.Org != nil {
+		if ps.Default.Subject.Org == nil {
+			t.Fatalf("specified policy default org is not specified")
+		}
+		if *(ps.Default.Subject.Org) != *(specifiedPS.Default.Subject.Org) {
+			t.Fatalf("specified policy default org is different")
+		}
+	}
+
+	if specifiedPS.Default.Subject.OrgUnits != nil {
+
+		if ps.Default.Subject.OrgUnits == nil {
+			t.Fatalf("specified policy default org is not specified")
+		}
+
+		valid := test.IsArrayStringEqual(specifiedPS.Default.Subject.OrgUnits, ps.Default.Subject.OrgUnits)
+
+		if !valid {
+			t.Fatalf("specified policy default org unit are different")
+		}
+
+	}
+
+	if specifiedPS.Default.Subject.Locality != nil {
+		if ps.Default.Subject.Locality == nil {
+			t.Fatalf("specified policy default locality is not specified")
+		}
+		if *(ps.Default.Subject.Locality) != *(specifiedPS.Default.Subject.Locality) {
+			t.Fatalf("specified policy default locality is different")
+		}
+	}
+
+	if specifiedPS.Default.Subject.State != nil {
+		if ps.Default.Subject.State == nil {
+			t.Fatalf("specified policy default state is not specified")
+		}
+		if *(ps.Default.Subject.State) != *(specifiedPS.Default.Subject.State) {
+			t.Fatalf("specified policy default state is different")
+		}
+	}
+
+	if specifiedPS.Default.Subject.Country != nil {
+		if ps.Default.Subject.Country == nil {
+			t.Fatalf("policy default country is not specified")
+		}
+		if *(ps.Default.Subject.Country) != *(specifiedPS.Default.Subject.Country) {
+			t.Fatalf("specified policy default country is different")
+		}
+	}
+
+	if specifiedPS.Default.KeyPair.KeyType != nil {
+		if ps.Default.KeyPair.KeyType == nil {
+			t.Fatalf("policy default key type is not specified ")
+		}
+		psDefaultKeyType := ps.Default.KeyPair.KeyType
+		psDefaultKeyTypeConverted := test.UnifyECvalue(*psDefaultKeyType)
+		ps.Default.KeyPair.KeyType = &psDefaultKeyTypeConverted
+		if *(ps.Default.KeyPair.KeyType) != *(specifiedPS.Default.KeyPair.KeyType) {
+
 			t.Fatalf("specified policy default key type is different")
 		}
 	}

--- a/test/context.go
+++ b/test/context.go
@@ -33,6 +33,7 @@ type Context struct {
 	CloudUrl            string
 	CloudAPIkey         string
 	CloudZone           string
+	VAASzoneEC          string
 	CloudZoneRestricted string
 }
 
@@ -51,6 +52,7 @@ func GetEnvContext() *Context {
 	c.CloudUrl = os.Getenv("CLOUD_URL")
 	c.CloudAPIkey = os.Getenv("CLOUD_APIKEY")
 	c.CloudZone = os.Getenv("CLOUD_ZONE")
+	c.VAASzoneEC = os.Getenv("VAAS_ZONE_EC")
 	c.CloudZoneRestricted = os.Getenv("CLOUD_ZONE_RESTRICTED")
 
 	return c


### PR DESCRIPTION
This caused the ReadZoneConfiguration function to return an empty keyCurves array for VaaS.