### PR TITLE
NewRequest: set KeyCurve in NewRequest and add support for ed25519 for local CSR on VaaS

### DIFF
--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -119,6 +119,8 @@ func (kt *KeyType) X509Type() x509.PublicKeyAlgorithm {
 		return x509.RSA
 	case KeyTypeECDSA:
 		return x509.ECDSA
+	case KeyTypeED25519:
+		return x509.Ed25519
 	}
 	return x509.UnknownPublicKeyAlgorithm
 }
@@ -141,6 +143,8 @@ const (
 	KeyTypeRSA KeyType = iota
 	// KeyTypeECDSA represents a key type of ECDSA
 	KeyTypeECDSA
+	// KeyTypeED25519 represents a ket ype of ED25519
+	KeyTypeED25519
 )
 
 type CSrOriginOption int
@@ -521,6 +525,8 @@ func (request *Request) GeneratePrivateKey() error {
 	switch request.KeyType {
 	case KeyTypeECDSA:
 		request.PrivateKey, err = GenerateECDSAPrivateKey(request.KeyCurve)
+	case KeyTypeED25519:
+		request.PrivateKey, err = GenerateED25519PrivateKey()
 	case KeyTypeRSA:
 		if request.KeyLength == 0 {
 			request.KeyLength = defaultRSAlength
@@ -571,6 +577,15 @@ func (request *Request) CheckCertificate(certPEM string) error {
 			}
 			if certPubkey.X.Cmp(reqPubkey.X) != 0 {
 				return fmt.Errorf("%w: unmatched X for elliptic keys", verror.CertificateCheckError)
+			}
+		case x509.Ed25519:
+			certPubkey := cert.PublicKey.(ed25519.PublicKey)
+			reqPubkey, ok := request.PrivateKey.Public().(ed25519.PublicKey)
+			if !ok {
+				return fmt.Errorf("%w: request KeyType not matched with real PrivateKey type", verror.CertificateCheckError)
+			}
+			if !certPubkey.Equal(reqPubkey) {
+				return fmt.Errorf("%w: unmatched elliptic ed25519 keys", verror.CertificateCheckError)
 			}
 		default:
 			return fmt.Errorf("%w: unknown key algorythm %d", verror.CertificateCheckError, cert.PublicKeyAlgorithm)
@@ -647,6 +662,16 @@ func GetPrivateKeyPEMBock(key crypto.Signer, format ...string) (*pem.Block, erro
 			}
 			return &pem.Block{Type: "PRIVATE KEY", Bytes: dataBytes}, err
 		}
+	case ed25519.PrivateKey:
+		if currentFormat == "legacy-pem" {
+			return nil, fmt.Errorf("%w: unable to format Key. Legacy format for ed25519 is not supported", verror.VcertError)
+		} else {
+			dataBytes, err := pkcs8.MarshalPrivateKey(key.(ed25519.PrivateKey), nil, nil)
+			if err != nil {
+				return nil, err
+			}
+			return &pem.Block{Type: "PRIVATE KEY", Bytes: dataBytes}, err
+		}
 	default:
 		return nil, fmt.Errorf("%w: unable to format Key", verror.VcertError)
 	}
@@ -683,6 +708,16 @@ func GetEncryptedPrivateKeyPEMBock(key crypto.Signer, password []byte, format ..
 			}
 			return &pem.Block{Type: "ENCRYPTED PRIVATE KEY", Bytes: dataBytes}, err
 		}
+	case ed25519.PrivateKey:
+		if currentFormat == "legacy-pem" {
+			return nil, fmt.Errorf("%w: unable to format Key. Legacy format for ed25519 is not supported", verror.VcertError)
+		} else {
+			dataBytes, err := pkcs8.MarshalPrivateKey(key.(ed25519.PrivateKey), password, nil)
+			if err != nil {
+				return nil, err
+			}
+			return &pem.Block{Type: "ENCRYPTED PRIVATE KEY", Bytes: dataBytes}, err
+		}
 	default:
 		return nil, fmt.Errorf("%w: unable to format Key", verror.VcertError)
 	}
@@ -707,14 +742,6 @@ func GenerateECDSAPrivateKey(curve EllipticCurve) (crypto.Signer, error) {
 		curve = EllipticCurveDefault
 	}
 
