### PR TITLE
Change certificate type to auto. Fixes #299.

### DIFF
--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -522,7 +522,7 @@ func prepareRequest(req *certificate.Request, zone string) (tppReq certificateRe
 		return tppReq, fmt.Errorf("Unexpected option in PrivateKeyOrigin")
 	}
 
-	tppReq.CertificateType = "AUTO"
+	tppReq.CertificateType = "auto"
 	tppReq.PolicyDN = getPolicyDN(zone)
 	tppReq.CADN = req.CADN
 	tppReq.ObjectName = req.FriendlyName


### PR DESCRIPTION
vCert already had the proper setting to make CertificateType = "AUTO" in the TPP request. However, this was being ignored by TPP. Testing confirmed that this must be passed in all lowercase in order to work. (Probably need to file a bug with TPP for this). Changed to "auto" and tested to confirm desired behavior.  Fixes #299 .