### PR TITLE
Consumers can now request private keys (for SSH certificates) protected by a passphrase

### DIFF
--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -227,7 +227,6 @@ type SshCertRequest struct {
 	Guid                      string
 	IncludePrivateKeyData     bool
 	PrivateKeyPassphrase      string
-	PrivateKeyFormat          string
 	IncludeCertificateDetails bool
 
 	Timeout time.Duration
@@ -262,7 +261,6 @@ type TppSshCertRetrieveRequest struct {
 	DN                        string
 	IncludePrivateKeyData     bool
 	PrivateKeyPassphrase      string
-	PrivateKeyFormat          string
 	IncludeCertificateDetails bool
 }
 

--- a/pkg/venafi/tpp/sshCertUtils.go
+++ b/pkg/venafi/tpp/sshCertUtils.go
@@ -135,6 +135,10 @@ func convertToSshCertReq(req *certificate.SshCertRequest) certificate.TPPSshCert
 		tppSshCertReq.ForceCommand = req.ForceCommand
 	}
 
+	if req.PrivateKeyPassphrase != "" {
+		tppSshCertReq.PrivateKeyPassphrase = req.PrivateKeyPassphrase
+	}
+
 	tppSshCertReq.IncludePrivateKeyData = true
 	tppSshCertReq.IncludeCertificateDetails = true
 


### PR DESCRIPTION
- The PrivateKeyPassphrase attribute was missing, so consumers cannot request private keys protected by a passphrase. 
- Remove PrivateKeyFormat from the SSH cert data structure. This option has never been implemented on the server side. 