### PR TITLE
run 'go fmt ./...' using go 1.19.2

### DIFF
--- a/client.go
+++ b/client.go
@@ -41,7 +41,7 @@ func (cfg *Config) NewClient(args ...interface{}) (connector endpoint.Connector,
 	return cfg.newClient(args)
 }
 
-//this function is to manage the variadic arguments
+// this function is to manage the variadic arguments
 func (cfg *Config) newClient(args []interface{}) (connector endpoint.Connector, err error) {
 
 	var clientArgs *newClientArgs

--- a/cmd/vcert/utils.go
+++ b/cmd/vcert/utils.go
@@ -308,8 +308,8 @@ func retrieveCertificate(connector endpoint.Connector, req *certificate.Request,
 	}
 }
 
-/* TODO: This one utilizes req.Timeout feature that is added to connector.RetrieveCertificate(), but
-it cannot do logging in CLI context right now -- logger.Printf("Issuance of certificate is pending ...") */
+// TODO: This one utilizes req.Timeout feature that is added to connector.RetrieveCertificate(), but
+// it cannot do logging in CLI context right now -- logger.Printf("Issuance of certificate is pending ...")
 func retrieveCertificateNew(connector endpoint.Connector, req *certificate.Request, timeout time.Duration) (certificates *certificate.PEMCollection, err error) {
 	req.Timeout = timeout
 	certificates, err = connector.RetrieveCertificate(req)

--- a/cmd/vcert/validators.go
+++ b/cmd/vcert/validators.go
@@ -38,7 +38,7 @@ var RevocationReasonOptions = []string{
 	"cessation-of-operation",
 }
 
-//taken from keystore.minPasswordLen constant
+// taken from keystore.minPasswordLen constant
 const JKSMinPasswordLen = 6
 
 func readData(commandName string) error {

--- a/listener.go
+++ b/listener.go
@@ -19,7 +19,7 @@ import (
 //
 // It enables one-line HTTPS servers:
 //
-//     log.Fatal(http.Serve(vcert.NewListener("example.com"), handler))
+//	log.Fatal(http.Serve(vcert.NewListener("example.com"), handler))
 //
 // The returned listener uses a *tls.Config that enables HTTP/2, and
 // should only be used with servers that support HTTP/2.

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -161,10 +161,11 @@ const (
 // CustomField can be used for adding additional information to certificate. For example: custom fields or Origin.
 // By default it's custom field. For adding Origin set Type: CustomFieldOrigin
 // For adding custom field with one name and few values give to request:
-//  request.CustomFields = []CustomField{
-//    {Name: "name1", Value: "value1"}
-//    {Name: "name1", Value: "value2"}
-//  }
+//
+//	request.CustomFields = []CustomField{
+//	  {Name: "name1", Value: "value1"}
+//	  {Name: "name1", Value: "value2"}
+//	}
 type CustomField struct {
 	Type  CustomFieldType
 	Name  string
@@ -215,7 +216,7 @@ type Request struct {
 //SSH Certificate structures
 
 // SshCertRequest This request is a standard one, it will hold data for tpp request
-//and in the future it will hold VaS data.
+// and in the future it will hold VaS data.
 type SshCertRequest struct {
 	Template             string
 	PolicyDN             string

--- a/pkg/certificate/certificateCollection.go
+++ b/pkg/certificate/certificateCollection.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 )
 
-//ChainOption represents the options to be used with the certificate chain
+// ChainOption represents the options to be used with the certificate chain
 type ChainOption int
 
 const (
@@ -38,7 +38,7 @@ const (
 	ChainOptionIgnore
 )
 
-//ChainOptionFromString converts the string to the corresponding ChainOption
+// ChainOptionFromString converts the string to the corresponding ChainOption
 func ChainOptionFromString(order string) ChainOption {
 	switch strings.ToLower(order) {
 	case "root-first":
@@ -50,7 +50,7 @@ func ChainOptionFromString(order string) ChainOption {
 	}
 }
 
-//PEMCollection represents a collection of PEM data
+// PEMCollection represents a collection of PEM data
 type PEMCollection struct {
 	Certificate string   `json:",omitempty"`
 	PrivateKey  string   `json:",omitempty"`
@@ -58,7 +58,7 @@ type PEMCollection struct {
 	CSR         string   `json:",omitempty"`
 }
 
-//NewPEMCollection creates a PEMCollection based on the data being passed in
+// NewPEMCollection creates a PEMCollection based on the data being passed in
 func NewPEMCollection(certificate *x509.Certificate, privateKey crypto.Signer, privateKeyPassword []byte, format ...string) (*PEMCollection, error) {
 	collection := PEMCollection{}
 	currentFormat := ""
@@ -84,7 +84,7 @@ func NewPEMCollection(certificate *x509.Certificate, privateKey crypto.Signer, p
 	return &collection, nil
 }
 
-//PEMCollectionFromBytes creates a PEMCollection based on the data passed in
+// PEMCollectionFromBytes creates a PEMCollection based on the data passed in
 func PEMCollectionFromBytes(certBytes []byte, chainOrder ChainOption) (*PEMCollection, error) {
 	var (
 		current    []byte
@@ -150,7 +150,7 @@ func PEMCollectionFromBytes(certBytes []byte, chainOrder ChainOption) (*PEMColle
 	return collection, nil
 }
 
-//AddPrivateKey adds a Private Key to the PEMCollection. Note that the collection can only contain one private key
+// AddPrivateKey adds a Private Key to the PEMCollection. Note that the collection can only contain one private key
 func (col *PEMCollection) AddPrivateKey(privateKey crypto.Signer, privateKeyPassword []byte, format ...string) error {
 
 	currentFormat := ""
@@ -175,7 +175,7 @@ func (col *PEMCollection) AddPrivateKey(privateKey crypto.Signer, privateKeyPass
 	return nil
 }
 
-//AddChainElement adds a chain element to the collection
+// AddChainElement adds a chain element to the collection
 func (col *PEMCollection) AddChainElement(certificate *x509.Certificate) error {
 	if certificate == nil {
 		return fmt.Errorf("%w: certificate cannot be nil", verror.VcertError)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -139,7 +139,7 @@ type Authentication struct {
 	ClientPKCS12 bool
 }
 
-//todo: replace with verror
+// todo: replace with verror
 // ErrRetrieveCertificateTimeout provides a common error structure for a timeout while retrieving a certificate
 type ErrRetrieveCertificateTimeout struct {
 	CertificateID string
@@ -149,7 +149,7 @@ func (err ErrRetrieveCertificateTimeout) Error() string {
 	return fmt.Sprintf("Operation timed out. You may try retrieving the certificate later using Pickup ID: %s", err.CertificateID)
 }
 
-//todo: replace with verror
+// todo: replace with verror
 // ErrCertificatePending provides a common error structure for a timeout while retrieving a certificate
 type ErrCertificatePending struct {
 	CertificateID string

--- a/pkg/policy/policyUtils.go
+++ b/pkg/policy/policyUtils.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 )
 
-//there is no way for creating an array as constant, so creating a variable
-//this is the nearest to a constant on arrays.
+// there is no way for creating an array as constant, so creating a variable
+// this is the nearest to a constant on arrays.
 var TppKeyType = []string{"RSA", "ECDSA"}
 var TppRsaKeySize = []int{512, 1024, 2048, 3072, 4096}
 var CloudRsaKeySize = []int{1024, 2048, 3072, 4096}

--- a/pkg/util/pemUtil.go
+++ b/pkg/util/pemUtil.go
@@ -1,7 +1,7 @@
-//This file contains functions that were copied from x509.pem_decrypt.go
-//in order to keep supporting X509EncryptPEMBlock and x509DecryptPEMBlock
-//the use of this is not recommended, this is just to continue supporting old
-//applications.
+// This file contains functions that were copied from x509.pem_decrypt.go
+// in order to keep supporting X509EncryptPEMBlock and x509DecryptPEMBlock
+// the use of this is not recommended, this is just to continue supporting old
+// applications.
 package util
 
 import (

--- a/pkg/venafi/cloud/cloud.go
+++ b/pkg/venafi/cloud/cloud.go
@@ -228,7 +228,7 @@ type ApplicationDetails struct {
 	FqDns                     []string             `json:"fqDns,omitempty"`
 }
 
-//GenerateRequest generates a CertificateRequest based on the zone configuration, and returns the request along with the private key.
+// GenerateRequest generates a CertificateRequest based on the zone configuration, and returns the request along with the private key.
 func (c *Connector) GenerateRequest(config *endpoint.ZoneConfiguration, req *certificate.Request) (err error) {
 	switch req.CsrOrigin {
 	case certificate.LocalGeneratedCSR:

--- a/pkg/venafi/cloud/cloudUtil.go
+++ b/pkg/venafi/cloud/cloudUtil.go
@@ -235,7 +235,7 @@ func getSANByType(csrAttributes *CsrAttributes) *SubjectAlternativeNamesByType {
 	return csrAttributes.SubjectAlternativeNamesByType
 }
 
-//receives a string regex and a string to test
+// receives a string regex and a string to test
 func testRegex(toTest, regex string) (bool, error) {
 	compiledRegex, err := regexp.Compile(regex)
 	if err != nil {

--- a/pkg/venafi/cloud/company.go
+++ b/pkg/venafi/cloud/company.go
@@ -54,12 +54,15 @@ func getZoneConfiguration(policy *certificateTemplate) (zoneConfig *endpoint.Zon
 
 /*
 const (
+
 	zoneKeyGeneratorDeviceKeyGeneration  = "DEVICE_KEY_GENERATION"
 	zoneKeyGeneratorCentralKeyGeneration = "CENTRAL_KEY_GENERATION"
 	zoneKeyGeneratorUnknown              = "UNKNOWN"
+
 )
 
 const (
+
 	zoneEncryptionTypeRSA        = "RSA"
 	zoneEncryptionTypeDSA        = "DSA"
 	zoneEncryptionTypeEC         = "EC"
@@ -67,6 +70,7 @@ const (
 	zoneEncryptionTypeECGOST3410 = "ECGOST3410"
 	zoneEncryptionTypeRESERVED3  = "RESERVED3"
 	zoneEncryptionTypeUnknown    = "UNKNOWN"
+
 )
 */
 const (

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -667,7 +667,7 @@ func NewConnector(url string, zone string, verbose bool, trust *x509.CertPool) (
 	return &c, nil
 }
 
-//normalizeURL allows overriding the default URL used to communicate with Venafi Cloud
+// normalizeURL allows overriding the default URL used to communicate with Venafi Cloud
 func normalizeURL(url string) (normalizedURL string, err error) {
 	if url == "" {
 		url = apiURL
@@ -1348,15 +1348,16 @@ func (c *Connector) searchCertificatesByFingerprint(fp string) (*CertificateSear
 }
 
 /*
-  "id": "32a656d1-69b1-11e8-93d8-71014a32ec53",
-  "companyId": "b5ed6d60-22c4-11e7-ac27-035f0608fd2c",
-  "latestCertificateRequestId": "0e546560-69b1-11e8-9102-a1f1c55d36fb",
-  "ownerUserId": "593cdba0-2124-11e8-8219-0932652c1da0",
-  "certificateIds": [
-    "32a656d0-69b1-11e8-93d8-71014a32ec53"
-  ],
-  "certificateName": "cn=svc6.venafi.example.com",
+"id": "32a656d1-69b1-11e8-93d8-71014a32ec53",
+"companyId": "b5ed6d60-22c4-11e7-ac27-035f0608fd2c",
+"latestCertificateRequestId": "0e546560-69b1-11e8-9102-a1f1c55d36fb",
+"ownerUserId": "593cdba0-2124-11e8-8219-0932652c1da0",
+"certificateIds": [
 
+	"32a656d0-69b1-11e8-93d8-71014a32ec53"
+
+],
+"certificateName": "cn=svc6.venafi.example.com",
 */
 type managedCertificate struct {
 	Id                   string `json:"id"`

--- a/pkg/venafi/cloud/connector_test.go
+++ b/pkg/venafi/cloud/connector_test.go
@@ -26,7 +26,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"github.com/Venafi/vcert/v4/pkg/policy"
 	"math/big"
 	"net"
 	"net/url"
@@ -36,6 +35,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Venafi/vcert/v4/pkg/policy"
 
 	"github.com/Venafi/vcert/v4/pkg/certificate"
 	"github.com/Venafi/vcert/v4/pkg/endpoint"
@@ -1753,9 +1754,7 @@ func TestSetPolicyValuesAndValidate(t *testing.T) {
 
 }
 
-/**
-This test is just for verifying that a policy can be created using ENTRUST CA.
-*/
+// This test is just for verifying that a policy can be created using ENTRUST CA.
 func TestSetPolicyEntrust(t *testing.T) {
 
 	policyName := test.RandAppName() + "\\" + test.RandCitName()
@@ -1790,7 +1789,8 @@ func TestSetPolicyEntrust(t *testing.T) {
 
 }
 
-/**
+/*
+*
 This test is just for verifying that a policy can be created using DIGICERT	 CA.
 */
 func TestSetPolicyDigicert(t *testing.T) {

--- a/pkg/venafi/fake/fake.go
+++ b/pkg/venafi/fake/fake.go
@@ -22,7 +22,7 @@ import (
 	"github.com/Venafi/vcert/v4/pkg/endpoint"
 )
 
-//GenerateRequest creates a new certificate request, based on the zone/policy configuration and the user data
+// GenerateRequest creates a new certificate request, based on the zone/policy configuration and the user data
 func (c *Connector) GenerateRequest(config *endpoint.ZoneConfiguration, req *certificate.Request) (err error) {
 
 	switch req.CsrOrigin {

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -102,7 +102,7 @@ func (c *Connector) GetType() endpoint.ConnectorType {
 	return endpoint.ConnectorTypeTPP
 }
 
-//Ping attempts to connect to the TPP Server WebSDK API and returns an error if it cannot
+// Ping attempts to connect to the TPP Server WebSDK API and returns an error if it cannot
 func (c *Connector) Ping() (err error) {
 
 	//Extended timeout to allow the server to wake up
@@ -1434,7 +1434,7 @@ func (c *Connector) ReadPolicyConfiguration() (policy *endpoint.Policy, err erro
 	return
 }
 
-//ReadZoneConfiguration reads the policy data from TPP to get locked and pre-configured values for certificate requests
+// ReadZoneConfiguration reads the policy data from TPP to get locked and pre-configured values for certificate requests
 func (c *Connector) ReadZoneConfiguration() (config *endpoint.ZoneConfiguration, err error) {
 	if c.zone == "" {
 		return nil, fmt.Errorf("empty zone")

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -128,8 +128,8 @@ type certificateRevokeRequest struct {
 	Disable       bool             `json:",omitempty"`
 }
 
-/* {Requested:true  Success:true Error:} -- means requested
-   {Requested:false Success:true Error:} -- means already revoked  */
+// {Requested:true  Success:true Error:} -- means requested
+// {Requested:false Success:true Error:} -- means already revoked
 type certificateRevokeResponse struct {
 	Requested bool   `json:",omitempty"`
 	Success   bool   `json:",omitempty"`

--- a/vcert.go
+++ b/vcert.go
@@ -23,7 +23,7 @@ var (
 	versionString         string
 )
 
-//GetFormattedVersionString gets a friendly printable string to represent the version
+// GetFormattedVersionString gets a friendly printable string to represent the version
 func GetFormattedVersionString() string {
 	if versionString == "" {
 		versionString = "Unknown"


### PR DESCRIPTION
Since Go 1.19, the go code formatter also formats comments.
This PR formats all source code.
This will prevent contributors that use go 1.19+ from contributing unrelated formatting changes in the future.