### PR TITLE
Add reset TPP endpoint

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -87,6 +87,10 @@ type Connector interface {
 	ReadZoneConfiguration() (config *ZoneConfiguration, err error)
 	// GenerateRequest update certificate.Request with data from zone configuration.
 	GenerateRequest(config *ZoneConfiguration, req *certificate.Request) (err error)
+	// ResetCertificate resets the state of a TPP certificate.
+	// This function is idempotent, i.e., it won't fail if there is nothing to be reset.
+	// It returns an error of type *errCertNotFound if the certificate is not found.
+	ResetCertificate(req *certificate.Request, restart bool) (err error)
 	// RequestCertificate makes a request to the server with data for enrolling the certificate.
 	RequestCertificate(req *certificate.Request) (requestID string, err error)
 	// RetrieveCertificate immediately returns an enrolled certificate. Otherwise, RetrieveCertificate waits and retries during req.Timeout.

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -838,6 +838,11 @@ func getCloudRequest(c *Connector, req *certificate.Request) (*certificateReques
 	return &cloudReq, nil
 }
 
+// ResetCertificate resets the state of a certificate.
+func (c *Connector) ResetCertificate(req *certificate.Request, restart bool) (err error) {
+	return fmt.Errorf("not supported by endpoint")
+}
+
 // RequestCertificate submits the CSR to the Venafi Cloud API for processing
 func (c *Connector) RequestCertificate(req *certificate.Request) (requestID string, err error) {
 

--- a/pkg/venafi/fake/connector.go
+++ b/pkg/venafi/fake/connector.go
@@ -75,6 +75,10 @@ func (c *Connector) RetrieveSystemVersion() (response string, err error) {
 	panic("operation is not supported yet")
 }
 
+func (c *Connector) ResetCertificate(req *certificate.Request, restart bool) (err error) {
+	panic("operation is not supported yet")
+}
+
 func (c *Connector) GetPolicy(name string) (*policy.PolicySpecification, error) {
 
 	caName := "\\VED\\Policy\\Certificate Authorities\\TEST CA\\QA Test CA - Server 90 Days"

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -146,6 +146,15 @@ type certificateRenewResponse struct {
 	Error   string `json:",omitempty"`
 }
 
+type certificateResetRequest struct {
+	CertificateDN string `json:",omitempty"`
+	Restart       bool   `json:",omitempty"`
+}
+
+type certificateResetResponse struct {
+	Error string `json:"Error"`
+}
+
 type sanItem struct {
 	Type int    `json:""`
 	Name string `json:""`
@@ -355,6 +364,7 @@ const (
 	urlResourceCertificateRevoke      urlResource = "vedsdk/certificates/revoke"
 	urlResourceCertificatesAssociate  urlResource = "vedsdk/certificates/associate"
 	urlResourceCertificatesDissociate urlResource = "vedsdk/certificates/dissociate"
+	urlResourceCertificateReset       urlResource = "vedsdk/certificates/reset"
 	urlResourceCertificate            urlResource = "vedsdk/certificates/"
 	urlResourceCertificateSearch                  = urlResourceCertificate
 	urlResourceCertificatesList                   = urlResourceCertificate


### PR DESCRIPTION
https://github.com/Venafi/vcert/pull/274 has shown that it is very hard to find an auto-reset solution that works for all usecases.
For this reason, I propose that we add a low level ResetCertificate function which can be called only on the TPP Connector.
This function exposes a low-level endpoint to client libraries who want to use this functionality.