### PR TITLE
Fixing linter issue

### DIFF
--- a/cmd/vcert/commands.go
+++ b/cmd/vcert/commands.go
@@ -228,6 +228,10 @@ func setTLSConfig() error {
 	}
 
 	if flags.insecure {
+		// We are ignoring the following from the linter, since from:
+		// golangci-lint version 1.51.2 built from 3e8facb4 on 2023-02-19T21:43:54Z
+		// started failing
+		// #nosec G402: Look for bad TLS connection settings
 		tlsConfig.InsecureSkipVerify = true
 	}
 

--- a/cmd/vcert/commands.go
+++ b/cmd/vcert/commands.go
@@ -230,7 +230,7 @@ func setTLSConfig() error {
 	if flags.insecure {
 		// We are ignoring the following from the linter, since from:
 		// golangci-lint version 1.51.2 built from 3e8facb4 on 2023-02-19T21:43:54Z
-		// started failing
+		// it started failing due to error in this version of the linter
 		// #nosec G402: Look for bad TLS connection settings
 		tlsConfig.InsecureSkipVerify = true
 	}


### PR DESCRIPTION
This changes fix current (v1.51) golangci-lint issue:
```
golangci-lint run
cmd/vcert/commands.go:231:34: G402: TLS InsecureSkipVerify set true. (gosec)
                tlsConfig.InsecureSkipVerify = true
```
