### PR TITLE
Change RetrieveCertificate so that it resets the enrollment (if it exists) while retrieving the certificate

### DIFF
--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -1232,9 +1232,32 @@ func (c *Connector) RetrieveCertificate(req *certificate.Request) (certificates 
 	}
 
 	startTime := time.Now()
+	retrieveCount := 0
 	for {
+		retrieveCount++
+
 		var retrieveResponse *certificateRetrieveResponse
 		retrieveResponse, err = c.retrieveCertificateOnce(certReq)
+
+		// As a workaround to certificates being stuck due to a past failed
+		// enrollment, we reset the certificate as part of RetrieveCertificate
+		// to avoid making an extra HTTP call when requesting a certificate. We
+		// only reset once, since it only makes sense to reset the past failed
+		// enrollment.
+		if shouldReset(err) && retrieveCount == 1 {
+			statusCode, status, _, err := c.request("POST", urlResourceCertificateReset, certificateResetRequest{
+				CertificateDN: req.PickupID,
+				Restart:       true,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("while resetting certificate due to a past failed enrollment: %w", err)
+			}
+			if statusCode != http.StatusOK {
+				return nil, fmt.Errorf("while resetting certificate due to a past failed enrollment. Status: %s", status)
+			}
+
+			continue
+		}
 		if err != nil {
 			return nil, fmt.Errorf("unable to retrieve: %s", err)
 		}
@@ -1254,6 +1277,27 @@ func (c *Connector) RetrieveCertificate(req *certificate.Request) (certificates 
 		}
 		time.Sleep(2 * time.Second)
 	}
+}
+
+// After many tests, we found that the only way to know if the current
+// certificate request is stuck due to an old failed enrollment is to look for
+// "WebSDK CertRequest" or "Fix any errors, and then click Retry." in the
+// retrieve response when it returns a 500.
+func shouldReset(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if !strings.Contains(err.Error(), "Status: 500") {
+		return false
+	}
+
+	if strings.Contains(err.Error(), "This certificate cannot be processed while it is in an error state. Fix any errors, and then click Retry.") ||
+		strings.Contains(err.Error(), "WebSDK CertRequest Module Requested Certificate") {
+		return true
+	}
+
+	return false
 }
 
 func (c *Connector) retrieveCertificateOnce(certReq certificateRetrieveRequest) (*certificateRetrieveResponse, error) {

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -107,6 +107,11 @@ type certificateRetrieveResponse struct {
 	Stage           int    `json:",omitempty"`
 }
 
+type certificateResetRequest struct {
+	CertificateDN string `json:",omitempty"`
+	Restart       bool   `json:",omitempty"`
+}
+
 type RevocationReason int
 
 // RevocationReasonsMap maps *certificate.RevocationRequest.Reason to TPP-specific webSDK codes
@@ -352,6 +357,7 @@ const (
 	urlResourceCertificateRenew       urlResource = "vedsdk/certificates/renew"
 	urlResourceCertificateRequest     urlResource = "vedsdk/certificates/request"
 	urlResourceCertificateRetrieve    urlResource = "vedsdk/certificates/retrieve"
+	urlResourceCertificateReset       urlResource = "vedsdk/certificates/reset"
 	urlResourceCertificateRevoke      urlResource = "vedsdk/certificates/revoke"
 	urlResourceCertificatesAssociate  urlResource = "vedsdk/certificates/associate"
 	urlResourceCertificatesDissociate urlResource = "vedsdk/certificates/dissociate"


### PR DESCRIPTION
**Update 29 Nov 2022:** I put this PR back to "draft" because I am less and less confident with the changes I am making here. I propose to first agree on a set of `RetrieveCertificate` tests in #270 before I make any change to it `RetrieveCertificate`. When we have merged #270, we can proceed with the current PR.
**Update 5 Dec 2022:** I am now confident with the PR, it can now be reviewed.

---

**The problem:** When enrolling a new certificate, for example by running `vcert enroll` or when using cert-manager, people get "stuck" with an error of the like:

    500 Certificate \VED\Policy\Test\foo.com has encountered an error while processing,
    Status: This certificate cannot be processed while it is in an error state. Fix any
    errors, and then click Retry., Stage: 700.

This message occurs when a past enrollment has failed or an enrollment was still in progress for that certificate. The current workaround is to call to `POST /reset` with Restart=False, and then re-run the command `vcert enroll` (or renew the certificate in cert-manager).

This PR implements the design presented in [Solution 3: request, then reset if retrieve returns “Click Retry” or “WebSDK CertRequest”](https://hackmd.io/@maelvls/design-reset-cert-when-requesting#Solution-3-request-then-reset-if-retrieve-returns-%E2%80%9CClick-Retry%E2%80%9D-or-%E2%80%9CWebSDK-CertRequest%E2%80%9D). The OAuth token doesn't need to change (`certificate:manage`).

The [Jenkins build 2378](https://jenkins.eng.venafi.com/blue/organizations/jenkins/VCert%2Fvcert/detail/vcert/2378/pipeline) is passing for 63f7dff.

**Self-review:**

- I went with a "mock" HTTP server due to the difficulty to get the 202 and 500 HTTP status codes "on demand" from TPP. I didn't add a "live test" because I don't know how to consistently force TPP to return a 500 without RDP'ing into the VM and putting a PowerShell script or turning off the Windows CA (it can't be a policy check such as the domain, as this would be a "Stage 0" error which is the only stage number which gets reset upon requesting a new certificate).
  - **Fake server:** use a fake server to test it, but there is currently no fake server (note that @wallrj started to write a fake server in #262). The fake server, as opposed to the mock server, contains some logic.
  - **Mock responses:** use mock HTTP responses with a mock HTTP server.

**Manual test performed:**

Apart from the "mock" tests that I added, I also manually tested this change with a live TPP instance:

<details>
<summary>Reproducing the manual test</summary>

1. I spun up a TPP instance on CloudShare (using my Jetstack account), using the template "Master NGINX/K8s Blueprint" (snapshot "[6] training_2020-08-28") that comes with TPP 20.1.
2. I went to https://uvo1dq3vmkecfydcwxm.env.cloudshare.com/aperture/application-integrations/ and create a new API integration, since none of the existing contains `configuration:manage` (which I need to set the correct policy):
  <img alt="" src="https://user-images.githubusercontent.com/2195781/201674161-3f7ee781-dfce-4095-9391-a63697166a7c.png" width="300"><img alt="" src="https://user-images.githubusercontent.com/2195781/201674190-884b1a26-a5ee-410f-b7e5-856beadb4a12.png" width="500">
4. I created a token and stored it in the env var `TOKEN` with the following:
  
    ```sh
    TPP_URL=https://uvo1dq3vmkecfydcwxm.env.cloudshare.com
    TPP_USER=tppadmin
    TPP_PASSWORD=
    TOKEN=$(vcert getcred -u $TPP_URL --username $TPP_USER --password $TPP_PASSWORD --client-id=test --scope='certificate:manage;configuration:manage' --format json | jq -r .access_token)
    ```

5. Since we need to trigger an enrollment failure at a stage higher than 0, we will purposefully break the CA. To do that, I RDP'ed into the TPP VM, I opened the program `pkiview`, right-clicked on the only entry, "Manage CA...", and then clicked the "Stop" button:

    <img alt="" src="https://user-images.githubusercontent.com/2195781/201878971-d3f0e80e-cc20-48d1-99ac-817da0cdb85b.png" width="600">

6. I then enrolled:
  
    ```sh
    vcert enroll -u "$TPP_URL" -t "$TOKEN" --cn example.com -z 'TLS/SSL' --san-dns=example.com
    ```

    As expected, it shows:

    > vCert: 2022/11/14 14:58:38 unable to retrieve: Unexpected status code on TPP Certificate Retrieval. Status: 500 Certificate \VED\Policy\TLS/SSL\example.com has encountered an error while processing, Status: Post CSR failed with error: Cannot connect to the certificate authority (CA). Verify that your CA template settings are correct and that the remote server is available. For more information, search the Help system for Configuring the Microsoft Certificate Services Template Object., Stage: 500.

7. If we try to submit the certificate again, we still get the error at stage 500 (weirdly, the original disappeared and a generic message appears instead):
  
    > vCert: 2022/11/14 14:59:43 unable to retrieve: Unexpected status code on TPP Certificate Retrieval. Status: 500 Certificate \VED\Policy\TLS/SSL\example.com has encountered an error while processing, Status: This certificate cannot be processed while it is in an error state. Fix any errors, and then click Retry., Stage: 500.

8. I then fixed the CA:
  
    <img alt="" src="https://user-images.githubusercontent.com/2195781/201879892-b0c1449b-9992-4d11-970f-f10dd5ca5e1c.png" width="600">
   

9. I then tried to enroll again, and the "old" error with the sage 500 still shows:
  
    > vCert: 2022/11/14 15:06:30 unable to retrieve: Unexpected status code on TPP Certificate Retrieval. Status: 500 Certificate \VED\Policy\TLS/SSL\example.com has encountered an error while processing, Status: This certificate cannot be processed while it is in an error state. Fix any errors, and then click Retry., Stage: 500.

10. Now, from this project's folder, let us run `vcert` with the changes made in this PR:
    
    ```sh
    git fetch origin refs/pull/269/head:reset-before-request
    git checkout reset-before-request
    go run ./cmd/vcert enroll -u "$TPP_URL" -t "$TOKEN" --cn example.com -z 'TLS/SSL' --san-dns=example.com
    ```
  
    This time, the certificate gets properly requested.

</details>

**Changes in error messages:** this PR purposefully doesn't change any of the error messages.

**Possible breakages to other projects:**

- ✅  [terraform-provider-venafi](https://github.com/Venafi/terraform-provider-venafi) uses RetrieveCertificate in three locations. [One](https://github.com/Venafi/terraform-provider-venafi/blob/5374fa5ae86bb09609d228ef89f90a89261d3d3a/venafi/resource_venafi_certificate.go#L818) of them matches on the following specific error message:
    ```go
    "unable to retrieve: Unexpected status code on TPP Certificate Retrieval. Status: 400 Failed to lookup private key, error: Failed to lookup private key vault id"
     ```
     I added a test proving that this same error message will be shown in the same ciscumstances.
- ✅  [vault-pki-backend-venafi](https://github.com/Venafi/vault-pki-backend-venafi) won't be affected since it doesn't parses messages. It uses `RetrieveCertificate` [once](https://github.com/Venafi/vault-pki-backend-venafi/blob/88b14567c280d3d1b57addc2e51d4b5764e7b64e/plugin/pki/vcert_test.go#L61).
- ✅  [cert-manager](https://github.com/cert-manager/cert-manager) has a [single call](https://github.com/cert-manager/cert-manager/blob/d85e424cd0741bdb0fd4a5837d376c690e80fb9f/pkg/issuer/venafi/client/request.go#L65) to `RetrieveCertificate` and doesn't look at the messages.
