### PR TITLE
Replaced province with state in request section

### DIFF
--- a/examples/playbook/sample.capi.yaml
+++ b/examples/playbook/sample.capi.yaml
@@ -18,7 +18,7 @@ certificateTasks:
         commonName: '{{ Hostname | ToLower -}}.{{- Env "USERDNSDOMAIN" | ToLower }}'
         country: US
         locality: Salt Lake City
-        province: Utah
+        state: Utah
         organization: Venafi Inc
         orgUnits:
           - engineering

--- a/examples/playbook/sample.jks.yaml
+++ b/examples/playbook/sample.jks.yaml
@@ -18,7 +18,7 @@ certificateTasks:
         commonName: '{{ Hostname | ToLower -}}.{{- Env "USERDNSDOMAIN" | ToLower }}'
         country: US
         locality: Salt Lake City
-        province: Utah
+        state: Utah
         organization: Venafi Inc
         orgUnits:
           - engineering

--- a/examples/playbook/sample.multi.yaml
+++ b/examples/playbook/sample.multi.yaml
@@ -19,7 +19,7 @@ certificateTasks:
         commonName: '{{ Hostname | ToLower -}}.{{- Env "USERDNSDOMAIN" | ToLower }}'
         country: US
         locality: Salt Lake City
-        province: Utah
+        state: Utah
         organization: Venafi Inc
         orgUnits:
           - engineering

--- a/examples/playbook/sample.pem.yaml
+++ b/examples/playbook/sample.pem.yaml
@@ -19,7 +19,7 @@ certificateTasks:
         commonName: '{{ Hostname | ToLower -}}.{{- Env "USERDNSDOMAIN" | ToLower }}'
         country: US
         locality: Salt Lake City
-        province: Utah
+        state: Utah
         organization: Venafi Inc
         orgUnits:
           - engineering

--- a/examples/playbook/sample.pkcs12.yaml
+++ b/examples/playbook/sample.pkcs12.yaml
@@ -18,7 +18,7 @@ certificateTasks:
         commonName: '{{ Hostname | ToLower -}}.{{- Env "USERDNSDOMAIN" | ToLower }}'
         country: US
         locality: Salt Lake City
-        province: Utah
+        state: Utah
         organization: Venafi Inc
         orgUnits:
           - engineering

--- a/examples/playbook/sample.tlspc.yaml
+++ b/examples/playbook/sample.tlspc.yaml
@@ -2,7 +2,7 @@ config:
   connection:
     platform: vaas
     credentials:
-      apiKey: '{{ Env "TLSCP_APIKEY" }}'
+      apiKey: '{{ Env "TLSCP_APIKEY" }}' # APIKEY as Environment variable
 certificateTasks:
   - name: myCertificate # Task Identifier, no relevance in tool run
     renewBefore: 31d

--- a/examples/playbook/sample.tlspc.yaml
+++ b/examples/playbook/sample.tlspc.yaml
@@ -2,7 +2,7 @@ config:
   connection:
     platform: vaas
     credentials:
-      apiKey: "XxXXxXxx-Xxxx-XXxX-XxXx-xXxxXXxxXXxX"
+      apiKey: '{{ Env "TLSCP_APIKEY" }}'
 certificateTasks:
   - name: myCertificate # Task Identifier, no relevance in tool run
     renewBefore: 31d
@@ -14,7 +14,7 @@ certificateTasks:
         commonName: '{{ Hostname | ToLower -}}.{{- Env "USERDNSDOMAIN" | ToLower }}'
         country: US
         locality: Salt Lake City
-        province: Utah
+        state: Utah
         organization: Venafi Inc
         orgUnits:
           - engineering


### PR DESCRIPTION
1. Updated playbooks with the **state** field in the request section (replacing **province**) as per (https://github.com/Venafi/vcert/blob/master/README-PLAYBOOK.md#subject)

2. Updated the TLSPC example to use a ENVVAR for the APIKEY