### PR TITLE
Add ValidityDuration option

### DIFF
--- a/cmd/vcert/utils.go
+++ b/cmd/vcert/utils.go
@@ -183,32 +183,26 @@ func fillCertificateRequest(req *certificate.Request, cf *commandFlags) *certifi
 	}
 
 	if cf.validDays != "" {
-		validDays := cf.validDays
-
-		data := strings.Split(validDays, "#")
+		data := strings.Split(cf.validDays, "#")
 		days, _ := strconv.ParseInt(data[0], 10, 64)
-		hours := days * 24
+		duration := time.Duration(days) * time.Hour * 24
 
-		req.ValidityHours = int(hours)
+		req.ValidityDuration = &duration
 
-		issuerHint := ""
-		if len(data) > 1 { //means that issuer hint is set
+		if len(data) > 1 { // means that issuer hint is set
+			var issuerHint util.IssuerHint
 
-			option := strings.ToLower(data[1])
-
-			switch option {
-
+			switch strings.ToLower(data[1]) {
 			case "m":
 				issuerHint = util.IssuerHintMicrosoft
 			case "d":
 				issuerHint = util.IssuerHintDigicert
 			case "e":
 				issuerHint = util.IssuerHintEntrust
-
 			}
-		}
 
-		req.IssuerHint = issuerHint
+			req.IssuerHint = issuerHint
+		}
 	}
 
 	return req

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -213,6 +213,9 @@ type Request struct {
 	Location         *Location
 	ValidityDuration *time.Duration
 	IssuerHint       util.IssuerHint
+
+	// DEPRECATED: use ValidityDuration instead, this field is ignored if ValidityDuration is set
+	ValidityHours int
 }
 
 //SSH Certificate structures

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -26,16 +26,18 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"github.com/Venafi/vcert/v4/pkg/util"
-	"github.com/youmark/pkcs8"
 	"net"
 	"net/url"
 	"strings"
 	"time"
 
-	"github.com/Venafi/vcert/v4/pkg/verror"
+	"github.com/Venafi/vcert/v4/pkg/util"
+	"github.com/youmark/pkcs8"
+
 	"reflect"
 	"sort"
+
+	"github.com/Venafi/vcert/v4/pkg/verror"
 )
 
 // EllipticCurve represents the types of supported elliptic curves
@@ -205,12 +207,12 @@ type Request struct {
 	FetchPrivateKey bool
 	/*	Thumbprint is here because *Request is used in RetrieveCertificate().
 		Code should be refactored so that RetrieveCertificate() uses some abstract search object, instead of *Request{PickupID} */
-	Thumbprint    string
-	Timeout       time.Duration
-	CustomFields  []CustomField
-	Location      *Location
-	ValidityHours int
-	IssuerHint    string
+	Thumbprint       string
+	Timeout          time.Duration
+	CustomFields     []CustomField
+	Location         *Location
+	ValidityDuration *time.Duration
+	IssuerHint       util.IssuerHint
 }
 
 //SSH Certificate structures

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -1,9 +1,16 @@
 package util
 
 const (
-	IssuerHintMicrosoft     = "MICROSOFT"
-	IssuerHintDigicert      = "DIGICERT"
-	IssuerHintEntrust       = "ENTRUST"
 	PathSeparator           = "\\"
 	ApplicationServerTypeID = "784938d1-ef0d-11eb-9461-7bb533ba575b"
+)
+
+type IssuerHint string
+
+const (
+	IssuerHintMicrosoft  IssuerHint = "MICROSOFT"
+	IssuerHintDigicert   IssuerHint = "DIGICERT"
+	IssuerHintEntrust    IssuerHint = "ENTRUST"
+	IssuerHintAllIssuers IssuerHint = "ALL_ISSUERS"
+	IssuerHintGeneric    IssuerHint = ""
 )

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -823,8 +823,17 @@ func getCloudRequest(c *Connector, req *certificate.Request) (*certificateReques
 		}
 	}
 
