### PR TITLE
Contact Emails: RequestCertificate can now be given contact emails

### DIFF
--- a/pkg/certificate/request.go
+++ b/pkg/certificate/request.go
@@ -67,10 +67,10 @@ type Request struct {
 	// When an email is used by multiple TPP identities, the first identity
 	// found is picked arbitrarily.
 	//
-	// The scope `configuration` is required. Since Contact works by searching
+	// The scope `configuration` is required. Since Contacts works by searching
 	// the emails in the same LDAP or AD as the user attached to the token, you
 	// must check that you are using a user in that same identity provider.
-	// Contact doesn't work with the local TPP identities. Using Contact
+	// Contacts doesn't work with the local TPP identities. Using Contacts
 	// requires adding `mail` to the list of fields searched when performing a
 	// user search, which can be configured in the Venafi Configuration Console
 	// by RDP'ing into the TPP VM. This configuration cannot be performed

--- a/pkg/certificate/request.go
+++ b/pkg/certificate/request.go
@@ -56,8 +56,18 @@ type Request struct {
 	IssuerHint       util.IssuerHint
 
 	// ContactEmails is TPP-specific. It allows you to configure an email
-	// address to send notifications about the certificate to. Requires the
-	// scope `configuration`.
+	// address to send notifications about the certificate to. When an email is
+	// used by multiple TPP identities, the first identity found is picked
+	// arbitrarily.
+	//
+	// The scope `configuration` is required. Since ContactEmails works by
+	// searching the emails in the same LDAP or AD as the user attached to the
+	// token, you must check that you are using a user in that same identity
+	// provider. ContactEmails doesn't work with the local TPP identities. Using
+	// ContactEmails requires adding `mail` to the list of fields searched when
+	// performing a user search, which can be configured in the Venafi
+	// Configuration Console by RDP'ing into the TPP VM. This configuration
+	// cannot be performed directly in the TPP UI.
 	ContactEmails []string
 
 	// Deprecated: use ValidityDuration instead, this field is ignored if ValidityDuration is set

--- a/pkg/certificate/request.go
+++ b/pkg/certificate/request.go
@@ -55,20 +55,20 @@ type Request struct {
 	ValidityPeriod   string //represents the validity of the certificate expressed as an ISO 8601 duration
 	IssuerHint       util.IssuerHint
 
-	// ContactEmails is TPP-specific. It allows you to configure an email
+	// Contact is TPP-specific. It allows you to configure an email
 	// address to send notifications about the certificate to. When an email is
 	// used by multiple TPP identities, the first identity found is picked
 	// arbitrarily.
 	//
-	// The scope `configuration` is required. Since ContactEmails works by
+	// The scope `configuration` is required. Since Contact works by
 	// searching the emails in the same LDAP or AD as the user attached to the
 	// token, you must check that you are using a user in that same identity
-	// provider. ContactEmails doesn't work with the local TPP identities. Using
-	// ContactEmails requires adding `mail` to the list of fields searched when
+	// provider. Contact doesn't work with the local TPP identities. Using
+	// Contact requires adding `mail` to the list of fields searched when
 	// performing a user search, which can be configured in the Venafi
 	// Configuration Console by RDP'ing into the TPP VM. This configuration
 	// cannot be performed directly in the TPP UI.
-	ContactEmails []string
+	Contacts []string
 
 	// Deprecated: use ValidityDuration instead, this field is ignored if ValidityDuration is set
 	ValidityHours int

--- a/pkg/certificate/request.go
+++ b/pkg/certificate/request.go
@@ -55,19 +55,26 @@ type Request struct {
 	ValidityPeriod   string //represents the validity of the certificate expressed as an ISO 8601 duration
 	IssuerHint       util.IssuerHint
 
-	// Contact is TPP-specific. It allows you to configure an email
-	// address to send notifications about the certificate to. When an email is
-	// used by multiple TPP identities, the first identity found is picked
-	// arbitrarily.
+	// Contacts allows you to configure email addresses to send notifications
+	// about the certificate. This field is TPP-specific.
 	//
-	// The scope `configuration` is required. Since Contact works by
-	// searching the emails in the same LDAP or AD as the user attached to the
-	// token, you must check that you are using a user in that same identity
-	// provider. Contact doesn't work with the local TPP identities. Using
-	// Contact requires adding `mail` to the list of fields searched when
-	// performing a user search, which can be configured in the Venafi
-	// Configuration Console by RDP'ing into the TPP VM. This configuration
-	// cannot be performed directly in the TPP UI.
+	// Note: the user who receives the notification isn't automatically given
+	// access to that certificate. Access is configured at the policy folder
+	// level; if the user doesn't permissions on that folder, they will not be
+	// able to see the certificate's status in TPP or remediate the problem
+	// through the TPP UI.
+	//
+	// When an email is used by multiple TPP identities, the first identity
+	// found is picked arbitrarily.
+	//
+	// The scope `configuration` is required. Since Contact works by searching
+	// the emails in the same LDAP or AD as the user attached to the token, you
+	// must check that you are using a user in that same identity provider.
+	// Contact doesn't work with the local TPP identities. Using Contact
+	// requires adding `mail` to the list of fields searched when performing a
+	// user search, which can be configured in the Venafi Configuration Console
+	// by RDP'ing into the TPP VM. This configuration cannot be performed
+	// directly in the TPP UI.
 	Contacts []string
 
 	// Deprecated: use ValidityDuration instead, this field is ignored if ValidityDuration is set

--- a/pkg/certificate/request.go
+++ b/pkg/certificate/request.go
@@ -55,6 +55,11 @@ type Request struct {
 	ValidityPeriod   string //represents the validity of the certificate expressed as an ISO 8601 duration
 	IssuerHint       util.IssuerHint
 
+	// ContactEmails is TPP-specific. It allows you to configure an email
+	// address to send notifications about the certificate to. Requires the
+	// scope `configuration`.
+	ContactEmails []string
+
 	// Deprecated: use ValidityDuration instead, this field is ignored if ValidityDuration is set
 	ValidityHours int
 }

--- a/pkg/policy/policyStructures.go
+++ b/pkg/policy/policyStructures.go
@@ -155,42 +155,6 @@ type TppPolicy struct {
 	WantRenewal          *int
 }
 
-type BrowseIdentitiesRequest struct {
-	Filter       string
-	Limit        int
-	IdentityType int
-}
-
-type BrowseIdentitiesResponse struct {
-	Identities []IdentityEntry
-}
-
-type IdentitySelfResponse struct {
-	Identities []IdentityEntry
-}
-
-type ValidateIdentityRequest struct {
-	ID IdentityInformation
-}
-
-type ValidateIdentityResponse struct {
-	ID IdentityEntry
-}
-
-type IdentityInformation struct {
-	PrefixedUniversal string
-}
-
-type IdentityEntry struct {
-	FullName          string
-	Name              string
-	Prefix            string
-	PrefixedName      string
-	PrefixedUniversal string
-	Type              int
-	Universal         string
-}
-
 type LockedAttribute struct {
 	Value  string
 	Locked bool

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -1192,7 +1192,7 @@ func (c *Connector) SetPolicy(name string, ps *policy.PolicySpecification) (stri
 func (c *Connector) setContact(tppPolicy *policy.TppPolicy) (status string, err error) {
 
 	if tppPolicy.Contact != nil {
-		contacts, err := c.resolvePrefixedUniversals(tppPolicy.Contact)
+		contacts, err := c.resolveContacts(tppPolicy.Contact)
 		if err != nil {
 			return "", fmt.Errorf("an error happened trying to resolve the contacts: %w", err)
 		}
@@ -1209,28 +1209,15 @@ func (c *Connector) setContact(tppPolicy *policy.TppPolicy) (status string, err 
 	return status, nil
 }
 
-func (c *Connector) resolvePrefixedUniversals(filters []string) ([]string, error) {
-	var prefixedUniversals []string
-	identities, err := c.resolveIdentities(filters)
-	if err != nil {
-		return nil, err
-	}
-	for _, identityEntry := range identities {
-		prefixedUniversals = append(prefixedUniversals, identityEntry.PrefixedUniversal)
-	}
-
-	return prefixedUniversals, nil
-}
-
-func (c *Connector) resolveIdentities(filters []string) ([]*IdentityEntry, error) {
-	var identities []*IdentityEntry
-	uniqueContacts := getUniqueStringSlice(filters)
+func (c *Connector) resolveContacts(contacts []string) ([]string, error) {
+	var identities []string
+	uniqueContacts := getUniqueStringSlice(contacts)
 	for _, contact := range uniqueContacts {
-		identityEntry, err := c.getIdentity(contact)
+		identity, err := c.getIdentity(contact)
 		if err != nil {
 			return nil, err
 		}
-		identities = append(identities, identityEntry)
+		identities = append(identities, identity.PrefixedUniversal)
 	}
 
 	return identities, nil

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -582,7 +582,7 @@ func (c *Connector) prepareRequest(req *certificate.Request, zone string) (tppRe
 		}
 	}
 
-	//resolving Contacts if them were provide
+	// Resolve emails to TPP identities if needed.
 	var contacts []IdentityEntry
 	if req.Contacts != nil {
 		var err error

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -1288,9 +1288,7 @@ func (c *Connector) getIdentity(filter string) (*IdentityEntry, error) {
 	switch {
 	case len(resp.Identities) == 0:
 		return nil, fmt.Errorf("no identity found for '%s'", filter)
-	case len(resp.Identities) == 1:
-		return &resp.Identities[0], nil
-	case len(resp.Identities) > 1 && !isEmail:
+	case len(resp.Identities) >= 1 && !isEmail:
 		// The username case: we need to ignore the results that are prefixes of
 		// the queried username. For example, if the filter is `jsmith`, we
 		// ignore `jsmithson` and `jsmithers`.
@@ -1300,7 +1298,7 @@ func (c *Connector) getIdentity(filter string) (*IdentityEntry, error) {
 			}
 		}
 		return nil, fmt.Errorf("%d identities were found but none of these identities has a username equal to '%s'", len(resp.Identities), filter)
-	case len(resp.Identities) > 1 && isEmail:
+	case len(resp.Identities) >= 1 && isEmail:
 		// The email case: we do not need to filter out anything. So let's
 		// arbitrarily return the first identity.
 		return &resp.Identities[0], nil

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -1301,7 +1301,7 @@ func (c *Connector) getIdentity(filter string) (*IdentityEntry, error) {
 				return &identity, nil
 			}
 		}
-		return nil, fmt.Errorf("unexpected: browseIdentities(%s) returned two identities but none of them match the username exactly", filter)
+		return nil, fmt.Errorf("unexpected: browseIdentities(%q) returned %d identities but none of them match the username exactly", filter, len(resp.Identities))
 	case len(resp.Identities) > 1 && isEmail:
 		// The email case: we do not need to filter out anything. So let's
 		// arbitrarily return the first identity.

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -697,11 +697,12 @@ func (c *Connector) RequestCertificate(req *certificate.Request) (requestID stri
 	var contactIdentities []contactIdentity
 	if req.ContactEmails != nil {
 		var err error
-		contactIdentities, err = c.findContactIdentities(req.ContactEmails)
+		contactIdentities, err = c.resolveContactEmails(req.ContactEmails)
 		if err != nil {
 			return "", fmt.Errorf("failed to find contact identities: %w", err)
 		}
 	}
+
 	tppCertificateRequest, err := prepareRequest(req, c.zone)
 	if err != nil {
 		return "", err
@@ -776,7 +777,9 @@ func (c *Connector) RequestCertificate(req *certificate.Request) (requestID stri
 	return
 }
 
-func (c *Connector) findContactIdentities(contactEmails []string) ([]contactIdentity, error) {
+// Unlike the resolveContacts func above that only works for usernames, this
+// func works with emails.
+func (c *Connector) resolveContactEmails(contactEmails []string) ([]contactIdentity, error) {
 	var contactIdentities []contactIdentity
 	for _, email := range contactEmails {
 		identity, err := c.browseIdentities(

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -779,7 +779,7 @@ func (c *Connector) RequestCertificate(req *certificate.Request) (requestID stri
 }
 
 // Unlike the resolveContacts func above that only works for usernames, this
-// func works with emails. Returns an error when no match is found.
+// func works with emails. No error is returned when no identity is found.
 //
 // It is possible that the same email is used by multiple TPP identities, that's
 // why multiple identities may be returned.
@@ -797,9 +797,6 @@ func (c *Connector) resolveEmail(email string) ([]identity, error) {
 		})
 	if err != nil {
 		return nil, fmt.Errorf("failed to find email %s: %w", email, err)
-	}
-	if len(resp.Identities) == 0 {
-		return nil, fmt.Errorf("email %s not found", email)
 	}
 
 	var identities []identity
@@ -829,6 +826,10 @@ func (c *Connector) resolveCertificateRequestContacts(emails []string) ([]contac
 		if err != nil {
 			return nil, err
 		}
+		if len(ids) == 0 {
+			return nil, fmt.Errorf("email %s was not found", email)
+		}
+
 		// Arbitrarily choose the first identity when multiple are found.
 		contacts = append(contacts, contactReq{
 			PrefixedUniversal: ids[0].PrefixedUniversal,

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -1306,7 +1306,9 @@ func (c *Connector) getIdentity(filter string) (*IdentityEntry, error) {
 		return &resp.Identities[0], nil
 	}
 
-	return nil, fmt.Errorf("programmer mistake: impossible case in getIdentity")
+	// The above switch cases must catch 100% of the cases. If we arrive here,
+	// it means that we have made a programming mistake.
+	return nil, fmt.Errorf("programmer mistake: browseIdentities returned %d identities for the filter '%s' and none of the switch cases matched, but the switch cases are expected to catch 100%% of the cases", len(resp.Identities), filter)
 }
 
 func (c *Connector) browseIdentities(browseReq BrowseIdentitiesRequest) (*BrowseIdentitiesResponse, error) {

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -1305,7 +1305,10 @@ func (c *Connector) getIdentityMatching(identities []IdentityEntry, identityName
 // the TPP UI.
 func (c *Connector) getIdentities(filter string) ([]IdentityEntry, error) {
 	resp, err := c.browseIdentities(BrowseIdentitiesRequest{
-		Filter:       filter,
+		Filter: filter,
+		// The limit can't be set to 0 when the identity provider is LDAP. So we
+		// use an arbitrarily large number.
+		Limit:        100,
 		IdentityType: policy.AllIdentities,
 	})
 	if err != nil {

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -1297,7 +1297,7 @@ func (c *Connector) getIdentity(filter string) (*IdentityEntry, error) {
 				return &identity, nil
 			}
 		}
-		return nil, fmt.Errorf("%d identities were found but none of these identities has a username equal to '%s'", len(resp.Identities), filter)
+		return nil, fmt.Errorf("it was not possible to find the user %s", filter)
 	case len(resp.Identities) >= 1 && isEmail:
 		// The email case: we do not need to filter out anything. So let's
 		// arbitrarily return the first identity.
@@ -1306,7 +1306,7 @@ func (c *Connector) getIdentity(filter string) (*IdentityEntry, error) {
 
 	// The above switch cases must catch 100% of the cases. If we arrive here,
 	// it means that we have made a programming mistake.
-	return nil, fmt.Errorf("programmer mistake: browseIdentities returned %d identities for the filter '%s' and none of the switch cases matched, but the switch cases are expected to catch 100%% of the cases", len(resp.Identities), filter)
+	return nil, fmt.Errorf("this was not supposed to happen, please report to the developer team: browseIdentities returned %d identities for the filter '%s' and none of the switch cases matched, but the switch cases are expected to catch 100%% of the cases", len(resp.Identities), filter)
 }
 
 func (c *Connector) browseIdentities(browseReq BrowseIdentitiesRequest) (*BrowseIdentitiesResponse, error) {

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -1286,15 +1286,15 @@ func (c *Connector) getIdentityMatching(identities []IdentityEntry, identityName
 //
 // Note: It is only possible to query usernames when using a local TPP user.
 // Querying emails isn't possible for local TPP identities. For querying an
-// email, you need to add `mail` to the list of fields searched when performing
-// a user search, which can be configured in the Venafi Configuration Console by
-// RDP'ing into the TPP VM. This configuration cannot be performed directly in
-// the TPP UI.
+// email when using LDAP or AD, you need to add `mail` to the list of fields
+// searched when performing a user search, which can be configured in the Venafi
+// Configuration Console by RDP'ing into the TPP VM. This configuration cannot
+// be performed directly in the TPP UI.
 func (c *Connector) getIdentities(filter string) ([]IdentityEntry, error) {
 	resp, err := c.browseIdentities(BrowseIdentitiesRequest{
 		Filter: filter,
-		// The limit can't be set to 0 when the identity provider is LDAP. So we
-		// use an arbitrarily large number.
+		// The limit can't be set to 0 when the identity provider is LDAP or AD.
+		// So we use an arbitrarily large number.
 		Limit:        100,
 		IdentityType: policy.AllIdentities,
 	})

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -837,16 +837,6 @@ func (c *Connector) resolveCertificateRequestContacts(emails []string) ([]contac
 	return contacts, nil
 }
 
-func identitiesToContactReqs(ids []identity) []contactReq {
-	var reqs []contactReq
-	for _, id := range ids {
-		reqs = append(reqs, contactReq{
-			PrefixedUniversal: id.PrefixedUniversal,
-		})
-	}
-	return reqs
-}
-
 // SynchronousRequestCertificate It's not supported yet in TPP
 func (c *Connector) SynchronousRequestCertificate(_ *certificate.Request) (certificates *certificate.PEMCollection, err error) {
 	panic("operation is not supported yet")

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -1245,6 +1245,9 @@ func getUniqueStringSlice(stringSlice []string) []string {
 	return list
 }
 
+// Searches for an identity using the username. The user name must exactly match
+// a username that exists in TPP. When two identities are found for the same
+// username, the first identity found is returned.
 func (c *Connector) getIdentity(userName string) (*IdentityEntry, error) {
 	if userName == "" {
 		return nil, fmt.Errorf("identity string cannot be null")
@@ -1264,6 +1267,8 @@ func (c *Connector) getIdentity(userName string) (*IdentityEntry, error) {
 	return c.getIdentityMatching(resp.Identities, userName)
 }
 
+// Returns the first identity in the given identities that matches the given
+// username. An error is returned when no identity matches the given username.
 func (c *Connector) getIdentityMatching(identities []IdentityEntry, identityName string) (*IdentityEntry, error) {
 	var identityEntryMatching *IdentityEntry
 

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -549,7 +549,7 @@ func TestRequestCertificateWithValidityDuration(t *testing.T) {
 }
 
 func TestRequestCertificateWithContactEmails(t *testing.T) {
-	t.Skipf("Skipping test because the TPP instance doesn't have LDAP configured")
+	t.Skipf("Skipping by default because this test only works over TPP instances which have LDAP users configured")
 
 	tpp, err := getTestConnector(ctx.TPPurl, ctx.TPPZone)
 	if err != nil {

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -3317,9 +3317,9 @@ func Test_getIdentity(t *testing.T) {
 			givenFilter: "jsmith",
 			mockReturns: []IdentityEntry{{
 				FullName:          "CN=jsmithers,CN=Users,DC=domain,DC=local",
-				Name:              "jsmithson",
+				Name:              "jsmithers",
 				Prefix:            "LDAP+AD",
-				PrefixedName:      "LDAP+AD:jsmithson",
+				PrefixedName:      "LDAP+AD:jsmithers",
 				PrefixedUniversal: "LDAP+AD:6ef23fe2-0728-4930-87a8-e1513d7087e4",
 				Type:              1,
 				Universal:         "6ef23fe2-0728-4930-87a8-e1513d7087e4",
@@ -3349,7 +3349,7 @@ func Test_getIdentity(t *testing.T) {
 				Type:              1,
 				Universal:         "{a89b8519-6fd7-4f88-9de8-3013f87c4fd7}",
 			}},
-			wantErr: "it was not possible to find the user jsmith",
+			wantFullName: "\\VED\\Identity\\jsmith",
 		}, {
 			name:        "email not found",
 			givenFilter: "jsmithson@venafi.com",
@@ -3400,13 +3400,6 @@ func Test_getIdentity(t *testing.T) {
 			req := BrowseIdentitiesRequest{}
 			err = json.Unmarshal(bytes, &req)
 			require.NoError(t, err)
-
-			// Only return the number of identities set in the Limit field.
-			if req.Limit <= len(mockReturns) {
-				mockReturns = mockReturns[:req.Limit]
-			}
-			require.GreaterOrEqual(t, req.Limit, len(mockReturns))
-
 			bytes, err = json.Marshal(BrowseIdentitiesResponse{Identities: mockReturns})
 			require.NoError(t, err)
 			w.Write(bytes)

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -3236,7 +3236,7 @@ func Test_getIdentity(t *testing.T) {
 		}, {
 			name:        "exact username found",
 			givenFilter: "foo",
-			mockReturns: []policy.IdentityEntry{{
+			mockReturns: []IdentityEntry{{
 				FullName:          "\\VED\\Identity\\foo",
 				Name:              "foo",
 				Prefix:            "local",
@@ -3249,7 +3249,7 @@ func Test_getIdentity(t *testing.T) {
 		}, {
 			name:        "mismatch with a longer username",
 			givenFilter: "foo",
-			mockReturns: []policy.IdentityEntry{{
+			mockReturns: []IdentityEntry{{
 				FullName:          "\\VED\\Identity\\foobar",
 				Name:              "foobar", // "longer" username.
 				Prefix:            "local",
@@ -3258,7 +3258,7 @@ func Test_getIdentity(t *testing.T) {
 				Type:              1,
 				Universal:         "{c1f0ac9a-c9da-55a7-963a-fd6445af8307}",
 			}},
-			wantErr: "it was not possible to find the user foo",
+			wantErr: "1 identities were found but none of these identities has a username equal to 'foo'",
 		}, {
 			name: "finds the first exact username match: exact match in 2nd position",
 			// In this example, we reproduce the case where the AD has
@@ -3289,7 +3289,7 @@ func Test_getIdentity(t *testing.T) {
 			name: "finds the first exact username match: exact match in 1st position",
 			// Same, except that the correct match is first.
 			givenFilter: "jsmith",
-			mockReturns: []policy.IdentityEntry{{
+			mockReturns: []IdentityEntry{{
 				// This is the identity that is expected to be returned.
 				FullName:          "CN=jsmith,CN=Users,DC=domain,DC=local",
 				Name:              "jsmith",

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -3349,7 +3349,7 @@ func Test_getIdentity(t *testing.T) {
 				Type:              1,
 				Universal:         "{a89b8519-6fd7-4f88-9de8-3013f87c4fd7}",
 			}},
-			wantErr: "unexpected: browseIdentities(jsmith) returned two identities but none of them match the username exactly",
+			wantErr: "2 identities were found but none of these identities has a username equal to 'jsmith'",
 		}, {
 			name:        "email not found",
 			givenFilter: "jsmithson@venafi.com",

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -567,7 +567,7 @@ func TestRequestCertificateWithContactEmails(t *testing.T) {
 		Timeout:  time.Second * 30,
 		Subject:  pkix.Name{CommonName: test.RandCN()},
 		DNSNames: []string{"example.com"},
-		Contacts: []string{"mael.valais@venafi.com"},
+		Contacts: []string{"mael.valais@venafi.com", "richard.wall@venafi.com"},
 	}
 
 	config, err := tpp.ReadZoneConfiguration()
@@ -3258,7 +3258,7 @@ func Test_getIdentity(t *testing.T) {
 				Type:              1,
 				Universal:         "{c1f0ac9a-c9da-55a7-963a-fd6445af8307}",
 			}},
-			wantErr: "1 identities were found but none of these identities has a username equal to 'foo'",
+			wantErr: "it was not possible to find the user foo",
 		}, {
 			name: "finds the first exact username match: exact match in 2nd position",
 			// In this example, we reproduce the case where the AD has
@@ -3349,7 +3349,7 @@ func Test_getIdentity(t *testing.T) {
 				Type:              1,
 				Universal:         "{a89b8519-6fd7-4f88-9de8-3013f87c4fd7}",
 			}},
-			wantErr: "2 identities were found but none of these identities has a username equal to 'jsmith'",
+			wantErr: "it was not possible to find the user jsmith",
 		}, {
 			name:        "email not found",
 			givenFilter: "jsmithson@venafi.com",

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -62,16 +62,19 @@ type device struct {
 }
 
 type certificateRequest struct {
-	PolicyDN                string          `json:",omitempty"`
-	CADN                    string          `json:",omitempty"`
-	ObjectName              string          `json:",omitempty"`
-	Subject                 string          `json:",omitempty"`
-	OrganizationalUnit      string          `json:",omitempty"`
-	Organization            string          `json:",omitempty"`
-	City                    string          `json:",omitempty"`
-	State                   string          `json:",omitempty"`
-	Country                 string          `json:",omitempty"`
-	SubjectAltNames         []sanItem       `json:",omitempty"`
+	PolicyDN           string    `json:",omitempty"`
+	CADN               string    `json:",omitempty"`
+	ObjectName         string    `json:",omitempty"`
+	Subject            string    `json:",omitempty"`
+	OrganizationalUnit string    `json:",omitempty"`
+	Organization       string    `json:",omitempty"`
+	City               string    `json:",omitempty"`
+	State              string    `json:",omitempty"`
+	Country            string    `json:",omitempty"`
+	SubjectAltNames    []sanItem `json:",omitempty"`
+
+	// TPP only considers the fields `PrefixedUniversal`, `Prefix`, and
+	// `Universal` from the IdentityEntry struct.
 	Contacts                []IdentityEntry `json:",omitempty"`
 	CASpecificAttributes    []nameValuePair `json:",omitempty"`
 	Origin                  string          `json:",omitempty"`

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/Venafi/vcert/v5/pkg/certificate"
 	"github.com/Venafi/vcert/v5/pkg/endpoint"
-	"github.com/Venafi/vcert/v5/pkg/policy"
 )
 
 const defaultKeySize = 2048
@@ -73,7 +72,7 @@ type certificateRequest struct {
 	State                   string          `json:",omitempty"`
 	Country                 string          `json:",omitempty"`
 	SubjectAltNames         []sanItem       `json:",omitempty"`
-	Contacts                []contactReq    `json:",omitempty"`
+	Contacts                []IdentityEntry `json:",omitempty"`
 	CASpecificAttributes    []nameValuePair `json:",omitempty"`
 	Origin                  string          `json:",omitempty"`
 	PKCS10                  string          `json:",omitempty"`
@@ -151,6 +150,42 @@ type certificateResetRequest struct {
 
 type certificateResetResponse struct {
 	Error string `json:"Error"`
+}
+
+type BrowseIdentitiesRequest struct {
+	Filter       string
+	Limit        int
+	IdentityType int
+}
+
+type BrowseIdentitiesResponse struct {
+	Identities []IdentityEntry
+}
+
+type IdentitySelfResponse struct {
+	Identities []IdentityEntry
+}
+
+type ValidateIdentityRequest struct {
+	ID IdentityInformation
+}
+
+type ValidateIdentityResponse struct {
+	ID IdentityEntry
+}
+
+type IdentityInformation struct {
+	PrefixedUniversal string
+}
+
+type IdentityEntry struct {
+	FullName          string `json:",omitempty"`
+	Name              string `json:",omitempty"`
+	Prefix            string `json:",omitempty"`
+	PrefixedName      string `json:",omitempty"`
+	PrefixedUniversal string `json:",omitempty"`
+	Type              int    `json:",omitempty"`
+	Universal         string `json:",omitempty"`
 }
 
 type sanItem struct {
@@ -344,10 +379,6 @@ type identity struct {
 	PrefixedUniversal string `json:"PrefixedUniversal"`
 	Type              int    `json:"Type"`
 	Universal         string `json:"Universal"`
-}
-
-type contactReq struct {
-	PrefixedUniversal string `json:"PrefixedUniversal"`
 }
 
 type systemStatusVersionResponse string
@@ -721,8 +752,8 @@ func newPEMCollectionFromResponse(base64Response string, chainOrder certificate.
 	return nil, nil
 }
 
-func parseBrowseIdentitiesResult(httpStatusCode int, httpStatus string, body []byte) (policy.BrowseIdentitiesResponse, error) {
-	var browseIdentitiesResponse policy.BrowseIdentitiesResponse
+func parseBrowseIdentitiesResult(httpStatusCode int, httpStatus string, body []byte) (BrowseIdentitiesResponse, error) {
+	var browseIdentitiesResponse BrowseIdentitiesResponse
 	switch httpStatusCode {
 	case http.StatusOK, http.StatusAccepted:
 		browseIdentitiesResponse, err := parseBrowseIdentitiesData(body)
@@ -735,13 +766,13 @@ func parseBrowseIdentitiesResult(httpStatusCode int, httpStatus string, body []b
 	}
 }
 
-func parseBrowseIdentitiesData(b []byte) (data policy.BrowseIdentitiesResponse, err error) {
+func parseBrowseIdentitiesData(b []byte) (data BrowseIdentitiesResponse, err error) {
 	err = json.Unmarshal(b, &data)
 	return
 }
 
-func parseValidateIdentityResponse(httpStatusCode int, httpStatus string, body []byte) (policy.ValidateIdentityResponse, error) {
-	var validateIdentityResponse policy.ValidateIdentityResponse
+func parseValidateIdentityResponse(httpStatusCode int, httpStatus string, body []byte) (ValidateIdentityResponse, error) {
+	var validateIdentityResponse ValidateIdentityResponse
 	switch httpStatusCode {
 	case http.StatusOK, http.StatusAccepted:
 		validateIdentityResponse, err := parseValidateIdentityData(body)
@@ -754,7 +785,7 @@ func parseValidateIdentityResponse(httpStatusCode int, httpStatus string, body [
 	}
 }
 
-func parseValidateIdentityData(b []byte) (data policy.ValidateIdentityResponse, err error) {
+func parseValidateIdentityData(b []byte) (data ValidateIdentityResponse, err error) {
 	err = json.Unmarshal(b, &data)
 	return
 }

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -63,28 +63,28 @@ type device struct {
 }
 
 type certificateRequest struct {
-	PolicyDN                string          `json:",omitempty"`
-	CADN                    string          `json:",omitempty"`
-	ObjectName              string          `json:",omitempty"`
-	Subject                 string          `json:",omitempty"`
-	OrganizationalUnit      string          `json:",omitempty"`
-	Organization            string          `json:",omitempty"`
-	City                    string          `json:",omitempty"`
-	State                   string          `json:",omitempty"`
-	Country                 string          `json:",omitempty"`
-	SubjectAltNames         []sanItem       `json:",omitempty"`
-	Contact                 string          `json:",omitempty"`
-	CASpecificAttributes    []nameValuePair `json:",omitempty"`
-	Origin                  string          `json:",omitempty"`
-	PKCS10                  string          `json:",omitempty"`
-	KeyAlgorithm            string          `json:",omitempty"`
-	KeyBitSize              int             `json:",omitempty"`
-	EllipticCurve           string          `json:",omitempty"`
-	DisableAutomaticRenewal bool            `json:",omitempty"`
-	CustomFields            []customField   `json:",omitempty"`
-	Devices                 []device        `json:",omitempty"`
-	CertificateType         string          `json:",omitempty"`
-	Reenable                bool            `json:",omitempty"`
+	PolicyDN                string            `json:",omitempty"`
+	CADN                    string            `json:",omitempty"`
+	ObjectName              string            `json:",omitempty"`
+	Subject                 string            `json:",omitempty"`
+	OrganizationalUnit      string            `json:",omitempty"`
+	Organization            string            `json:",omitempty"`
+	City                    string            `json:",omitempty"`
+	State                   string            `json:",omitempty"`
+	Country                 string            `json:",omitempty"`
+	SubjectAltNames         []sanItem         `json:",omitempty"`
+	Contacts                []contactIdentity `json:",omitempty"`
+	CASpecificAttributes    []nameValuePair   `json:",omitempty"`
+	Origin                  string            `json:",omitempty"`
+	PKCS10                  string            `json:",omitempty"`
+	KeyAlgorithm            string            `json:",omitempty"`
+	KeyBitSize              int               `json:",omitempty"`
+	EllipticCurve           string            `json:",omitempty"`
+	DisableAutomaticRenewal bool              `json:",omitempty"`
+	CustomFields            []customField     `json:",omitempty"`
+	Devices                 []device          `json:",omitempty"`
+	CertificateType         string            `json:",omitempty"`
+	Reenable                bool              `json:",omitempty"`
 }
 
 type certificateRetrieveRequest struct {
@@ -151,6 +151,11 @@ type certificateResetRequest struct {
 
 type certificateResetResponse struct {
 	Error string `json:"Error"`
+}
+
+// https://docs.venafi.com/Docs/currentSDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-request-IdentityHow.php
+type contactIdentity struct {
+	PrefixedUniversal string `json:",omitempty"`
 }
 
 type sanItem struct {

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -62,19 +62,16 @@ type device struct {
 }
 
 type certificateRequest struct {
-	PolicyDN           string    `json:",omitempty"`
-	CADN               string    `json:",omitempty"`
-	ObjectName         string    `json:",omitempty"`
-	Subject            string    `json:",omitempty"`
-	OrganizationalUnit string    `json:",omitempty"`
-	Organization       string    `json:",omitempty"`
-	City               string    `json:",omitempty"`
-	State              string    `json:",omitempty"`
-	Country            string    `json:",omitempty"`
-	SubjectAltNames    []sanItem `json:",omitempty"`
-
-	// TPP only considers the fields `PrefixedUniversal`, `Prefix`, and
-	// `Universal` from the IdentityEntry struct.
+	PolicyDN                string          `json:",omitempty"`
+	CADN                    string          `json:",omitempty"`
+	ObjectName              string          `json:",omitempty"`
+	Subject                 string          `json:",omitempty"`
+	OrganizationalUnit      string          `json:",omitempty"`
+	Organization            string          `json:",omitempty"`
+	City                    string          `json:",omitempty"`
+	State                   string          `json:",omitempty"`
+	Country                 string          `json:",omitempty"`
+	SubjectAltNames         []sanItem       `json:",omitempty"`
 	Contacts                []IdentityEntry `json:",omitempty"`
 	CASpecificAttributes    []nameValuePair `json:",omitempty"`
 	Origin                  string          `json:",omitempty"`

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -73,7 +73,7 @@ type certificateRequest struct {
 	State                   string          `json:",omitempty"`
 	Country                 string          `json:",omitempty"`
 	SubjectAltNames         []sanItem       `json:",omitempty"`
-	Contacts                []identityReq   `json:",omitempty"`
+	Contacts                []contactReq    `json:",omitempty"`
 	CASpecificAttributes    []nameValuePair `json:",omitempty"`
 	Origin                  string          `json:",omitempty"`
 	PKCS10                  string          `json:",omitempty"`
@@ -346,7 +346,7 @@ type identity struct {
 	Universal         string `json:"Universal"`
 }
 
-type identityReq struct {
+type contactReq struct {
 	PrefixedUniversal string `json:"PrefixedUniversal"`
 }
 

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -63,28 +63,28 @@ type device struct {
 }
 
 type certificateRequest struct {
-	PolicyDN                string            `json:",omitempty"`
-	CADN                    string            `json:",omitempty"`
-	ObjectName              string            `json:",omitempty"`
-	Subject                 string            `json:",omitempty"`
-	OrganizationalUnit      string            `json:",omitempty"`
-	Organization            string            `json:",omitempty"`
-	City                    string            `json:",omitempty"`
-	State                   string            `json:",omitempty"`
-	Country                 string            `json:",omitempty"`
-	SubjectAltNames         []sanItem         `json:",omitempty"`
-	Contacts                []contactIdentity `json:",omitempty"`
-	CASpecificAttributes    []nameValuePair   `json:",omitempty"`
-	Origin                  string            `json:",omitempty"`
-	PKCS10                  string            `json:",omitempty"`
-	KeyAlgorithm            string            `json:",omitempty"`
-	KeyBitSize              int               `json:",omitempty"`
-	EllipticCurve           string            `json:",omitempty"`
-	DisableAutomaticRenewal bool              `json:",omitempty"`
-	CustomFields            []customField     `json:",omitempty"`
-	Devices                 []device          `json:",omitempty"`
-	CertificateType         string            `json:",omitempty"`
-	Reenable                bool              `json:",omitempty"`
+	PolicyDN                string          `json:",omitempty"`
+	CADN                    string          `json:",omitempty"`
+	ObjectName              string          `json:",omitempty"`
+	Subject                 string          `json:",omitempty"`
+	OrganizationalUnit      string          `json:",omitempty"`
+	Organization            string          `json:",omitempty"`
+	City                    string          `json:",omitempty"`
+	State                   string          `json:",omitempty"`
+	Country                 string          `json:",omitempty"`
+	SubjectAltNames         []sanItem       `json:",omitempty"`
+	Contacts                []identity      `json:",omitempty"`
+	CASpecificAttributes    []nameValuePair `json:",omitempty"`
+	Origin                  string          `json:",omitempty"`
+	PKCS10                  string          `json:",omitempty"`
+	KeyAlgorithm            string          `json:",omitempty"`
+	KeyBitSize              int             `json:",omitempty"`
+	EllipticCurve           string          `json:",omitempty"`
+	DisableAutomaticRenewal bool            `json:",omitempty"`
+	CustomFields            []customField   `json:",omitempty"`
+	Devices                 []device        `json:",omitempty"`
+	CertificateType         string          `json:",omitempty"`
+	Reenable                bool            `json:",omitempty"`
 }
 
 type certificateRetrieveRequest struct {
@@ -151,11 +151,6 @@ type certificateResetRequest struct {
 
 type certificateResetResponse struct {
 	Error string `json:"Error"`
-}
-
-// https://docs.venafi.com/Docs/currentSDK/TopNav/Content/SDK/WebSDK/r-SDK-POST-Certificates-request-IdentityHow.php
-type contactIdentity struct {
-	PrefixedUniversal string `json:",omitempty"`
 }
 
 type sanItem struct {

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -73,7 +73,7 @@ type certificateRequest struct {
 	State                   string          `json:",omitempty"`
 	Country                 string          `json:",omitempty"`
 	SubjectAltNames         []sanItem       `json:",omitempty"`
-	Contacts                []identity      `json:",omitempty"`
+	Contacts                []identityReq   `json:",omitempty"`
 	CASpecificAttributes    []nameValuePair `json:",omitempty"`
 	Origin                  string          `json:",omitempty"`
 	PKCS10                  string          `json:",omitempty"`
@@ -344,6 +344,10 @@ type identity struct {
 	PrefixedUniversal string `json:"PrefixedUniversal"`
 	Type              int    `json:"Type"`
 	Universal         string `json:"Universal"`
+}
+
+type identityReq struct {
+	PrefixedUniversal string `json:"PrefixedUniversal"`
 }
 
 type systemStatusVersionResponse string


### PR DESCRIPTION
To be considered:

- I wrote an end-to-end test but it will fail on VCert's TPP test instance https://supertreat.venqa.venafi.com/ because this instance only has local users, but this feature requires TPP to be configured with LDAP or AD. I'm not sure how to proceed with this.
- The func `RequestCertificate` now requires the scope `configuration` when ~`ContactEmails`~ `Contacts` is used. I don't think that's a big deal as long as we indicate it in the Go struct's documentation as well as above the RequestCertificate func.


Regarding the new ~`ContactEmails`~ `Contacts` field that I propose on the Request struct, I thought about making it more generic to allow for using an ID in the future (corresponding to the prefixed universal in TPP or a UUID in TLSPC) but since I could not find a reason for anyone to use a prefixed universal or TLSPC UUID (imagining we do implement ~`ContactEmails`~ `Contacts` for TLSPC in the future). I think it's fine to go with just ~`ContactEmails`~ `Contacts`.

Links (private to Venafi):

- [Use-case on Confluence](https://venafi.atlassian.net/wiki/spaces/~862991627/pages/2266071146/VCert+Set+the+Contact+Field+Using+an+Email+When+Requesting+Certificates+TPP)
- [Jira Feature](https://venafi.atlassian.net/browse/VC-28331)
