### PR TITLE
feat(firefly): Add support for Firefly in VCert Playbook

### DIFF
--- a/pkg/playbook/app/parser/writer_test.go
+++ b/pkg/playbook/app/parser/writer_test.go
@@ -21,10 +21,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Venafi/vcert/v5/pkg/endpoint"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/Venafi/vcert/v5/pkg/certificate"
+	"github.com/Venafi/vcert/v5/pkg/endpoint"
 	"github.com/Venafi/vcert/v5/pkg/playbook/app/domain"
 )
 
@@ -77,6 +77,10 @@ func (s *WriterSuite) SetupTest() {
 					Authentication: endpoint.Authentication{
 						AccessToken:  "123fooBar",
 						RefreshToken: "456XyzABc",
+						IdentityProvider: &endpoint.OAuthProvider{
+							TokenURL: "okta.com",
+							Audience: "myAudience",
+						},
 					},
 					P12Task: "",
 				},

--- a/pkg/playbook/app/vcertutil/vcertutil.go
+++ b/pkg/playbook/app/vcertutil/vcertutil.go
@@ -55,16 +55,23 @@ func EnrollCertificate(config domain.Config, request domain.PlaybookRequest) (*c
 	}
 	zap.L().Debug("successfully updated Request with zone config values")
 
-	reqID, err := client.RequestCertificate(&vRequest)
-	if err != nil {
-		return nil, nil, err
+	var pcc *certificate.PEMCollection
+
+	if client.SupportSynchronousRequestCertificate() {
+		pcc, err = client.SynchronousRequestCertificate(&vRequest)
+	} else {
+		reqID, err := client.RequestCertificate(&vRequest)
+		if err != nil {
+			return nil, nil, err
+		}
+		zap.L().Debug("successfully requested certificate", zap.String("requestID", reqID))
+
+		vRequest.PickupID = reqID
+		vRequest.Timeout = 180 * time.Second
+
+		pcc, err = client.RetrieveCertificate(&vRequest)
 	}
-	zap.L().Debug("successfully requested certificate", zap.String("requestID", reqID))
 
-	vRequest.PickupID = reqID
-	vRequest.Timeout = 180 * time.Second
-
-	pcc, err := client.RetrieveCertificate(&vRequest)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -79,13 +86,18 @@ func buildClient(config domain.Config, zone string) (endpoint.Connector, error) 
 		BaseUrl:       config.Connection.URL,
 		Zone:          zone,
 		Credentials: &endpoint.Authentication{
-			APIKey:      config.Connection.Credentials.APIKey,
-			Scope:       config.Connection.Credentials.Scope,
-			ClientId:    config.Connection.Credentials.ClientId,
-			AccessToken: config.Connection.Credentials.AccessToken,
+			APIKey:       config.Connection.Credentials.APIKey,
+			Scope:        config.Connection.Credentials.Scope,
+			ClientId:     config.Connection.Credentials.ClientId,
+			AccessToken:  config.Connection.Credentials.AccessToken,
+			ClientSecret: config.Connection.Credentials.ClientSecret,
 		},
 		ConnectionTrust: loadTrustBundle(config.Connection.TrustBundlePath),
 		LogVerbose:      false,
+	}
+
+	if config.Connection.Credentials.IdentityProvider != nil {
+		vConfig.Credentials.IdentityProvider = config.Connection.Credentials.IdentityProvider
 	}
 
 	client, err := vcert.NewClient(vConfig)

--- a/test-files/playbook/sample.yaml
+++ b/test-files/playbook/sample.yaml
@@ -3,6 +3,9 @@ config:
     type: TLSPC
     credentials:
       apiKey: fooo123bar!
+      idP:
+        tokenURL: okta.com
+        audience: someAudience
 certificateTasks:
   - name: mtls
     request:


### PR DESCRIPTION
Adds support to Firefly certificate enrollment in VCert Playbook. 
An Access Token must be provided in credentials

Closes VC-25641