-	if req.ValidityDuration != nil {
-		cloudReq.ValidityPeriod = "PT" + strings.ToUpper((*req.ValidityDuration).Truncate(time.Second).String())
+	validityDuration := req.ValidityDuration
+
+	// DEPRECATED: ValidityHours is deprecated in favor of ValidityDuration, but we
+	// still support it for backwards compatibility.
+	if validityDuration == nil && req.ValidityHours > 0 {
+		duration := time.Duration(req.ValidityHours) * time.Hour
+		validityDuration = &duration
+	}
+
+	if validityDuration != nil {
+		cloudReq.ValidityPeriod = "PT" + strings.ToUpper((*validityDuration).Truncate(time.Second).String())
 	}
 
 	return &cloudReq, nil

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -30,7 +30,6 @@ import (
 	"net/http"
 	netUrl "net/url"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -824,10 +823,8 @@ func getCloudRequest(c *Connector, req *certificate.Request) (*certificateReques
 		}
 	}
 
-	if req.ValidityHours > 0 {
-		hoursStr := strconv.Itoa(req.ValidityHours)
-		validityHoursStr := "PT" + hoursStr + "H"
-		cloudReq.ValidityPeriod = validityHoursStr
+	if req.ValidityDuration != nil {
+		cloudReq.ValidityPeriod = "PT" + strings.ToUpper((*req.ValidityDuration).Truncate(time.Second).String())
 	}
 
 	return &cloudReq, nil

--- a/pkg/venafi/cloud/connector_test.go
+++ b/pkg/venafi/cloud/connector_test.go
@@ -195,9 +195,9 @@ func TestRequestCertificateWithValidDays(t *testing.T) {
 	req.Subject.Organization = []string{"Venafi, Inc."}
 	req.Subject.OrganizationalUnit = []string{"Automated Tests"}
 
-	validHours := 144
-	req.ValidityHours = validHours
-	req.IssuerHint = "MICROSOFT"
+	validDuration := 144 * time.Hour * 24
+	req.ValidityDuration = &validDuration
+	req.IssuerHint = util.IssuerHintMicrosoft
 
 	err = conn.GenerateRequest(zoneConfig, req)
 	if err != nil {
@@ -244,8 +244,7 @@ func TestRequestCertificateWithValidDays(t *testing.T) {
 	//need to convert local date on utc, since the certificate' NotAfter value we got on previous step, is on utc
 	//so for comparing them we need to have both dates on utc.
 	loc, _ := time.LoadLocation("UTC")
-	utcNow := time.Now().In(loc)
-	expectedValidDate := utcNow.AddDate(0, 0, validHours/24).Format("2006-01-02")
+	expectedValidDate := time.Now().Add(validDuration).In(loc).Format("2006-01-02")
 
 	if expectedValidDate != certValidUntil {
 		t.Fatalf("Expiration date is different than expected, expected: %s, but got %s: ", expectedValidDate, certValidUntil)

--- a/pkg/venafi/cloud/connector_test.go
+++ b/pkg/venafi/cloud/connector_test.go
@@ -195,7 +195,7 @@ func TestRequestCertificateWithValidDays(t *testing.T) {
 	req.Subject.Organization = []string{"Venafi, Inc."}
 	req.Subject.OrganizationalUnit = []string{"Automated Tests"}
 
-	validDuration := 144 * time.Hour * 24
+	validDuration := 144 * time.Hour
 	req.ValidityDuration = &validDuration
 	req.IssuerHint = util.IssuerHintMicrosoft
 

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -546,8 +546,17 @@ func prepareRequest(req *certificate.Request, zone string) (tppReq certificateRe
 	tppReq.CASpecificAttributes = append(tppReq.CASpecificAttributes, nameValuePair{Name: "Origin", Value: origin})
 	tppReq.Origin = origin
 
-	if req.ValidityDuration != nil {
-		formattedExpirationDate := time.Now().Add(*req.ValidityDuration).Format(time.RFC3339)
+	validityDuration := req.ValidityDuration
+
+	// DEPRECATED: ValidityHours is deprecated in favor of ValidityDuration, but we
+	// still support it for backwards compatibility.
+	if validityDuration == nil && req.ValidityHours > 0 {
+		duration := time.Duration(req.ValidityHours) * time.Hour
+		validityDuration = &duration
+	}
+
+	if validityDuration != nil {
+		formattedExpirationDate := time.Now().Add(*validityDuration).Format(time.RFC3339)
 
 		var attributeNames []string
 

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -546,39 +546,37 @@ func prepareRequest(req *certificate.Request, zone string) (tppReq certificateRe
 	tppReq.CASpecificAttributes = append(tppReq.CASpecificAttributes, nameValuePair{Name: "Origin", Value: origin})
 	tppReq.Origin = origin
 
-	if req.ValidityHours > 0 {
+	if req.ValidityDuration != nil {
+		formattedExpirationDate := time.Now().Add(*req.ValidityDuration).Format(time.RFC3339)
 
-		expirationDateAttribute := ""
+		var attributeNames []string
 
 		switch req.IssuerHint {
-		case util.IssuerHintMicrosoft:
-			expirationDateAttribute = "Microsoft CA:Specific End Date"
 		case util.IssuerHintDigicert:
-			expirationDateAttribute = "DigiCert CA:Specific End Date"
+			attributeNames = []string{"DigiCert CA:Specific End Date"}
+		case util.IssuerHintMicrosoft:
+			attributeNames = []string{"Microsoft CA:Specific End Date"}
 		case util.IssuerHintEntrust:
-			expirationDateAttribute = "EntrustNET CA:Specific End Date"
+			attributeNames = []string{"EntrustNET CA:Specific End Date"}
+		case util.IssuerHintAllIssuers:
+			attributeNames = []string{
+				"Microsoft CA:Specific End Date",
+				"DigiCert CA:Specific End Date",
+				"EntrustNET CA:Specific End Date",
+				"Specific End Date",
+			}
+		case util.IssuerHintGeneric:
+			attributeNames = []string{"Specific End Date"}
 		default:
-			expirationDateAttribute = "Specific End Date"
+			return tppReq, fmt.Errorf("invalid issuer hint: %s", req.IssuerHint)
 		}
 
-		loc, _ := time.LoadLocation("UTC")
-		utcNow := time.Now().In(loc)
-
-		//if the days have decimal parts then round it to next day.
-		validityDays := req.ValidityHours / 24
-
-		if req.ValidityHours%24 > 0 {
-
-			validityDays = validityDays + 1
-
+		for _, attributeName := range attributeNames {
+			tppReq.CASpecificAttributes = append(tppReq.CASpecificAttributes, nameValuePair{
+				Name:  attributeName,
+				Value: formattedExpirationDate,
+			})
 		}
-
-		expirationDate := utcNow.AddDate(0, 0, validityDays)
-
-		formattedExpirationDate := fmt.Sprintf("%d-%02d-%02d %02d:%02d:%02d",
-			expirationDate.Year(), expirationDate.Month(), expirationDate.Day(), expirationDate.Hour(), expirationDate.Minute(), expirationDate.Second())
-
-		tppReq.CASpecificAttributes = append(tppReq.CASpecificAttributes, nameValuePair{Name: expirationDateAttribute, Value: formattedExpirationDate})
 	}
 
 	for name, value := range customFieldsMap {

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -515,7 +515,7 @@ func TestRequestCertificateToken(t *testing.T) {
 	DoRequestCertificate(t, tpp)
 }
 
-func TestRequestCertificateWithValidHours(t *testing.T) {
+func TestRequestCertificateWithValidityHours(t *testing.T) {
 	tpp, err := getTestConnector(ctx.TPPurl, ctx.TPPZone)
 	if err != nil {
 		t.Fatalf("err is not nil, err: %s url: %s", err, expectedURL)
@@ -527,7 +527,22 @@ func TestRequestCertificateWithValidHours(t *testing.T) {
 			t.Fatalf("err is not nil, err: %s", err)
 		}
 	}
-	DoRequestCertificateWithValidHours(t, tpp)
+	DoRequestCertificateWithValidityHours(t, tpp)
+}
+
+func TestRequestCertificateWithValidityDuration(t *testing.T) {
+	tpp, err := getTestConnector(ctx.TPPurl, ctx.TPPZone)
+	if err != nil {
+		t.Fatalf("err is not nil, err: %s url: %s", err, expectedURL)
+	}
+
+	if tpp.apiKey == "" {
+		err = tpp.Authenticate(&endpoint.Authentication{AccessToken: ctx.TPPaccessToken})
+		if err != nil {
+			t.Fatalf("err is not nil, err: %s", err)
+		}
+	}
+	DoRequestCertificateWithValidityDuration(t, tpp)
 }
 
 // The reason we are using a mock HTTP server rather than the live TPP server is

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -774,9 +774,9 @@ func DoRequestCertificateWithValidHours(t *testing.T, tpp *Connector) {
 		{Name: "custom", Value: "2019-10-10"},
 	}
 
-	validHours := 144
-	req.ValidityHours = validHours
-	req.IssuerHint = "MICROSOFT"
+	validDuration := 144 * time.Hour * 24
+	req.ValidityDuration = &validDuration
+	req.IssuerHint = util.IssuerHintMicrosoft
 
 	err = tpp.GenerateRequest(config, req)
 	if err != nil {
@@ -803,8 +803,7 @@ func DoRequestCertificateWithValidHours(t *testing.T, tpp *Connector) {
 	//need to convert local date on utc, since the certificate' NotAfter value we got on previous step, is on utc
 	//so for comparing them we need to have both dates on utc.
 	loc, _ := time.LoadLocation("UTC")
-	utcNow := time.Now().In(loc)
-	expectedValidDate := utcNow.AddDate(0, 0, validHours/24).Format("2006-01-02")
+	expectedValidDate := time.Now().Add(validDuration).In(loc).Format("2006-01-02")
 
 	if expectedValidDate != certValidUntil {
 		t.Fatalf("Expiration date is different than expected, expected: %s, but got %s: ", expectedValidDate, certValidUntil)


### PR DESCRIPTION
The current ValidityHours option is too limiting when using VCert as a Go library.
Instead, I introduced the ValidityDuration option in this PR.
This option:
- allows creating certificates that are valid for:
  - < 1day (currently not supported in combination with TPP)
  - < 1hour (currently not supported in combination with TPP & VaaS)
- adds a new option "ALL_ISSUERS" to the `issuerHint`; when you use this option, all known issuer-specific "Specific End Date" attributes will be send to TPP.