### PR TITLE
Adds ValidityDuration in favor of deprecating ValiditityHours

### DIFF
--- a/cmd/vcert/utils.go
+++ b/cmd/vcert/utils.go
@@ -2,6 +2,7 @@
  * Copyright 2018-2021 Venafi, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
+
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -183,32 +184,26 @@ func fillCertificateRequest(req *certificate.Request, cf *commandFlags) *certifi
 	}
 
 	if cf.validDays != "" {
-		validDays := cf.validDays
-
-		data := strings.Split(validDays, "#")
+		data := strings.Split(cf.validDays, "#")
 		days, _ := strconv.ParseInt(data[0], 10, 64)
-		hours := days * 24
+		duration := time.Duration(days) * time.Hour * 24
 
-		req.ValidityHours = int(hours)
+		req.ValidityDuration = &duration
 
-		issuerHint := ""
-		if len(data) > 1 { //means that issuer hint is set
+		if len(data) > 1 { // means that issuer hint is set
+			var issuerHint util.IssuerHint
 
-			option := strings.ToLower(data[1])
-
-			switch option {
-
+			switch strings.ToLower(data[1]) {
 			case "m":
 				issuerHint = util.IssuerHintMicrosoft
 			case "d":
 				issuerHint = util.IssuerHintDigicert
 			case "e":
 				issuerHint = util.IssuerHintEntrust
-
 			}
-		}
 
-		req.IssuerHint = issuerHint
+			req.IssuerHint = issuerHint
+		}
 	}
 
 	return req

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -26,16 +26,18 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"github.com/Venafi/vcert/v4/pkg/util"
-	"github.com/youmark/pkcs8"
 	"net"
 	"net/url"
 	"strings"
 	"time"
 
-	"github.com/Venafi/vcert/v4/pkg/verror"
+	"github.com/Venafi/vcert/v4/pkg/util"
+	"github.com/youmark/pkcs8"
+
 	"reflect"
 	"sort"
+
+	"github.com/Venafi/vcert/v4/pkg/verror"
 )
 
 // EllipticCurve represents the types of supported elliptic curves
@@ -205,12 +207,15 @@ type Request struct {
 	FetchPrivateKey bool
 	/*	Thumbprint is here because *Request is used in RetrieveCertificate().
 		Code should be refactored so that RetrieveCertificate() uses some abstract search object, instead of *Request{PickupID} */
-	Thumbprint    string
-	Timeout       time.Duration
-	CustomFields  []CustomField
-	Location      *Location
+	Thumbprint       string
+	Timeout          time.Duration
+	CustomFields     []CustomField
+	Location         *Location
+	ValidityDuration *time.Duration
+	IssuerHint       util.IssuerHint
+
+	// DEPRECATED: use ValidityDuration instead, this field is ignored if ValidityDuration is set
 	ValidityHours int
-	IssuerHint    string
 }
 
 //SSH Certificate structures

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -1,9 +1,16 @@
 package util
 
 const (
-	IssuerHintMicrosoft     = "MICROSOFT"
-	IssuerHintDigicert      = "DIGICERT"
-	IssuerHintEntrust       = "ENTRUST"
 	PathSeparator           = "\\"
 	ApplicationServerTypeID = "784938d1-ef0d-11eb-9461-7bb533ba575b"
+)
+
+type IssuerHint string
+
+const (
+	IssuerHintMicrosoft  IssuerHint = "MICROSOFT"
+	IssuerHintDigicert   IssuerHint = "DIGICERT"
+	IssuerHintEntrust    IssuerHint = "ENTRUST"
+	IssuerHintAllIssuers IssuerHint = "ALL_ISSUERS"
+	IssuerHintGeneric    IssuerHint = ""
 )

--- a/pkg/venafi/cloud/connector_test.go
+++ b/pkg/venafi/cloud/connector_test.go
@@ -178,7 +178,7 @@ func TestRequestCertificateWithUsageMetadata(t *testing.T) {
 	}
 }
 
