### PR TITLE
More CAPI fixes following testing

### DIFF
--- a/pkg/playbook/app/installer/capi.go
+++ b/pkg/playbook/app/installer/capi.go
@@ -48,9 +48,10 @@ func NewCAPIInstaller(inst domain.Installation) CAPIInstaller {
 func (r CAPIInstaller) Check(renewBefore string, request domain.PlaybookRequest) (bool, error) {
 	zap.L().Info("checking certificate health", zap.String("format", r.Type.String()), zap.String("location", r.Location))
 
-	// Get friendly name. If no friendly name is set, get CN from request as friendly name
+	// Get friendly name. If no friendly name is set, get CN from request as friendly name.
+	//  NOTE: This functionality is deprecated, and in a future version will be removed, and CAPIFriendlyName will be req'd
 	friendlyName := r.CAPIFriendlyName
-	if request.FriendlyName == "" {
+	if friendlyName == "" {
 		friendlyName = request.Subject.CommonName
 	}
 


### PR DESCRIPTION
Fixed 2 issued found during testing:
1. CAPI Installer Check() function had a logic bug and was checking the wrong variable to determine if it should fall back to deprecated behavior.
2. Error in the actual CAPI Install script, causing the root and intermediate certificate to be installed in the "My" store all the time. (This will cause unintended results on Windows)