### PR TITLE
Contact Emails: Add unit tests for `getIdentity`

### DIFF
--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -28,6 +28,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -48,6 +49,7 @@ import (
 	"github.com/Venafi/vcert/v5/pkg/util"
 	"github.com/Venafi/vcert/v5/pkg/verror"
 	"github.com/Venafi/vcert/v5/test"
+	"github.com/stretchr/testify/require"
 )
 
 var ctx *test.Context
@@ -3149,5 +3151,127 @@ func TestWriteLog(t *testing.T) {
 	err = tpp.WriteLog(&logReq)
 	if err != nil {
 		t.Fatalf("err is not nil, err: %s", err)
+	}
+}
+
+func Test_getIdentity(t *testing.T) {
+	tests := []struct {
+		name string
+
+		givenFilter  string
+		mockReturns  []policy.IdentityEntry
+		wantFullName string
+		wantErr      string
+	}{
+		{
+			name:        "no identities",
+			givenFilter: "jsmith",
+			mockReturns: []policy.IdentityEntry{},
+			wantErr:     "it was not possible to find the user jsmith",
+		}, {
+			// In this example, we reproduce the case where the AD has
+			// `jsmithson`, and there is a local `jsmith` (the AD identity
+			// provider was given permission to access the local identities).
+			// The response comes from a real-world TPP instance.
+			name:        "wrong username picked due to 1 other username with same prefix",
+			givenFilter: "jsmith",
+			mockReturns: []policy.IdentityEntry{{
+				FullName:          "CN=jsmithson,CN=Users,DC=domain,DC=local",
+				Name:              "jsmithson",
+				Prefix:            "LDAP+AD",
+				PrefixedName:      "LDAP+AD:jsmithson",
+				PrefixedUniversal: "LDAP+AD:6ef23fe2-0728-4930-87a8-e1513d7087e4",
+				Type:              1,
+				Universal:         "6ef23fe2-0728-4930-87a8-e1513d7087e4",
+			}, {
+				// This is the identity that is expected to be returned.
+				FullName:          "\\VED\\Identity\\jsmith",
+				Name:              "jsmith",
+				Prefix:            "local",
+				PrefixedName:      "local:jsmith",
+				PrefixedUniversal: "local:{46cdaf34-0d13-4f8f-8c75-4c8df24783d7}",
+				Type:              1,
+				Universal:         "{46cdaf34-0d13-4f8f-8c75-4c8df24783d7}",
+			}},
+			wantFullName: "\\VED\\Identity\\jsmith",
+		}, {
+			// Same, but with the maximum number of identities that can be
+			// returned with Limit=2. The response comes from a real-world TPP
+			// instance. There are 4 items are returned the limit applies to
+			// each identity provider separately.
+			name:        "wrong username picked due to 2 other usernames with same prefix",
+			givenFilter: "jsmith",
+			mockReturns: []policy.IdentityEntry{{
+				FullName:          "CN=jsmithers,CN=Users,DC=domain,DC=local",
+				Name:              "jsmithson",
+				Prefix:            "LDAP+AD",
+				PrefixedName:      "LDAP+AD:jsmithson",
+				PrefixedUniversal: "LDAP+AD:6ef23fe2-0728-4930-87a8-e1513d7087e4",
+				Type:              1,
+				Universal:         "6ef23fe2-0728-4930-87a8-e1513d7087e4",
+			}, {
+				FullName:          "CN=jsmithson,CN=Users,DC=domain,DC=local",
+				Name:              "jsmithson",
+				Prefix:            "LDAP+AD",
+				PrefixedName:      "LDAP+AD:jsmithson",
+				PrefixedUniversal: "LDAP+AD:6ef23fe2-0728-4930-87a8-e1513d7087e4",
+				Type:              1,
+				Universal:         "6ef23fe2-0728-4930-87a8-e1513d7087e4",
+			}, {
+				// This is the identity that is expected to be returned.
+				FullName:          "\\VED\\Identity\\jsmith",
+				Name:              "jsmith",
+				Prefix:            "local",
+				PrefixedName:      "local:jsmith",
+				PrefixedUniversal: "local:{46cdaf34-0d13-4f8f-8c75-4c8df24783d7}",
+				Type:              1,
+				Universal:         "{46cdaf34-0d13-4f8f-8c75-4c8df24783d7}",
+			}, {
+				FullName:          "\\VED\\Identity\\jsmithson",
+				Name:              "jsmithson",
+				Prefix:            "local",
+				PrefixedName:      "local:jsmithson",
+				PrefixedUniversal: "local:{a89b8519-6fd7-4f88-9de8-3013f87c4fd7}",
+				Type:              1,
+				Universal:         "{a89b8519-6fd7-4f88-9de8-3013f87c4fd7}",
+			}},
+			wantFullName: "\\VED\\Identity\\jsmith",
+		},
+	}
+
+	serverWith := func(t *testing.T, mockReturns []policy.IdentityEntry) (_ *httptest.Server, ca *x509.CertPool) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "/vedsdk/Identity/Browse", r.URL.Path)
+			bytes, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			req := policy.BrowseIdentitiesRequest{}
+			err = json.Unmarshal(bytes, &req)
+			require.NoError(t, err)
+			bytes, err = json.Marshal(policy.BrowseIdentitiesResponse{Identities: mockReturns})
+			require.NoError(t, err)
+			w.Write(bytes)
+		}))
+		t.Cleanup(server.Close)
+		ca = x509.NewCertPool()
+		ca.AddCert(server.Certificate())
+		return server, ca
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			server, ca := serverWith(t, tt.mockReturns)
+			tpp, err := NewConnector(server.URL, `\VED\Policy\Test`, true, ca)
+			require.NoError(t, err)
+
+			got, gotErr := tpp.getIdentity(tt.givenFilter)
+			if tt.wantErr != "" {
+				require.EqualError(t, gotErr, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, gotErr)
+			require.Equal(t, tt.wantFullName, got.FullName)
+		})
 	}
 }


### PR DESCRIPTION
This PR should be merged before continuing reviews on #418.

I paused working on #418 so that I could write some unit tests around `getIdentity` with the existing implementation (the one in the master branch). Once we have the unit tests merged to master, we can resume working on #418.

I could have added all of these tests directly to #418, but we wouldn't be sure whether the old implementation and the new implementation pass the same tests.

This way, we can decrease the chance of introducing a regression in `getIdentity`.

To know more about the tricks that `getIdentity` does, you can read https://github.com/Venafi/vcert/pull/221#issuecomment-1911747389.