-func TestRequestCertificateWithValidDays(t *testing.T) {
+func TestRequestCertificateWithValidityHours(t *testing.T) {
 	conn := getTestConnector(ctx.CloudZone)
 	conn.verbose = true
 	err := conn.Authenticate(&endpoint.Authentication{APIKey: ctx.CloudAPIkey})
@@ -195,9 +195,9 @@ func TestRequestCertificateWithValidDays(t *testing.T) {
 	req.Subject.Organization = []string{"Venafi, Inc."}
 	req.Subject.OrganizationalUnit = []string{"Automated Tests"}
 
-	validHours := 144
-	req.ValidityHours = validHours
-	req.IssuerHint = "MICROSOFT"
+	nrHours := 144
+	req.ValidityHours = nrHours
+	req.IssuerHint = util.IssuerHintMicrosoft
 
 	err = conn.GenerateRequest(zoneConfig, req)
 	if err != nil {
@@ -244,8 +244,81 @@ func TestRequestCertificateWithValidDays(t *testing.T) {
 	//need to convert local date on utc, since the certificate' NotAfter value we got on previous step, is on utc
 	//so for comparing them we need to have both dates on utc.
 	loc, _ := time.LoadLocation("UTC")
-	utcNow := time.Now().In(loc)
-	expectedValidDate := utcNow.AddDate(0, 0, validHours/24).Format("2006-01-02")
+	expectedValidDate := time.Now().Add(time.Duration(nrHours) * time.Hour).In(loc).Format("2006-01-02")
+
+	if expectedValidDate != certValidUntil {
+		t.Fatalf("Expiration date is different than expected, expected: %s, but got %s: ", expectedValidDate, certValidUntil)
+	}
+
+}
+
+func TestRequestCertificateWithValidityDuration(t *testing.T) {
+	conn := getTestConnector(ctx.CloudZone)
+	conn.verbose = true
+	err := conn.Authenticate(&endpoint.Authentication{APIKey: ctx.CloudAPIkey})
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	zoneConfig, err := conn.ReadZoneConfiguration()
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	req := &certificate.Request{}
+	req.Subject.CommonName = test.RandCN()
+	req.Subject.Organization = []string{"Venafi, Inc."}
+	req.Subject.OrganizationalUnit = []string{"Automated Tests"}
+
+	validDuration := 144 * time.Hour
+	req.ValidityDuration = &validDuration
+	req.IssuerHint = util.IssuerHintMicrosoft
+
+	err = conn.GenerateRequest(zoneConfig, req)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	pickupID, err := conn.RequestCertificate(req)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	req.PickupID = pickupID
+	req.ChainOption = certificate.ChainOptionRootLast
+
+	pcc, _ := certificate.NewPEMCollection(nil, nil, nil)
+	startTime := time.Now()
+	for {
+
+		pcc, err = conn.RetrieveCertificate(req)
+		if err != nil {
+			_, ok := err.(endpoint.ErrCertificatePending)
+			if ok {
+				if time.Now().After(startTime.Add(time.Duration(600) * time.Second)) {
+					err = endpoint.ErrRetrieveCertificateTimeout{CertificateID: pickupID}
+					break
+				}
+				time.Sleep(time.Duration(10) * time.Second)
+				continue
+			}
+			break
+		}
+		break
+	}
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	p, _ := pem.Decode([]byte(pcc.Certificate))
+	cert, err := x509.ParseCertificate(p.Bytes)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	certValidUntil := cert.NotAfter.Format("2006-01-02")
+
+	//need to convert local date on utc, since the certificate' NotAfter value we got on previous step, is on utc
+	//so for comparing them we need to have both dates on utc.
+	loc, _ := time.LoadLocation("UTC")
+	expectedValidDate := time.Now().Add(validDuration).In(loc).Format("2006-01-02")
 
 	if expectedValidDate != certValidUntil {
 		t.Fatalf("Expiration date is different than expected, expected: %s, but got %s: ", expectedValidDate, certValidUntil)


### PR DESCRIPTION
From: https://github.com/Venafi/vcert/pull/285

> The current ValidityHours option is too limiting when using VCert as a Go library.
> Instead, I introduced the ValidityDuration option in this PR.
> This option:
> - allows creating certificates that are valid for:
>   - < 1day (currently not supported in combination with TPP)
>   - < 1hour (currently not supported in combination with TPP & VaaS)
> - adds a new option "ALL_ISSUERS" to the `issuerHint`; when you use this option, all known issuer-specific "Specific End Date" attributes will be send to TPP.

Doing this PR as other one #285 got on bad state due to rebase.
