### PR TITLE
feat(playbook): Added attributes to CAPI installation

### DIFF
--- a/pkg/playbook/app/domain/error.go
+++ b/pkg/playbook/app/domain/error.go
@@ -72,6 +72,11 @@ var (
 	ErrInvalidCAPILocation = fmt.Errorf("invalid CAPI location. Should be either 'LocalMachine' or 'CurrentUser' (i.e. 'LocalMachine\\My')")
 	// ErrInvalidCAPIStoreName is thrown when certificates.installations[].type is CAPI but the location is malformed
 	ErrInvalidCAPIStoreName = fmt.Errorf("invalid CAPI store name. Should contain a valid storeName after the '\\' (i.e. 'LocalMachine\\My')")
+	// WarningLocationFieldDeprecated is thrown when certificates.installations[].type is CAPI but the deprecated location field is set
+	WarningLocationFieldDeprecated = "location field is deprecated and will be removed in a future release. Use capiLocation instead"
+	// WarningNoCAPIFriendlyName is thrown when certificates.installations[].type is CAPI but no friendlyName is set
+	WarningNoCAPIFriendlyName = "no capiFriendlyName defined. It is strongly recommended to define a " +
+		"capiFriendlyName for CAPI installation type. This will become required in a future release"
 
 	// ErrNoFireflyURL is thrown when platform is Firefly but no url is specified inf config.credentials
 	ErrNoFireflyURL = fmt.Errorf("no url defined. Firefly platform requires an url to the Firefly instance")

--- a/pkg/playbook/app/domain/installation.go
+++ b/pkg/playbook/app/domain/installation.go
@@ -38,19 +38,22 @@ var validStoreNames = []string{"addressbook", "authroot", "certificateauthority"
 // Installation represents a location in which a certificate will be installed,
 // along with the format in which it will be installed
 type Installation struct {
-	AfterAction         string             `yaml:"afterInstallAction,omitempty"`
-	BackupFiles         bool               `yaml:"backupFiles,omitempty"`
-	CAPIIsNonExportable bool               `yaml:"capiIsNonExportable,omitempty"`
-	ChainFile           string             `yaml:"chainFile,omitempty"`
-	File                string             `yaml:"file,omitempty"`
-	InstallValidation   string             `yaml:"installValidationAction,omitempty"`
-	JKSAlias            string             `yaml:"jksAlias,omitempty"`
-	JKSPassword         string             `yaml:"jksPassword,omitempty"`
-	KeyFile             string             `yaml:"keyFile,omitempty"`
-	KeyPassword         string             `yaml:"keyPassword,omitempty"`
-	Location            string             `yaml:"location,omitempty"`
-	P12Password         string             `yaml:"p12Password,omitempty"`
-	Type                InstallationFormat `yaml:"format,omitempty"`
+	AfterAction         string `yaml:"afterInstallAction,omitempty"`
+	BackupFiles         bool   `yaml:"backupFiles,omitempty"`
+	CAPIFriendlyName    string `yaml:"capiFriendlyName,omitempty"` // In a future version of vCert this will become REQUIRED!
+	CAPIIsNonExportable bool   `yaml:"capiIsNonExportable,omitempty"`
+	CAPILocation        string `yaml:"capiLocation,omitempty"` // This is an alias for Location
+	ChainFile           string `yaml:"chainFile,omitempty"`
+	File                string `yaml:"file,omitempty"`
+	InstallValidation   string `yaml:"installValidationAction,omitempty"`
+	JKSAlias            string `yaml:"jksAlias,omitempty"`
+	JKSPassword         string `yaml:"jksPassword,omitempty"`
+	KeyFile             string `yaml:"keyFile,omitempty"`
+	KeyPassword         string `yaml:"keyPassword,omitempty"`
+	// Deprecated: Location is deprecated in favor of CAPILocation. It will be removed on a future release
+	Location    string             `yaml:"location,omitempty"`
+	P12Password string             `yaml:"p12Password,omitempty"`
+	Type        InstallationFormat `yaml:"format,omitempty"`
 }
 
 // Installations is a slice of Installation
@@ -85,24 +88,40 @@ func (installation Installation) IsValid() (bool, error) {
 }
 
 func validateCAPI(installation Installation) error {
-	if installation.Location == "" {
-		return ErrNoCAPILocation
-	}
-
 	if runtime.GOOS != "windows" {
 		return ErrCAPIOnNonWindows
 	}
 
+	location := installation.CAPILocation
+	if location == "" {
+		location = installation.Location
+	}
+
+	// Ensure there is a location specified
+	if location == "" {
+		return ErrNoCAPILocation
+	}
+
+	// Throw warning if using deprecated field
+	if installation.Location != "" {
+		zap.L().Warn(WarningLocationFieldDeprecated)
+	}
+
+	// Throw warning if no friendly name set
+	if installation.CAPIFriendlyName == "" {
+		zap.L().Warn(WarningNoCAPIFriendlyName)
+	}
+
 	// Ensure proper location specified
-	segments := strings.Split(installation.Location, "\\")
+	segments := strings.Split(location, "\\")
 
 	// CAPI Location must be in form of <string>\<string>
 	if len(segments) != 2 {
 		return ErrMalformedCAPILocation
 	}
 
-	location := strings.ToLower(segments[0])
-	if location != capiLocationCurrentUser && location != capiLocationLocalMachine {
+	capiLocation := strings.ToLower(segments[0])
+	if capiLocation != capiLocationCurrentUser && capiLocation != capiLocationLocalMachine {
 		return ErrInvalidCAPILocation
 	}
 

--- a/pkg/playbook/app/installer/capi.go
+++ b/pkg/playbook/app/installer/capi.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/Venafi/vcert/v5/pkg/certificate"
 	"github.com/Venafi/vcert/v5/pkg/playbook/app/domain"
+	"github.com/Venafi/vcert/v5/pkg/playbook/app/vcertutil"
 	"github.com/Venafi/vcert/v5/pkg/playbook/util"
 	"github.com/Venafi/vcert/v5/pkg/playbook/util/capistore"
 )
@@ -47,12 +48,19 @@ func NewCAPIInstaller(inst domain.Installation) CAPIInstaller {
 func (r CAPIInstaller) Check(renewBefore string, request domain.PlaybookRequest) (bool, error) {
 	zap.L().Info("checking certificate health", zap.String("format", r.Type.String()), zap.String("location", r.Location))
 
-	friendlyName := request.Subject.CommonName
-	if request.FriendlyName != "" {
-		friendlyName = request.FriendlyName
+	// Get friendly name. If no friendly name is set, get CN from request as friendly name
+	friendlyName := r.CAPIFriendlyName
+	if request.FriendlyName == "" {
+		friendlyName = request.Subject.CommonName
 	}
 
-	storeLocation, storeName, err := getCertStore(r.Location)
+	// Get location from CAPILocation. If CAPILocation is not set, check deprecated Location field
+	location := r.CAPILocation
+	if location == "" {
+		location = r.Location
+	}
+
+	storeLocation, storeName, err := getCertStore(location)
 	if err != nil {
 		zap.L().Error("failed to get certificate store", zap.Error(err))
 		return true, err
@@ -97,21 +105,34 @@ func (r CAPIInstaller) Backup() error {
 }
 
 // Install takes the certificate bundle and moves it to the location specified in the installer
-func (r CAPIInstaller) Install(request domain.PlaybookRequest, pcc certificate.PEMCollection) error {
+func (r CAPIInstaller) Install(pcc certificate.PEMCollection) error {
 	zap.L().Debug("installing certificate", zap.String("location", r.Location))
 
-	content, err := packageAsPKCS12(pcc, r.P12Password)
+	// Generate random password for temporary P12 bundle
+	bundlePassword := vcertutil.GeneratePassword()
+
+	content, err := packageAsPKCS12(pcc, bundlePassword)
 	if err != nil {
 		zap.L().Error("could not package certificate as PKCS12", zap.Error(err))
 		return err
 	}
 
-	friendlyName := request.Subject.CommonName
-	if request.FriendlyName != "" {
-		friendlyName = request.FriendlyName
+	// Get friendly name. If no friendly name is set, get CN from certificate as friendly name
+	friendlyName := r.CAPIFriendlyName
+	if friendlyName == "" {
+		friendlyName, err = getCertFriendlyName([]byte(pcc.Certificate))
+		if err != nil {
+			return err
+		}
 	}
 
-	storeLocation, storeName, err := getCertStore(r.Location)
+	// Get location from CAPILocation. If CAPILocation is not set, check deprecated Location field
+	location := r.CAPILocation
+	if location == "" {
+		location = r.Location
+	}
+
+	storeLocation, storeName, err := getCertStore(location)
 	if err != nil {
 		zap.L().Error("failed to get certificate store", zap.Error(err))
 		return err
@@ -121,7 +142,7 @@ func (r CAPIInstaller) Install(request domain.PlaybookRequest, pcc certificate.P
 		PFX:             content,
 		FriendlyName:    friendlyName,
 		IsNonExportable: r.CAPIIsNonExportable,
-		Password:        r.P12Password,
+		Password:        bundlePassword,
 		StoreLocation:   storeLocation,
 		StoreName:       storeName,
 	}
@@ -168,4 +189,12 @@ func getCertStore(location string) (string, string, error) {
 	}
 
 	return segments[0], segments[1], nil
+}
+
+func getCertFriendlyName(cert []byte) (string, error) {
+	x509Cert, err := parsePEMCertificate(cert)
+	if err != nil {
+		return "", fmt.Errorf("failed to get friendly name from certificate: %w", err)
+	}
+	return x509Cert.Subject.CommonName, nil
 }

--- a/pkg/playbook/app/installer/capi.go
+++ b/pkg/playbook/app/installer/capi.go
@@ -48,9 +48,10 @@ func NewCAPIInstaller(inst domain.Installation) CAPIInstaller {
 func (r CAPIInstaller) Check(renewBefore string, request domain.PlaybookRequest) (bool, error) {
 	zap.L().Info("checking certificate health", zap.String("format", r.Type.String()), zap.String("location", r.Location))
 
-	// Get friendly name. If no friendly name is set, get CN from request as friendly name
+	// Get friendly name. If no friendly name is set, get CN from request as friendly name.
+	//  NOTE: This functionality is deprecated, and in a future version will be removed, and CAPIFriendlyName will be req'd
 	friendlyName := r.CAPIFriendlyName
-	if request.FriendlyName == "" {
+	if friendlyName == "" {
 		friendlyName = request.Subject.CommonName
 	}
 

--- a/pkg/playbook/app/installer/installer.go
+++ b/pkg/playbook/app/installer/installer.go
@@ -35,7 +35,7 @@ type Installer interface {
 	Backup() error
 
 	// Install takes the certificate bundle and moves it to the location specified in the installer
-	Install(request domain.PlaybookRequest, pcc certificate.PEMCollection) error
+	Install(pcc certificate.PEMCollection) error
 
 	// AfterInstallActions runs any instructions declared in the Installer on a terminal.
 	//

--- a/pkg/playbook/app/installer/jks.go
+++ b/pkg/playbook/app/installer/jks.go
@@ -101,7 +101,7 @@ func (r JKSInstaller) Backup() error {
 }
 
 // Install takes the certificate bundle and moves it to the location specified in the installer
-func (r JKSInstaller) Install(_ domain.PlaybookRequest, pcc certificate.PEMCollection) error {
+func (r JKSInstaller) Install(pcc certificate.PEMCollection) error {
 	zap.L().Debug("installing certificate", zap.String("location", r.File))
 
 	// If no password is set for the Private Key, use the JKSPassword

--- a/pkg/playbook/app/installer/pem.go
+++ b/pkg/playbook/app/installer/pem.go
@@ -111,7 +111,7 @@ func (r PEMInstaller) Backup() error {
 }
 
 // Install takes the certificate bundle and moves it to the location specified in the installer
-func (r PEMInstaller) Install(_ domain.PlaybookRequest, pcc certificate.PEMCollection) error {
+func (r PEMInstaller) Install(pcc certificate.PEMCollection) error {
 	zap.L().Debug("installing certificate", zap.String("location", r.File))
 
 	//TODO: should we add support for PEM bundle?

--- a/pkg/playbook/app/installer/pkcs12.go
+++ b/pkg/playbook/app/installer/pkcs12.go
@@ -95,7 +95,7 @@ func (r PKCS12Installer) Backup() error {
 }
 
 // Install takes the certificate bundle and moves it to the location specified in the installer
-func (r PKCS12Installer) Install(_ domain.PlaybookRequest, pcc certificate.PEMCollection) error {
+func (r PKCS12Installer) Install(pcc certificate.PEMCollection) error {
 	zap.L().Debug("installing certificate", zap.String("location", r.File))
 
 	if r.P12Password == "" {

--- a/pkg/playbook/app/vcertutil/vcertutil.go
+++ b/pkg/playbook/app/vcertutil/vcertutil.go
@@ -17,14 +17,15 @@
 package vcertutil
 
 import (
+	"crypto/rand"
 	"crypto/x509/pkix"
 	"errors"
 	"fmt"
 	"time"
 
-	"github.com/Venafi/vcert/v5"
 	"go.uber.org/zap"
 
+	"github.com/Venafi/vcert/v5"
 	"github.com/Venafi/vcert/v5/pkg/certificate"
 	"github.com/Venafi/vcert/v5/pkg/endpoint"
 	"github.com/Venafi/vcert/v5/pkg/playbook/app/domain"
@@ -240,4 +241,19 @@ func RefreshTPPTokens(config domain.Config) (string, string, error) {
 	}
 
 	return "", "", fmt.Errorf("no refresh token or certificate available to refresh access token")
+}
+
+func GeneratePassword() string {
+	letterRunes := "abcdefghijklmnopqrstuvwxyz"
+
+	b := make([]byte, 4)
+	_, _ = rand.Read(b)
+
+	for i, v := range b {
+		b[i] = letterRunes[v%byte(len(letterRunes))]
+	}
+
+	randString := string(b)
+
+	return fmt.Sprintf("t%d-%s.temp.pwd", time.Now().Unix(), randString)
 }


### PR DESCRIPTION
- Added capiFriendlyName field to installation object 
- Added capiLocation field to installation object
- Deprecated location field from installation object
- Added warning when using deprecated location field 
- Added warning when capiFriendlyName is not set

- Now CAPI installations will use the value set in `capiLocation`. If not set, then will use the value from `location`
- CAPI installations will use the value set in `capiFriendlyName`. If not set, then will use the value from the `request.subject.commonName` (Check) or `certificate.subject.commonName` (install)
- A random password will be generated for the P12 bundle used to import the certificate into CAPI store every time a certificate is installed