### PR TITLE
Align gencsr input validation with standards

### DIFF
--- a/cmd/vcert/validators.go
+++ b/cmd/vcert/validators.go
@@ -482,11 +482,18 @@ func validateGenerateFlags1(commandName string) error {
 		return err
 	}
 
-	if flags.commonName == "" && len(flags.dnsSans) == 0 {
-		return fmt.Errorf("A Common Name (cn) or Subject Alternative Name: DNS (san-dns) value is required")
+	// X.509 certificates must have either a Subject DN...
+	if flags.commonName != "" || len(flags.orgUnits) > 0 || flags.org != "" ||
+		flags.locality != "" || flags.state != "" || flags.country != "" {
+		return nil
 	}
-
-	return nil
+	// ...or at least one Subject Alternative Name
+	if len(flags.dnsSans) > 0 || len(flags.ipSans) > 0 || len(flags.emailSans) > 0 ||
+		len(flags.uriSans) > 0 || len(flags.upnSans) > 0 {
+		return nil
+	}
+	// the enrolling CA may have more strict requirements when the CSR is submitted
+	return fmt.Errorf("At least one Subject DN component or Subject Alternative Name value is required")
 }
 
 func validateRenewFlags1(commandName string) error {


### PR DESCRIPTION
When it comes to generating CSRs with SANs, VCert is much easier than OpenSSL.  Currently you can only generate a CSR using the `gencsr` action if you specify either a CN or DNS SAN.  This restriction exists because public CAs commonly have such a requirement and specifying a CN is best practice to give certificates a primary identifier.  Modern use cases, such as those using SPIFFE, typically request certificates with no subject and only a single URI SAN (i.e., the SPIFFE verifiable identity document, SVID).  I've made this small update to VCert CLI so that it is possible to generate certificates like this for testing with Venafi Firefly and enterprise PKIs supporting modern use cases.