-	if curve == EllipticCurveED25519 {
-		_, priv, err = ed25519.GenerateKey(rand.Reader)
-		if err != nil {
-			return nil, err
-		}
-		return priv, nil
-	}
-
 	switch curve {
 	case EllipticCurveP521:
 		c = elliptic.P521()
@@ -729,6 +756,14 @@ func GenerateECDSAPrivateKey(curve EllipticCurve) (crypto.Signer, error) {
 		return nil, err
 	}
 
+	return priv, nil
+}
+
+func GenerateED25519PrivateKey() (crypto.Signer, error) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
 	return priv, nil
 }
 
@@ -761,11 +796,9 @@ func NewRequest(cert *x509.Certificate) *Request {
 		req.KeyLength = pub.N.BitLen()
 	case *ecdsa.PublicKey:
 		req.KeyType = KeyTypeECDSA
-		req.KeyLength = pub.Curve.Params().BitSize
 		_ = req.KeyCurve.Set(pub.Curve.Params().Name)
 	case ed25519.PublicKey:
-		req.KeyType = KeyTypeECDSA
-		req.KeyLength = 256
+		req.KeyType = KeyTypeED25519
 		_ = req.KeyCurve.Set("ed25519")
 	default:
 		// vcert only works with RSA, ECDSA & Ed25519 keys

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -699,13 +699,22 @@ func GetCertificateRequestPEMBlock(request []byte) *pem.Block {
 }
 
 // GenerateECDSAPrivateKey generates a new ecdsa private key using the curve specified
-func GenerateECDSAPrivateKey(curve EllipticCurve) (*ecdsa.PrivateKey, error) {
-	var priv *ecdsa.PrivateKey
+func GenerateECDSAPrivateKey(curve EllipticCurve) (crypto.Signer, error) {
+	var priv crypto.Signer
 	var c elliptic.Curve
 	var err error
 	if curve == EllipticCurveNotSet {
 		curve = EllipticCurveDefault
 	}
+
+	if curve == EllipticCurveED25519 {
+		_, priv, err = ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			return nil, err
+		}
+		return priv, nil
+	}
+
 	switch curve {
 	case EllipticCurveP521:
 		c = elliptic.P521()

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -135,7 +135,9 @@ func (kt *KeyType) Set(value, curveValue string) error {
 		return nil
 	case "ecdsa", "ec", "ecc":
 		curve := EllipticCurveNotSet
-		curve.Set(curveValue)
+		if err := curve.Set(curveValue); err != nil {
+			return err
+		}
 		if curve == EllipticCurveED25519 {
 			*kt = KeyTypeED25519
 			return nil

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -19,6 +19,7 @@ package certificate
 import (
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
@@ -752,9 +753,13 @@ func NewRequest(cert *x509.Certificate) *Request {
 	case *ecdsa.PublicKey:
 		req.KeyType = KeyTypeECDSA
 		req.KeyLength = pub.Curve.Params().BitSize
-		// TODO: req.KeyCurve = pub.Curve.Params().Name ...
-	default: // case *dsa.PublicKey
-		// vcert only works with RSA & ECDSA
+		_ = req.KeyCurve.Set(pub.Curve.Params().Name)
+	case ed25519.PublicKey:
+		req.KeyType = KeyTypeECDSA
+		req.KeyLength = 256
+		_ = req.KeyCurve.Set("ed25519")
+	default:
+		// vcert only works with RSA, ECDSA & Ed25519 keys
 	}
 	return req
 }

--- a/pkg/certificate/certificate_test.go
+++ b/pkg/certificate/certificate_test.go
@@ -197,7 +197,7 @@ func TestGenerateCertificateRequestWithECDSAKey(t *testing.T) {
 func TestGenerateCertificateRequestWithED25519Key(t *testing.T) {
 	req := getCertificateRequestForTest()
 	var err error
-	req.PrivateKey, err = GenerateECDSAPrivateKey(EllipticCurveED25519)
+	req.PrivateKey, err = GenerateED25519PrivateKey()
 	if err != nil {
 		t.Fatalf("Error generating RSA Private Key\nError: %s", err)
 	}
@@ -570,7 +570,7 @@ func Test_NewRequest(t *testing.T) {
 		t.Fatalf("Error generating ECDSA Private Key\nError: %s", err)
 	}
 
-	ed25519Pk, err := GenerateECDSAPrivateKey(EllipticCurveED25519)
+	ed25519Pk, err := GenerateED25519PrivateKey()
 	if err != nil {
 		t.Fatalf("Error generating ECDSA Private Key\nError: %s", err)
 	}
@@ -592,14 +592,14 @@ func Test_NewRequest(t *testing.T) {
 			certificate: &x509.Certificate{
 				PublicKey: ecdsaPk.Public(),
 			},
-			expRequest: Request{KeyType: KeyTypeECDSA, KeyCurve: EllipticCurveP256, KeyLength: 256},
+			expRequest: Request{KeyType: KeyTypeECDSA, KeyCurve: EllipticCurveP256},
 		},
 		{
 			name: "ed25519 key",
 			certificate: &x509.Certificate{
 				PublicKey: ed25519Pk.Public(),
 			},
-			expRequest: Request{KeyType: KeyTypeECDSA, KeyCurve: EllipticCurveED25519, KeyLength: 256},
+			expRequest: Request{KeyType: KeyTypeED25519, KeyCurve: EllipticCurveED25519},
 		},
 	}
 	for _, c := range cases {

--- a/pkg/certificate/certificate_test.go
+++ b/pkg/certificate/certificate_test.go
@@ -289,21 +289,33 @@ func TestKeyTypeString(t *testing.T) {
 
 func TestKeyTypeSetByString(t *testing.T) {
 	keyType := KeyTypeRSA
-	keyType.Set("rsa")
+	keyType.Set("rsa", "")
 	if keyType != KeyTypeRSA {
 		t.Fatalf("Unexpected string value was returned.  Expected: RSA Actual: %s", keyType.String())
 	}
-	keyType.Set("RSA")
+	keyType.Set("RSA", "")
 	if keyType != KeyTypeRSA {
 		t.Fatalf("Unexpected string value was returned.  Expected: RSA Actual: %s", keyType.String())
 	}
-	keyType.Set("ecdsa")
+	keyType.Set("ecdsa", "")
 	if keyType != KeyTypeECDSA {
 		t.Fatalf("Unexpected string value was returned.  Expected: ECDSA Actual: %s", keyType.String())
 	}
-	keyType.Set("ECDSA")
+	keyType.Set("ECDSA", "p384")
 	if keyType != KeyTypeECDSA {
 		t.Fatalf("Unexpected string value was returned.  Expected: ECDSA Actual: %s", keyType.String())
+	}
+	keyType.Set("ECDSA", "p384")
+	if keyType != KeyTypeECDSA {
+		t.Fatalf("Unexpected string value was returned.  Expected: ECDSA Actual: %s", keyType.String())
+	}
+	keyType.Set("EC", "p384")
+	if keyType != KeyTypeECDSA {
+		t.Fatalf("Unexpected string value was returned.  Expected: ECDSA Actual: %s", keyType.String())
+	}
+	keyType.Set("EC", "ed25519")
+	if keyType != KeyTypeED25519 {
+		t.Fatalf("Unexpected string value was returned.  Expected: ED25519 Actual: %s", keyType.String())
 	}
 }
 

--- a/pkg/certificate/certificate_test.go
+++ b/pkg/certificate/certificate_test.go
@@ -194,6 +194,35 @@ func TestGenerateCertificateRequestWithECDSAKey(t *testing.T) {
 	}
 }
 
+func TestGenerateCertificateRequestWithED25519Key(t *testing.T) {
+	req := getCertificateRequestForTest()
+	var err error
+	req.PrivateKey, err = GenerateECDSAPrivateKey(EllipticCurveED25519)
+	if err != nil {
+		t.Fatalf("Error generating RSA Private Key\nError: %s", err)
+	}
+
+	err = req.GenerateCSR()
+	if err != nil {
+		t.Fatalf("Error generating Certificate Request\nError: %s", err)
+	}
+
+	pemBlock, _ := pem.Decode(req.GetCSR())
+	if pemBlock == nil {
+		t.Fatalf("Failed to decode CSR as PEM")
+	}
+
+	parsedReq, err := x509.ParseCertificateRequest(pemBlock.Bytes)
+	if err != nil {
+		t.Fatalf("Error parsing generated Certificate Request\nError: %s", err)
+	}
+
+	err = parsedReq.CheckSignature()
+	if err != nil {
+		t.Fatalf("Error checking signature of generated Certificate Request\nError: %s", err)
+	}
+}
+
 func TestEllipticCurveString(t *testing.T) {
 	curve := EllipticCurveP521
 	stringCurve := curve.String()

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -271,7 +271,7 @@ func TestBadKeyTypeValiateRequest(t *testing.T) {
 	}
 }
 
-func TestBadKeySizeValiateRequest(t *testing.T) {
+func TestBadKeySizeValidateRequest(t *testing.T) {
 	req := new(certificate.Request)
 	req.KeyType = certificate.KeyTypeRSA
 	req.KeyLength = 8192
@@ -288,7 +288,7 @@ func TestBadKeySizeValiateRequest(t *testing.T) {
 	}
 }
 
-func TestED25519KeyValiateRequest(t *testing.T) {
+func TestED25519KeyValidateRequest(t *testing.T) {
 	req := new(certificate.Request)
 	req.KeyType = certificate.KeyTypeED25519
 	req.KeyCurve = certificate.EllipticCurveED25519
@@ -297,9 +297,6 @@ func TestED25519KeyValiateRequest(t *testing.T) {
 	z.AllowedKeyConfigurations = []AllowedKeyConfiguration{
 		{
 			KeyType: certificate.KeyTypeED25519,
-			KeyCurves: []certificate.EllipticCurve{
-				certificate.EllipticCurveED25519,
-			},
 		},
 	}
 

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -18,10 +18,11 @@ package endpoint
 
 import (
 	"crypto/x509"
-	"github.com/Venafi/vcert/v4/pkg/certificate"
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/Venafi/vcert/v4/pkg/certificate"
 )
 
 func TestNewZoneConfiguration(t *testing.T) {
@@ -153,6 +154,9 @@ func TestBadCNValiateRequest(t *testing.T) {
 	if err == nil {
 		t.Fatalf("CN should not have matched")
 	}
+	if !strings.HasSuffix(err.Error(), "common name vcert.test.bonjo.com is not allowed in this policy: [.*.vfidev.com .*.venafi.com]") {
+		t.Fatalf("Got unexpected error: %s", err)
+	}
 }
 
 func TestBadOValiateRequest(t *testing.T) {
@@ -165,6 +169,9 @@ func TestBadOValiateRequest(t *testing.T) {
 	err := z.ValidateCertificateRequest(req)
 	if err == nil {
 		t.Fatalf("O should not have matched")
+	}
+	if !strings.HasSuffix(err.Error(), "organization [Bonjo Org] doesn't match regular expressions: [Venafi.*]") {
+		t.Fatalf("Got unexpected error: %s", err)
 	}
 }
 
@@ -179,6 +186,9 @@ func TestBadOUValiateRequest(t *testing.T) {
 	if err == nil {
 		t.Fatalf("OU should not have matched")
 	}
+	if !strings.HasSuffix(err.Error(), "organization unit [Oddballs Squares] doesn't match regular expressions: [Venafi Venafi, Inc.]") {
+		t.Fatalf("Got unexpected error: %s", err)
+	}
 }
 
 func TestBadLValiateRequest(t *testing.T) {
@@ -191,6 +201,9 @@ func TestBadLValiateRequest(t *testing.T) {
 	err := z.ValidateCertificateRequest(req)
 	if err == nil {
 		t.Fatalf("L should not have matched")
+	}
+	if !strings.HasSuffix(err.Error(), "location [Not in SLC] doesn't match regular expressions: [^(SLC|Salt Lake City)]") {
+		t.Fatalf("Got unexpected error: %s", err)
 	}
 }
 
@@ -205,6 +218,9 @@ func TestBadSTValiateRequest(t *testing.T) {
 	if err == nil {
 		t.Fatalf("ST should not have matched")
 	}
+	if !strings.HasSuffix(err.Error(), "state (province) [CO] doesn't match regular expressions: [(UT|Utah)]") {
+		t.Fatalf("Got unexpected error: %s", err)
+	}
 }
 
 func TestBadCValiateRequest(t *testing.T) {
@@ -217,6 +233,9 @@ func TestBadCValiateRequest(t *testing.T) {
 	err := z.ValidateCertificateRequest(req)
 	if err == nil {
 		t.Fatalf("C should not have matched")
+	}
+	if !strings.HasSuffix(err.Error(), "country [USA] doesn't match regular expressions: [^US$]") {
+		t.Fatalf("Got unexpected error: %s", err)
 	}
 }
 
@@ -231,6 +250,9 @@ func TestBadSANValiateRequest(t *testing.T) {
 	if err == nil {
 		t.Fatalf("SANs should not have matched")
 	}
+	if !strings.HasSuffix(err.Error(), "DNS SANs [vcert.test.venafi.com vcert.test1.venafi.com] do not match regular expressions: [.*.vfidev.com]") {
+		t.Fatalf("Got unexpected error: %s", err)
+	}
 }
 
 func TestBadKeyTypeValiateRequest(t *testing.T) {
@@ -243,6 +265,9 @@ func TestBadKeyTypeValiateRequest(t *testing.T) {
 	err := z.ValidateCertificateRequest(req)
 	if err == nil {
 		t.Fatalf("Key type ECDSA should not have been ok")
+	}
+	if !strings.HasSuffix(err.Error(), "the requested Key Type and Size do not match any of the allowed Key Types and Sizes") {
+		t.Fatalf("Got unexpected error: %s", err)
 	}
 }
 
@@ -258,6 +283,30 @@ func TestBadKeySizeValiateRequest(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Key size 8192 should not have been ok")
 	}
+	if !strings.HasSuffix(err.Error(), "the requested Key Type and Size do not match any of the allowed Key Types and Sizes") {
+		t.Fatalf("Got unexpected error: %s", err)
+	}
+}
+
+func TestED25519KeyValiateRequest(t *testing.T) {
+	req := new(certificate.Request)
+	req.KeyType = certificate.KeyTypeED25519
+	req.KeyCurve = certificate.EllipticCurveED25519
+
+	z := getBaseZoneConfiguration()
+	z.AllowedKeyConfigurations = []AllowedKeyConfiguration{
+		{
+			KeyType: certificate.KeyTypeED25519,
+			KeyCurves: []certificate.EllipticCurve{
+				certificate.EllipticCurveED25519,
+			},
+		},
+	}
+
+	err := z.ValidateCertificateRequest(req)
+	if err != nil {
+		t.Fatalf("Got unexpected error: %s", err)
+	}
 }
 
 func getBaseZoneConfiguration() *ZoneConfiguration {
@@ -270,5 +319,12 @@ func getBaseZoneConfiguration() *ZoneConfiguration {
 	z.AllowedKeyConfigurations = []AllowedKeyConfiguration{{KeyType: certificate.KeyTypeRSA, KeySizes: []int{2048, 4096}}}
 	z.KeyConfiguration = &AllowedKeyConfiguration{KeyType: certificate.KeyTypeRSA, KeySizes: []int{4096}}
 	z.HashAlgorithm = x509.SHA512WithRSA
+
+	z.SubjectCNRegexes = []string{".*"}
+	z.SubjectORegexes = []string{".*"}
+	z.SubjectOURegexes = []string{".*"}
+	z.SubjectSTRegexes = []string{".*"}
+	z.SubjectLRegexes = []string{".*"}
+	z.SubjectCRegexes = []string{".*"}
 	return &z
 }

--- a/pkg/venafi/cloud/certificatePolicies.go
+++ b/pkg/venafi/cloud/certificatePolicies.go
@@ -119,11 +119,6 @@ func (ct certificateTemplate) toPolicy() (p endpoint.Policy) {
 	}
 	p.AllowWildcards = allowWildCards
 
-	// We seperate the EC keys into two groups, ED25519 and the rest
-	ed25519KeyConfiguration := endpoint.AllowedKeyConfiguration{
-		KeyType: certificate.KeyTypeED25519,
-	}
-
 	for _, kt := range ct.KeyTypes {
 		keyConfiguration := endpoint.AllowedKeyConfiguration{}
 		if err := keyConfiguration.KeyType.Set(string(kt.KeyType), ""); err != nil {
@@ -137,23 +132,10 @@ func (ct certificateTemplate) toPolicy() (p endpoint.Policy) {
 				panic(err)
 			}
 
-			if v == certificate.EllipticCurveED25519 {
-				ed25519KeyConfiguration.KeyCurves = append(ed25519KeyConfiguration.KeyCurves, v)
-				continue
-			}
-
 			keyConfiguration.KeyCurves = append(keyConfiguration.KeyCurves, v)
 		}
-
-		if len(keyConfiguration.KeySizes) > 0 || len(keyConfiguration.KeyCurves) > 0 {
-			p.AllowedKeyConfigurations = append(p.AllowedKeyConfigurations, keyConfiguration)
-		}
+		p.AllowedKeyConfigurations = append(p.AllowedKeyConfigurations, keyConfiguration)
 	}
-
-	if len(ed25519KeyConfiguration.KeyCurves) > 0 {
-		p.AllowedKeyConfigurations = append(p.AllowedKeyConfigurations, ed25519KeyConfiguration)
-	}
-
 	return
 }
 

--- a/pkg/venafi/cloud/cloud.go
+++ b/pkg/venafi/cloud/cloud.go
@@ -22,8 +22,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/Venafi/vcert/v4/pkg/policy"
-	"github.com/Venafi/vcert/v4/pkg/util"
 	"io"
 	"io/ioutil"
 	"log"
@@ -33,6 +31,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/Venafi/vcert/v4/pkg/policy"
+	"github.com/Venafi/vcert/v4/pkg/util"
 
 	"github.com/Venafi/vcert/v4/pkg/verror"
 
@@ -251,6 +252,9 @@ func (c *Connector) GenerateRequest(config *endpoint.ZoneConfiguration, req *cer
 		return nil
 
 	case certificate.ServiceGeneratedCSR:
+		if req.KeyType == certificate.KeyTypeED25519 {
+			return fmt.Errorf("%w: ED25519 keys are not yet supported for Service Generated CSR", verror.UserDataError)
+		}
 		return nil
 
 	default:

--- a/pkg/venafi/cloud/connector_test.go
+++ b/pkg/venafi/cloud/connector_test.go
@@ -709,16 +709,33 @@ func TestReadPolicyConfigurationOnlyEC(t *testing.T) {
 		t.Fatalf("%s", err)
 	}
 	expectedPolice := endpoint.Policy{
-		SubjectCNRegexes:         []string{"^[a-z]{1}[a-z0-9.-]*\\.vfidev\\.com$"},
-		SubjectORegexes:          []string{"^Venafi Inc.$"},
-		SubjectOURegexes:         []string{"^Integrations$", "^Integration$"},
-		SubjectSTRegexes:         []string{"^Utah$"},
-		SubjectLRegexes:          []string{"^Salt Lake$"},
-		SubjectCRegexes:          []string{"^US$"},
-		AllowedKeyConfigurations: []endpoint.AllowedKeyConfiguration{{certificate.KeyTypeECDSA, nil, []certificate.EllipticCurve{certificate.EllipticCurveP256, certificate.EllipticCurveP384, certificate.EllipticCurveP521, certificate.EllipticCurveED25519}}},
-		DnsSanRegExs:             []string{"^[a-z]{1}[a-z0-9.-]*\\.vfidev\\.com$"},
-		AllowWildcards:           false,
-		AllowKeyReuse:            false,
+		SubjectCNRegexes: []string{"^[a-z]{1}[a-z0-9.-]*\\.vfidev\\.com$"},
+		SubjectORegexes:  []string{"^Venafi Inc.$"},
+		SubjectOURegexes: []string{"^Integrations$", "^Integration$"},
+		SubjectSTRegexes: []string{"^Utah$"},
+		SubjectLRegexes:  []string{"^Salt Lake$"},
+		SubjectCRegexes:  []string{"^US$"},
+		AllowedKeyConfigurations: []endpoint.AllowedKeyConfiguration{
+			{
+				KeyType:  certificate.KeyTypeECDSA,
+				KeySizes: nil,
+				KeyCurves: []certificate.EllipticCurve{
+					certificate.EllipticCurveP256,
+					certificate.EllipticCurveP384,
+					certificate.EllipticCurveP521,
+				},
+			},
+			{
+				KeyType:  certificate.KeyTypeED25519,
+				KeySizes: nil,
+				KeyCurves: []certificate.EllipticCurve{
+					certificate.EllipticCurveED25519,
+				},
+			},
+		},
+		DnsSanRegExs:   []string{"^[a-z]{1}[a-z0-9.-]*\\.vfidev\\.com$"},
+		AllowWildcards: false,
+		AllowKeyReuse:  false,
 	}
 
 	if !reflect.DeepEqual(*policy, expectedPolice) {

--- a/pkg/venafi/cloud/connector_test.go
+++ b/pkg/venafi/cloud/connector_test.go
@@ -147,6 +147,82 @@ func TestRequestCertificate(t *testing.T) {
 	}
 }
 
+func TestRequestCertificateED25519WithValidation(t *testing.T) {
+	conn := getTestConnector(ctx.VAASzoneEC)
+	conn.verbose = true
+	err := conn.Authenticate(&endpoint.Authentication{APIKey: ctx.CloudAPIkey})
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	req := certificate.Request{}
+	req.Subject.CommonName = test.RandSpecificCN("vfidev.com")
+	req.Subject.Organization = []string{"Venafi Inc."}
+	req.Subject.OrganizationalUnit = []string{"Integrations"}
+	req.Subject.Locality = []string{"Salt Lake"}
+	req.Subject.Province = []string{"Utah"}
+	req.Subject.Country = []string{"US"}
+	req.KeyType = certificate.KeyTypeED25519
+
+	zoneConfig, err := conn.ReadZoneConfiguration()
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	err = zoneConfig.ValidateCertificateRequest(&req)
+	if err != nil {
+		t.Fatalf("could not validate certificate request: %s", err)
+	}
+
+	zoneConfig.UpdateCertificateRequest(&req)
+
+	err = conn.GenerateRequest(zoneConfig, &req)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	_, err = conn.RequestCertificate(&req)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+}
+
+func TestRequestCertificateED25519WithPolicyValidation(t *testing.T) {
+	conn := getTestConnector(ctx.VAASzoneEC)
+	conn.verbose = true
+	err := conn.Authenticate(&endpoint.Authentication{APIKey: ctx.CloudAPIkey})
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	req := certificate.Request{}
+	req.Subject.CommonName = test.RandSpecificCN("vfidev.com")
+	req.Subject.Organization = []string{"Venafi Inc."}
+	req.Subject.OrganizationalUnit = []string{"Integrations"}
+	req.Subject.Locality = []string{"Salt Lake"}
+	req.Subject.Province = []string{"Utah"}
+	req.Subject.Country = []string{"US"}
+	req.KeyType = certificate.KeyTypeED25519
+
+	policy, err := conn.ReadPolicyConfiguration()
+	if err != nil {
+		t.Fatalf("could not read policy config certificate request: %s", err)
+	}
+
+	err = policy.ValidateCertificateRequest(&req)
+	if err != nil {
+		t.Fatalf("could not validate certificate request from policy: %s", err)
+	}
+
+	err = conn.GenerateRequest(nil, &req)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	_, err = conn.RequestCertificate(&req)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+}
+
 func TestRequestCertificateWithUsageMetadata(t *testing.T) {
 	conn := getTestConnector(ctx.CloudZone)
 	conn.verbose = true
@@ -697,6 +773,9 @@ func TestReadPolicyConfiguration(t *testing.T) {
 }
 
 func TestReadPolicyConfigurationOnlyEC(t *testing.T) {
+	// IMPORTANT NOTE: Now in VCert, we are treating ED25519 Keys, as per it's a different algorithm from ECDSA, as another
+	// type of key. This is conflicting with how VaaS handles EC Keys, as it considers ED25519 as another curve, which is
+	// it shouldn't, this test may need to change in the future once this is solved
 	//todo: add more zones
 	conn := getTestConnector(ctx.VAASzoneEC)
 	err := conn.Authenticate(&endpoint.Authentication{APIKey: ctx.CloudAPIkey})
@@ -709,33 +788,16 @@ func TestReadPolicyConfigurationOnlyEC(t *testing.T) {
 		t.Fatalf("%s", err)
 	}
 	expectedPolice := endpoint.Policy{
-		SubjectCNRegexes: []string{"^[a-z]{1}[a-z0-9.-]*\\.vfidev\\.com$"},
-		SubjectORegexes:  []string{"^Venafi Inc.$"},
-		SubjectOURegexes: []string{"^Integrations$", "^Integration$"},
-		SubjectSTRegexes: []string{"^Utah$"},
-		SubjectLRegexes:  []string{"^Salt Lake$"},
-		SubjectCRegexes:  []string{"^US$"},
-		AllowedKeyConfigurations: []endpoint.AllowedKeyConfiguration{
-			{
-				KeyType:  certificate.KeyTypeECDSA,
-				KeySizes: nil,
-				KeyCurves: []certificate.EllipticCurve{
-					certificate.EllipticCurveP256,
-					certificate.EllipticCurveP384,
-					certificate.EllipticCurveP521,
-				},
-			},
-			{
-				KeyType:  certificate.KeyTypeED25519,
-				KeySizes: nil,
-				KeyCurves: []certificate.EllipticCurve{
-					certificate.EllipticCurveED25519,
-				},
-			},
-		},
-		DnsSanRegExs:   []string{"^[a-z]{1}[a-z0-9.-]*\\.vfidev\\.com$"},
-		AllowWildcards: false,
-		AllowKeyReuse:  false,
+		SubjectCNRegexes:         []string{"^[a-z]{1}[a-z0-9.-]*\\.vfidev\\.com$"},
+		SubjectORegexes:          []string{"^Venafi Inc.$"},
+		SubjectOURegexes:         []string{"^Integrations$", "^Integration$"},
+		SubjectSTRegexes:         []string{"^Utah$"},
+		SubjectLRegexes:          []string{"^Salt Lake$"},
+		SubjectCRegexes:          []string{"^US$"},
+		AllowedKeyConfigurations: []endpoint.AllowedKeyConfiguration{{certificate.KeyTypeECDSA, nil, []certificate.EllipticCurve{certificate.EllipticCurveP256, certificate.EllipticCurveP384, certificate.EllipticCurveP521, certificate.EllipticCurveED25519}}},
+		DnsSanRegExs:             []string{"^[a-z]{1}[a-z0-9.-]*\\.vfidev\\.com$"},
+		AllowWildcards:           false,
+		AllowKeyReuse:            false,
 	}
 
 	if !reflect.DeepEqual(*policy, expectedPolice) {

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -524,6 +524,10 @@ func (c *Connector) getHTTPClient() *http.Client {
 
 // GenerateRequest creates a new certificate request, based on the zone/policy configuration and the user data
 func (c *Connector) GenerateRequest(config *endpoint.ZoneConfiguration, req *certificate.Request) (err error) {
+	if req.KeyType == certificate.KeyTypeED25519 {
+		return fmt.Errorf("Unable to request certificate from TPP, ed25519 key type is not for TPP")
+	}
+
 	if config == nil {
 		config, err = c.ReadZoneConfiguration()
 		if err != nil {
@@ -537,7 +541,6 @@ func (c *Connector) GenerateRequest(config *endpoint.ZoneConfiguration, req *cer
 	}
 
 	config.UpdateCertificateRequest(req)
-
 	switch req.CsrOrigin {
 	case certificate.LocalGeneratedCSR:
 		if config.CustomAttributeValues[tppAttributeManualCSR] == "0" {

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -807,7 +807,7 @@ func (sp serverPolicy) toZoneConfig(zc *endpoint.ZoneConfiguration) {
 	zc.Province = sp.Subject.State.Value
 	zc.Locality = sp.Subject.City.Value
 	key := endpoint.AllowedKeyConfiguration{}
-	err := key.KeyType.Set(sp.KeyPair.KeyAlgorithm.Value)
+	err := key.KeyType.Set(sp.KeyPair.KeyAlgorithm.Value, sp.KeyPair.EllipticCurve.Value)
 	if err != nil {
 		return
 	}
@@ -930,7 +930,7 @@ func (sp serverPolicy) toPolicy() (p endpoint.Policy) {
 	}
 	if sp.KeyPair.KeyAlgorithm.Locked {
 		var keyType certificate.KeyType
-		if err := keyType.Set(sp.KeyPair.KeyAlgorithm.Value); err != nil {
+		if err := keyType.Set(sp.KeyPair.KeyAlgorithm.Value, sp.KeyPair.EllipticCurve.Value); err != nil {
 			panic(err)
 		}
 		key := endpoint.AllowedKeyConfiguration{KeyType: keyType}


### PR DESCRIPTION
Summary:

- The KeyCurve value was left empty in `NewRequest` for `ecdsa.PublicKey`s, this was marked as a TODO item in the code.
- This PR adds code to set the ED25519 `local` generated CSR support for VaaS
- Adds a test for this `NewRequest` function.
 - Added a switch case that sets KeyType for ed25519 keys.

EDIT: This PR does the above but support for ED25519 Keys are only available for local generate CSR's and, only supported by VaaS, so we have set up validation for any use related to TPP, since TPP doesn't support ED25519 keys for any of the supported methods. Also we have made necessary changes for this Keys, as they are using another type of algorithm different from ECDSA, there's a validation we do in:
`func (request *Request) CheckCertificate(certPEM string) error {`
that required us to treat ED25519 Keys as another different set of keys

**To be noted**, currently VaaS treats ED25519 Keys as another Key Curve for ECDSA, which is wrong but currently we are not doing change as of now, as it will impact how `Policy Management` is being used now.