### PR TITLE
fix: lint issue with hardcoded credentials

### DIFF
--- a/pkg/venafi/fake/ca.go
+++ b/pkg/venafi/fake/ca.go
@@ -45,6 +45,8 @@ f6ZUnA9hhqxO4CHqQWmKPHftbGscwx5yg/J6J7TfG+rYd5ZVVhrr2un2xpOTctjO
 lriDCQa4FOwP9/x1OJRXEsSl5YFqBppX5A==
 -----END CERTIFICATE-----`
 
+// This credential is just meant for testing, no valid use for auth or any risk is present here
+// #nosec G101:Potential hardcoded credentials: RSA private key
 const caKeyPEM = `-----BEGIN RSA PRIVATE KEY-----
 MIIEpAIBAAKCAQEA0BobDKthxG5SuMfAp2heyDQN/IL9NTEnFJUUl/CkLEQTSQT6
 8M9US7TCxi+FOizIoev2k4Nkovgk7uM0q94aygbhcHyTTL64uphHwcClu99ZQ6DI


### PR DESCRIPTION
As our pipeline updated to version of golangci-lint: 1.55.1, now it identified our fake hardcoded credential. We need to let know the linter it can safely be ignored, since is not a valid credential and we just use it for testing.