### PR TITLE
Added encryption to Private Key for PEM installer

### DIFF
--- a/pkg/playbook/app/domain/playbookRequest.go
+++ b/pkg/playbook/app/domain/playbookRequest.go
@@ -39,14 +39,11 @@ type PlaybookRequest struct {
 	KeyType         certificate.KeyType         `yaml:"keyType,omitempty"`
 	Location        certificate.Location        `yaml:"location,omitempty"`
 	OmitSANs        bool                        `yaml:"omitSans,omitempty"`
-
-	Origin string `yaml:"origin,omitempty"`
-
-	Subject Subject  `yaml:"subject,omitempty"`
-	Timeout int      `yaml:"timeout"`
-	UPNs    []string `yaml:"upns,omitempty"`
-	URIs    []string `yaml:"uris,omitempty"`
-
-	ValidDays string `yaml:"validDays,omitempty"`
-	Zone      string `yaml:"zone,omitempty"`
+	Origin          string                      `yaml:"origin,omitempty"`
+	Subject         Subject                     `yaml:"subject,omitempty"`
+	Timeout         int                         `yaml:"timeout"`
+	UPNs            []string                    `yaml:"upns,omitempty"`
+	URIs            []string                    `yaml:"uris,omitempty"`
+	ValidDays       string                      `yaml:"validDays,omitempty"`
+	Zone            string                      `yaml:"zone,omitempty"`
 }

