### PR TITLE
Fix p12Task using incorrect password

### DIFF
--- a/cmd/vcert/playbook.go
+++ b/cmd/vcert/playbook.go
@@ -182,7 +182,7 @@ func setPlaybookTLSConfig(playbook domain.Playbook) error {
 					// Find the first installation that is of type P12
 					if inst.Type == domain.FormatPKCS12 {
 						p12FileLocation = inst.File
-						p12Password = task.Request.KeyPassword
+						p12Password = inst.P12Password
 						break
 					}
 				}

--- a/cmd/vcert/playbook_test.go
+++ b/cmd/vcert/playbook_test.go
@@ -44,12 +44,12 @@ func (s *PlaybookSuite) TestPlaybook_SetTLSConfig() {
 	playbook := domain.Playbook{
 		CertificateTasks: domain.CertificateTasks{
 			domain.CertificateTask{
-				Name:    "p12Auth",
-				Request: domain.PlaybookRequest{KeyPassword: p12Password},
+				Name: "p12Auth",
 				Installations: domain.Installations{
 					domain.Installation{
-						File: p12FileLocation,
-						Type: domain.FormatPKCS12,
+						File:        p12FileLocation,
+						Type:        domain.FormatPKCS12,
+						P12Password: p12Password,
 					},
 				},
 			},
@@ -103,12 +103,12 @@ func (s *PlaybookSuite) TestPlaybook_SetTLSConfig_noP12Certificate() {
 	playbook := domain.Playbook{
 		CertificateTasks: domain.CertificateTasks{
 			domain.CertificateTask{
-				Name:    "p12Auth",
-				Request: domain.PlaybookRequest{KeyPassword: "foo123"},
+				Name: "p12Auth",
 				Installations: domain.Installations{
 					domain.Installation{
-						File: "./bad/location.p12",
-						Type: domain.FormatPKCS12,
+						File:        "./bad/location.p12",
+						Type:        domain.FormatPKCS12,
+						P12Password: "foo123",
 					},
 				},
 			},


### PR DESCRIPTION
Fix issue where certificate authentication was trying to use the `request.keyPassword` value instead of the update `installation.p12Password`.  Includes updates to tests and validated.