### PR TITLE
Fix bug in IsCertNotFound function & add use function in test

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -89,7 +89,7 @@ type Connector interface {
 	GenerateRequest(config *ZoneConfiguration, req *certificate.Request) (err error)
 	// ResetCertificate resets the state of a TPP certificate.
 	// This function is idempotent, i.e., it won't fail if there is nothing to be reset.
-	// It returns an error of type *errCertNotFound if the certificate is not found.
+	// It returns an error of type *tpp.ErrCertNotFound if the certificate is not found.
 	ResetCertificate(req *certificate.Request, restart bool) (err error)
 	// RequestCertificate makes a request to the server with data for enrolling the certificate.
 	RequestCertificate(req *certificate.Request) (requestID string, err error)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -88,9 +88,8 @@ type Connector interface {
 	ReadZoneConfiguration() (config *ZoneConfiguration, err error)
 	// GenerateRequest update certificate.Request with data from zone configuration.
 	GenerateRequest(config *ZoneConfiguration, req *certificate.Request) (err error)
-	// ResetCertificate resets the state of a TPP certificate.
+	// ResetCertificate resets the state of a certificate.
 	// This function is idempotent, i.e., it won't fail if there is nothing to be reset.
-	// It returns an error of type *tpp.ErrCertNotFound if the certificate is not found.
 	ResetCertificate(req *certificate.Request, restart bool) (err error)
 	// RequestCertificate makes a request to the server with data for enrolling the certificate.
 	RequestCertificate(req *certificate.Request) (requestID string, err error)

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -779,11 +779,12 @@ func (e *ErrCertNotFound) Unwrap() error {
 }
 
 func IsCertNotFound(err error) bool {
-	return errors.Is(err, &ErrCertNotFound{})
+	notFoundErr := &ErrCertNotFound{}
+	return errors.As(err, &notFoundErr)
 }
 
 // This function is idempotent, i.e., it won't fail if there is nothing to be
-// reset. It returns an error of type *errCertNotFound if the certificate is not
+// reset. It returns an error of type *ErrCertNotFound if the certificate is not
 // found.
 func (c *Connector) ResetCertificate(req *certificate.Request, restart bool) (err error) {
 	certificateDN := getCertificateDN(c.zone, req.FriendlyName, req.Subject.CommonName)

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -682,8 +682,7 @@ func TestResetCertificate(t *testing.T) {
 
 			err = tpp.ResetCertificate(tt.request, false)
 			if tt.expCertNotFoundErr {
-				errType := &ErrCertNotFound{}
-				if err == nil || !errors.As(err, &errType) {
+				if err == nil || !IsCertNotFound(err) {
 					t.Errorf("expected error of type %T but got %T", &ErrCertNotFound{}, err)
 				}
 			}


### PR DESCRIPTION
I missed this in https://github.com/Venafi/vcert/pull/295.
This PR fixes the IsCertNotFound function and ensures that it keeps working by using it in our test.