### PR TITLE
Feat: Add support to Contacts for CertReq on TPP

### DIFF
--- a/pkg/certificate/request.go
+++ b/pkg/certificate/request.go
@@ -55,6 +55,21 @@ type Request struct {
 	ValidityPeriod   string //represents the validity of the certificate expressed as an ISO 8601 duration
 	IssuerHint       util.IssuerHint
 
+	// ContactEmails is TPP-specific. It allows you to configure an email
+	// address to send notifications about the certificate to. When an email is
+	// used by multiple TPP identities, the first identity found is picked
+	// arbitrarily.
+	//
+	// The scope `configuration` is required. Since ContactEmails works by
+	// searching the emails in the same LDAP or AD as the user attached to the
+	// token, you must check that you are using a user in that same identity
+	// provider. ContactEmails doesn't work with the local TPP identities. Using
+	// ContactEmails requires adding `mail` to the list of fields searched when
+	// performing a user search, which can be configured in the Venafi
+	// Configuration Console by RDP'ing into the TPP VM. This configuration
+	// cannot be performed directly in the TPP UI.
+	Contacts []string
+
 	// Deprecated: use ValidityDuration instead, this field is ignored if ValidityDuration is set
 	ValidityHours int
 }

--- a/pkg/policy/policyStructures.go
+++ b/pkg/policy/policyStructures.go
@@ -155,42 +155,6 @@ type TppPolicy struct {
 	WantRenewal          *int
 }
 
-type BrowseIdentitiesRequest struct {
-	Filter       string
-	Limit        int
-	IdentityType int
-}
-
-type BrowseIdentitiesResponse struct {
-	Identities []IdentityEntry
-}
-
-type IdentitySelfResponse struct {
-	Identities []IdentityEntry
-}
-
-type ValidateIdentityRequest struct {
-	ID IdentityInformation
-}
-
-type ValidateIdentityResponse struct {
-	ID IdentityEntry
-}
-
-type IdentityInformation struct {
-	PrefixedUniversal string
-}
-
-type IdentityEntry struct {
-	FullName          string
-	Name              string
-	Prefix            string
-	PrefixedName      string
-	PrefixedUniversal string
-	Type              int
-	Universal         string
-}
-
 type LockedAttribute struct {
 	Value  string
 	Locked bool

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -2330,7 +2330,7 @@ func TestOmitSans(t *testing.T) {
 		Timeout:   30 * time.Second,
 	}
 
-	tppReq, err := prepareRequest(&req, tpp.zone)
+	tppReq, err := tpp.prepareRequest(&req, tpp.zone)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/Venafi/vcert/v5/pkg/certificate"
 	"github.com/Venafi/vcert/v5/pkg/endpoint"
-	"github.com/Venafi/vcert/v5/pkg/policy"
 )
 
 const defaultKeySize = 2048
@@ -73,7 +72,7 @@ type certificateRequest struct {
 	State                   string          `json:",omitempty"`
 	Country                 string          `json:",omitempty"`
 	SubjectAltNames         []sanItem       `json:",omitempty"`
-	Contact                 string          `json:",omitempty"`
+	Contacts                []IdentityEntry `json:",omitempty"`
 	CASpecificAttributes    []nameValuePair `json:",omitempty"`
 	Origin                  string          `json:",omitempty"`
 	PKCS10                  string          `json:",omitempty"`
@@ -98,8 +97,8 @@ type certificateRetrieveRequest struct {
 }
 
 type certificateRetrieveResponse struct {
-	CertificateData string `json:",omitempty"`
 	Format          string `json:",omitempty"`
+	CertificateData string `json:",omitempty"`
 	Filename        string `json:",omitempty"`
 	Status          string `json:",omitempty"`
 	Stage           int    `json:",omitempty"`
@@ -156,6 +155,42 @@ type certificateResetResponse struct {
 type sanItem struct {
 	Type int    `json:""`
 	Name string `json:""`
+}
+
+type IdentityEntry struct {
+	FullName          string `json:",omitempty"`
+	Name              string `json:",omitempty"`
+	Prefix            string `json:",omitempty"`
+	PrefixedName      string `json:",omitempty"`
+	PrefixedUniversal string `json:",omitempty"`
+	Type              int    `json:",omitempty"`
+	Universal         string `json:",omitempty"`
+}
+
+type BrowseIdentitiesResponse struct {
+	Identities []IdentityEntry
+}
+
+type IdentitySelfResponse struct {
+	Identities []IdentityEntry
+}
+
+type ValidateIdentityResponse struct {
+	ID IdentityEntry
+}
+
+type BrowseIdentitiesRequest struct {
+	Filter       string
+	Limit        int
+	IdentityType int
+}
+
+type ValidateIdentityRequest struct {
+	ID IdentityInformation
+}
+
+type IdentityInformation struct {
+	PrefixedUniversal string
 }
 
 type nameValuePair struct {
@@ -717,8 +752,8 @@ func newPEMCollectionFromResponse(base64Response string, chainOrder certificate.
 	return nil, nil
 }
 
-func parseBrowseIdentitiesResult(httpStatusCode int, httpStatus string, body []byte) (policy.BrowseIdentitiesResponse, error) {
-	var browseIdentitiesResponse policy.BrowseIdentitiesResponse
+func parseBrowseIdentitiesResult(httpStatusCode int, httpStatus string, body []byte) (BrowseIdentitiesResponse, error) {
+	var browseIdentitiesResponse BrowseIdentitiesResponse
 	switch httpStatusCode {
 	case http.StatusOK, http.StatusAccepted:
 		browseIdentitiesResponse, err := parseBrowseIdentitiesData(body)
@@ -731,13 +766,13 @@ func parseBrowseIdentitiesResult(httpStatusCode int, httpStatus string, body []b
 	}
 }
 
-func parseBrowseIdentitiesData(b []byte) (data policy.BrowseIdentitiesResponse, err error) {
+func parseBrowseIdentitiesData(b []byte) (data BrowseIdentitiesResponse, err error) {
 	err = json.Unmarshal(b, &data)
 	return
 }
 
-func parseValidateIdentityResponse(httpStatusCode int, httpStatus string, body []byte) (policy.ValidateIdentityResponse, error) {
-	var validateIdentityResponse policy.ValidateIdentityResponse
+func parseValidateIdentityResponse(httpStatusCode int, httpStatus string, body []byte) (ValidateIdentityResponse, error) {
+	var validateIdentityResponse ValidateIdentityResponse
 	switch httpStatusCode {
 	case http.StatusOK, http.StatusAccepted:
 		validateIdentityResponse, err := parseValidateIdentityData(body)
@@ -750,7 +785,7 @@ func parseValidateIdentityResponse(httpStatusCode int, httpStatus string, body [
 	}
 }
 
-func parseValidateIdentityData(b []byte) (data policy.ValidateIdentityResponse, err error) {
+func parseValidateIdentityData(b []byte) (data ValidateIdentityResponse, err error) {
 	err = json.Unmarshal(b, &data)
 	return
 }


### PR DESCRIPTION
- The tpp.Connector.resolveContacts() method was refactored so it can be user not only for SetPolicy purpose but also for Request Certificate.
- The Structs related to Identity were moved from policy package to tpp package.
- The tpp.prepareRequest() function was converted in a tpp.Connector method and it also was added the management to resolve and set the Contacts to the TPP Certificate Request.