### PR TITLE
RetrieveCertificate: add mocked HTTP tests using real TPP responses

### DIFF
--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -663,9 +663,9 @@ func TestRetrieveCertificate(t *testing.T) {
 		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch {
 			case r.URL.Path == "/vedsdk/certificates/retrieve":
-				atomic.AddInt32(retrieveCount, 1)
-				if atomic.LoadInt32(retrieveCount) > int32(len(mockRetrieve)) {
-					t.Fatalf("/retrieve: expected no more than %d calls, but got %d", len(mockRetrieve), atomic.LoadInt32(retrieveCount))
+				index := atomic.AddInt32(retrieveCount, 1) - 1
+				if index >= int32(len(mockRetrieve)) {
+					t.Fatalf("/retrieve: expected no more than %d calls, but got %d", len(mockRetrieve), index)
 				}
 
 				req := certificateRetrieveRequest{}
@@ -675,8 +675,8 @@ func TestRetrieveCertificate(t *testing.T) {
 				}
 
 				writeRespWithCustomStatus(w,
-					mockRetrieve[atomic.LoadInt32(retrieveCount)-1].status,
-					mockRetrieve[atomic.LoadInt32(retrieveCount)-1].body,
+					mockRetrieve[index].status,
+					mockRetrieve[index].body,
 				)
 			default:
 				t.Fatalf("mock http server: unimplemented path " + r.URL.Path)


### PR DESCRIPTION
There are no tests that would allow us to "see" and discuss the issue reported in  https://github.com/Venafi/vcert/issues/171. Having tests, even statically mocked HTTP ones, would also allow us to prevent breakage (as much as possible) when changing RetrieveCertificate in #269.

I used `curl` and a 20.1 TPP VM to capture each individual HTTP response. At some point, I wish to document further how I produced these response samples.

The reason I went for a mocked HTTP server is because making the live TPP server return all of these messages is tricky; most 500 errors aren't easily reproducible unless we set up the e2e TPP VM to have e.g. one of its CA templates broken on purpose.
 
This "mocked HTTP server" approach isn't ideal because a drift may appear between earlier versions of TPP and these mocked responses, but I still think it is important to have them to prevent breakage when trying to refactor `RetrieveCertificate`.