--- a/pkg/playbook/app/installer/capi.go
+++ b/pkg/playbook/app/installer/capi.go
@@ -44,7 +44,7 @@ func NewCAPIInstaller(inst domain.Installation) CAPIInstaller {
 // 1. Does the certificate exists? > Install if it doesn't.
 // 2. Does the certificate is about to expire? Renew if about to expire.
 // Returns true if the certificate needs to be installed.
-func (r CAPIInstaller) Check(_ string, renewBefore string, request domain.PlaybookRequest) (bool, error) {
+func (r CAPIInstaller) Check(renewBefore string, request domain.PlaybookRequest) (bool, error) {
 	zap.L().Debug("checking certificate", zap.String("location", r.Location))
 
 	friendlyName := request.Subject.CommonName
@@ -90,22 +90,14 @@ func (r CAPIInstaller) Check(_ string, renewBefore string, request domain.Playbo
 	return renew, nil
 }
 
-// Prepare takes the certificate, chain and private key and converts them to the specific format required for the installer
-func (r CAPIInstaller) Prepare(request certificate.Request, pcc certificate.PEMCollection) (*certificate.PEMCollection, error) {
-	zap.L().Debug("preparing certificate", zap.String("location", r.Location))
-
-	return prepareCertificateForBundle(request, pcc)
-}
-
 // Backup takes the certificate request and backs up the current version prior to overwriting
-func (r CAPIInstaller) Backup(_ string, request certificate.Request) error {
+func (r CAPIInstaller) Backup() error {
 	zap.L().Debug("Certificate is backed up by default for CAPI")
-
 	return nil
 }
 
 // Install takes the certificate bundle and moves it to the location specified in the installer
-func (r CAPIInstaller) Install(_ string, request certificate.Request, pcc certificate.PEMCollection) error {
+func (r CAPIInstaller) Install(request domain.PlaybookRequest, pcc certificate.PEMCollection) error {
 	zap.L().Debug("installing certificate", zap.String("location", r.Location))
 
 	content, err := packageAsPKCS12(pcc, request.KeyPassword)

--- a/pkg/playbook/app/installer/installer.go
+++ b/pkg/playbook/app/installer/installer.go
@@ -24,20 +24,18 @@ import (
 // Installer represents the interface for all installers.
 // A new Installer must implement this interface to be picked up.
 type Installer interface {
+
 	// Check is the method in charge of making the validations to install a new certificate:
 	// 1. Does the certificate exists? > Install if it doesn't.
 	// 2. Does the certificate is about to expire? Renew if about to expire.
 	// Returns true if the certificate needs to be installed.
-	Check(certFile string, renewBefore string, request domain.PlaybookRequest) (bool, error)
-
-	// Prepare takes the certificate, chain and private key and converts them to the specific format required for the installer
-	Prepare(request certificate.Request, pcc certificate.PEMCollection) (*certificate.PEMCollection, error)
+	Check(renewBefore string, request domain.PlaybookRequest) (bool, error)
 
 	// Backup takes the certificate request and backs up the current version prior to overwriting
-	Backup(filename string, request certificate.Request) error
+	Backup() error
 
 	// Install takes the certificate bundle and moves it to the location specified in the installer
-	Install(filename string, request certificate.Request, pcc certificate.PEMCollection) error
+	Install(request domain.PlaybookRequest, pcc certificate.PEMCollection) error
 
 	// AfterInstallActions runs any instructions declared in the Installer on a terminal.
 	//

--- a/pkg/playbook/app/installer/jks.go
+++ b/pkg/playbook/app/installer/jks.go
@@ -46,7 +46,7 @@ func NewJKSInstaller(inst domain.Installation) JKSInstaller {
 // 1. Does the certificate exists? > Install if it doesn't.
 // 2. Does the certificate is about to expire? Renew if about to expire.
 // Returns true if the certificate needs to be installed.
-func (r JKSInstaller) Check(_ string, renewBefore string, request domain.PlaybookRequest) (bool, error) {
+func (r JKSInstaller) Check(renewBefore string, request domain.PlaybookRequest) (bool, error) {
 	zap.L().Debug("checking certificate:", zap.String("location", r.Location))
 
 	// Check certificate file exists
@@ -76,15 +76,8 @@ func (r JKSInstaller) Check(_ string, renewBefore string, request domain.Playboo
 	return renew, nil
 }
 
-// Prepare takes the certificate, chain and private key and converts them to the specific format required for the installer
-func (r JKSInstaller) Prepare(request certificate.Request, pcc certificate.PEMCollection) (*certificate.PEMCollection, error) {
-	zap.L().Debug("preparing certificate", zap.String("location", r.Location))
-
-	return prepareCertificateForBundle(request, pcc)
-}
-
 // Backup takes the certificate request and backs up the current version prior to overwriting
-func (r JKSInstaller) Backup(_ string, request certificate.Request) error {
+func (r JKSInstaller) Backup() error {
 	zap.L().Debug("backing up certificate", zap.String("location", r.Location))
 
 	// Check certificate file exists
@@ -109,7 +102,7 @@ func (r JKSInstaller) Backup(_ string, request certificate.Request) error {
 }
 
 // Install takes the certificate bundle and moves it to the location specified in the installer
-func (r JKSInstaller) Install(_ string, request certificate.Request, pcc certificate.PEMCollection) error {
+func (r JKSInstaller) Install(request domain.PlaybookRequest, pcc certificate.PEMCollection) error {
 	zap.L().Debug("installing certificate", zap.String("location", r.Location))
 
 	content, err := packageAsJKS(pcc, request.KeyPassword, r.JKSAlias, r.JKSPassword)

--- a/pkg/playbook/app/installer/pkcs12.go
+++ b/pkg/playbook/app/installer/pkcs12.go
@@ -45,7 +45,7 @@ func NewPKCS12Installer(inst domain.Installation) PKCS12Installer {
 // 1. Does the certificate exists? > Install if it doesn't.
 // 2. Does the certificate is about to expire? Renew if about to expire.
 // Returns true if the certificate needs to be installed.
-func (r PKCS12Installer) Check(_ string, renewBefore string, request domain.PlaybookRequest) (bool, error) {
+func (r PKCS12Installer) Check(renewBefore string, request domain.PlaybookRequest) (bool, error) {
 	zap.L().Debug("checking certificate:", zap.String("location", r.Location))
 
 	// Check certificate file exists
@@ -69,15 +69,8 @@ func (r PKCS12Installer) Check(_ string, renewBefore string, request domain.Play
 	return renew, nil
 }
 
-// Prepare takes the certificate, chain and private key and converts them to the specific format required for the installer
-func (r PKCS12Installer) Prepare(request certificate.Request, pcc certificate.PEMCollection) (*certificate.PEMCollection, error) {
-	zap.L().Debug("preparing certificate", zap.String("location", r.Location))
-
-	return prepareCertificateForBundle(request, pcc)
-}
-
 // Backup takes the certificate request and backs up the current version prior to overwriting
-func (r PKCS12Installer) Backup(_ string, _ certificate.Request) error {
+func (r PKCS12Installer) Backup() error {
 	zap.L().Debug("backing up certificate", zap.String("location", r.Location))
 
 	// Check certificate file exists
@@ -102,7 +95,7 @@ func (r PKCS12Installer) Backup(_ string, _ certificate.Request) error {
 }
 
 // Install takes the certificate bundle and moves it to the location specified in the installer
-func (r PKCS12Installer) Install(_ string, request certificate.Request, pcc certificate.PEMCollection) error {
+func (r PKCS12Installer) Install(request domain.PlaybookRequest, pcc certificate.PEMCollection) error {
 	zap.L().Debug("installing certificate", zap.String("location", r.Location))
 
 	content, err := packageAsPKCS12(pcc, request.KeyPassword)

--- a/pkg/playbook/app/vcertutil/vcertutil.go
+++ b/pkg/playbook/app/vcertutil/vcertutil.go
@@ -142,6 +142,12 @@ func DecryptPrivateKey(privateKey string, password string) (string, error) {
 	return privateKey, err
 }
 
+// EncryptPrivateKeyPKCS1 takes a decrypted PKCS8 private key and encrypts it back in PKCS1 format
+func EncryptPrivateKeyPKCS1(privateKey string, password string) (string, error) {
+	privateKey, err := util.EncryptPkcs1PrivateKey(privateKey, password)
+	return privateKey, err
+}
+
 // IsValidAccessToken checks that the accessToken in config is not expired.
 func IsValidAccessToken(config domain.Config) (bool, error) {
 	// No access token provided. Use refresh token to get new access token right away


### PR DESCRIPTION
Also:

- Removed unnecessary interface functions in installer.go 
- Removed unused arguments from Installer interface functions

Closes VC-25405