### PR TITLE
Provide user with useful error message in case VaaS API Key is invalid

### DIFF
--- a/pkg/venafi/cloud/cloud.go
+++ b/pkg/venafi/cloud/cloud.go
@@ -371,7 +371,13 @@ func parseUserDetailsResult(expectedStatusCode int, httpStatusCode int, httpStat
 	}
 	respErrors, err := parseResponseErrors(body)
 	if err != nil {
-		return nil, err // parseResponseErrors always return verror.ServerError
+		// Parsing the error failed, return the original error
+		bodyText := strings.TrimSpace(string(body))
+		if bodyText == "" {
+			return nil, fmt.Errorf("%w: %s", verror.ServerError, httpStatus)
+		}
+
+		return nil, fmt.Errorf("%w: %s, %s", verror.ServerError, httpStatus, bodyText)
 	}
 	respError := fmt.Sprintf("unexpected status code on Venafi Cloud registration. Status: %s\n", httpStatus)
 	for _, e := range respErrors {


### PR DESCRIPTION
Currently, I get the following errors in case I'm using an invalid API key for VaaS:
```console
$ vcert enroll -k xxxxxxxx-xxxx-xxxxx-xxxxxx-xxxxxxxxxx -z "a\a" --cn dd
Enter key passphrase:
Verifying - Enter key passphrase:
vCert: 2023/06/15 15:51:02 Unable to connect to Venafi as a Service: vcert error: server error: invalid character 'I' looking for beginning of value
vCert: 2023/06/15 15:51:02 vcert error: must be autheticated to retrieve certificate
$ vcert enroll -k aa -z "a\a" --cn dd
Enter key passphrase:
Verifying - Enter key passphrase:
vCert: 2023/06/15 15:51:10 Unable to connect to Venafi as a Service: vcert error: server error: unexpected end of JSON input
vCert: 2023/06/15 15:51:10 vcert error: must be autheticated to retrieve certificate
```

This PR makes it so the user receives much more useful feedback:
```console
$ vcert enroll -k xxxxxxxx-xxxx-xxxxx-xxxxxx-xxxxxxxxxx -z "a\a" --cn dd
Enter key passphrase:
Verifying - Enter key passphrase:
vCert: 2023/06/15 15:50:22 Unable to connect to Venafi as a Service: vcert error: server error: 401 Unauthorized, Invalid api key
vCert: 2023/06/15 15:50:22 vcert error: must be autheticated to retrieve certificate
$ vcert enroll -k aa -z "a\a" --cn dd
Enter key passphrase:
Verifying - Enter key passphrase:
vCert: 2023/06/15 15:50:30 Unable to connect to Venafi as a Service: vcert error: server error: 401 Unauthorized
vCert: 2023/06/15 15:50:30 vcert error: must be autheticated to retrieve certificate
```