### PR TITLE
Minor fixes for VCert e2e inorder to work with latests images

### DIFF
--- a/aruba/Dockerfile
+++ b/aruba/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby
+FROM ruby:3.2
 MAINTAINER Venafi DevOps Integrations <opensource@venafi.com>
 
 RUN gem install aruba json_spec

--- a/aruba/features/playbook/steps_definitions/my_steps.rb
+++ b/aruba/features/playbook/steps_definitions/my_steps.rb
@@ -268,7 +268,7 @@ When(/^playbook generated "([^"]*)" should be PKCS#12 archive with password "([^
   cert_path = Dir.pwd + $path_separator + $temp_path + $path_separator + filename
 
   steps %{
-    Then I try to run `openssl pkcs12 -in "#{cert_path}" -passin pass:#{password} -noout`
+    Then I try to run `openssl pkcs12 -in "#{cert_path}" -legacy -passin pass:#{password} -noout`
     And the exit status should be 0
   }
 end

--- a/aruba/features/step_definitions/openssl.rb
+++ b/aruba/features/step_definitions/openssl.rb
@@ -123,7 +123,7 @@ end
 
 When(/^"([^"]*)" should be PKCS#12 archive with password "([^"]*)"$/) do |filename, password|
   steps %{
-    Then I try to run `openssl pkcs12 -in "#{filename}" -passin pass:#{password} -noout`
+    Then I try to run `openssl pkcs12 -in "#{filename}" -legacy -passin pass:#{password} -noout`
     And the exit status should be 0
   }
   # -nokeys           Don't output private keys


### PR DESCRIPTION
 - Adds legacy support for PKCS12. E2E tests don't work on newer docker images because of new Open SSL that dropped support by default, adding flag to restore the support). This fixes:
```
vcert enroll -u '' -k **** -z 'redacted'  -cn 1my-test.example.com -format pkcs12 -file all.p12 -key-password ****
openssl pkcs12 -in "all.p12" -passin pass:*** -noout
Error outputting keys and certificates
40A71564917F0000:error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:../crypto/evp/evp_fetch.c:373:Global default library context, Algorithm (RC2-40-CBC : 0), Properties ()
```

 - Constrain Ruby image version to `ruby:3.2`. This is so we don't get any surprise eventually due issue mentioned happened above.