### PR TITLE
Enables WorkToDoTimeout for certificate request

### DIFF
--- a/pkg/certificate/request.go
+++ b/pkg/certificate/request.go
@@ -47,7 +47,16 @@ type Request struct {
 	FetchPrivateKey bool
 	/*	Thumbprint is here because *Request is used in RetrieveCertificate().
 		Code should be refactored so that RetrieveCertificate() uses some abstract search object, instead of *Request{PickupID} */
-	Thumbprint       string
+	Thumbprint string
+	// Timeout we have multiple purposes for timeout (bad practice, we need to correct this in the future)
+	// TPP (a.k.a TLPSDC): we use it in order to set WorkToDoTimeout, that overrides TPP default timeout waiting time for the CA to finish
+	// if the value is more than the maximum value, TPP will automatically set the maximum value supported (as of the moment of this
+	// commit, 120 seconds).
+	// Cloud (a.k.a VaaS a.k.a TLPSC) : We use this timeout in our RetrieveCertificate function which handles a retry logic
+	// TPP SSH feature: We override the http client default timeout to perform http requests.
+	// Firefly: not usage at all
+	// VCert CLI: We have hardcoded 180 seconds for retrieve certificate operation. For VaaS it will set retry logic for
+	// 180 seconds and TPP will override CA timeout as the hardcoded value
 	Timeout          time.Duration
 	CustomFields     []CustomField
 	Location         *Location

--- a/pkg/certificate/request.go
+++ b/pkg/certificate/request.go
@@ -48,14 +48,16 @@ type Request struct {
 	/*	Thumbprint is here because *Request is used in RetrieveCertificate().
 		Code should be refactored so that RetrieveCertificate() uses some abstract search object, instead of *Request{PickupID} */
 	Thumbprint string
-	// Timeout we have multiple purposes for timeout (bad practice, we need to correct this in the future)
-	// TPP (a.k.a TLPSDC): we use it in order to set WorkToDoTimeout, that overrides TPP default timeout waiting time for the CA to finish
+	// Timeout usage:
+	// TPP (a.k.a TLSPDC): we use it in order to set WorkToDoTimeout, that overrides TPP default timeout waiting time for the CA to finish
 	// if the value is more than the maximum value, TPP will automatically set the maximum value supported (as of the moment of this
 	// commit, 120 seconds).
-	// Cloud (a.k.a VaaS a.k.a TLPSC) : We use this timeout in our RetrieveCertificate function which handles a retry logic
+	// Cloud (a.k.a VaaS a.k.a TLSPC) : We use this timeout in our RetrieveCertificate function which handles a retry logic
 	// TPP SSH feature: We override the http client default timeout to perform http requests.
 	// Firefly: not usage at all
-	// VCert CLI: We have hardcoded 180 seconds for retrieve certificate operation. For VaaS it will set retry logic for
+	//
+	// Note:
+	// In VCert CLI we have hardcoded 180 seconds for retrieve certificate operation. For VaaS it will set retry logic for
 	// 180 seconds and TPP will override CA timeout as the hardcoded value
 	Timeout          time.Duration
 	CustomFields     []CustomField

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -656,7 +656,9 @@ func (c *Connector) prepareRequest(req *certificate.Request, zone string) (tppRe
 	// If enable timeout is defined by the user in the request, we use it in order
 	// override API's timeout for the CA to finish issuance
 	if req.Timeout != 0 {
-		tppReq.WorkToDoTimeout = strconv.FormatFloat(req.Timeout.Seconds(), 'f', 0, 64)
+		seconds := int64(req.Timeout.Seconds())
+		secondsString := strconv.FormatInt(seconds, 10)
+		tppReq.WorkToDoTimeout = secondsString
 	}
 
 	return tppReq, err

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -653,6 +653,12 @@ func (c *Connector) prepareRequest(req *certificate.Request, zone string) (tppRe
 	//    - true: Clear the Disabled attribute, reenable, and then renew the certificate (in this request). Reuse the same CertificateDN, that is also known as a Certificate object.
 	tppReq.Reenable = true
 
+	// If enable timeout is defined by the user in the request, we use it in order
+	// override API's timeout for the CA to finish issuance
+	if req.Timeout != 0 {
+		tppReq.WorkToDoTimeout = strconv.FormatFloat(req.Timeout.Seconds(), 'f', 0, 64)
+	}
+
 	return tppReq, err
 }
 

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -657,7 +657,7 @@ func (c *Connector) prepareRequest(req *certificate.Request, zone string) (tppRe
 	// override API's timeout for the CA to finish issuance. In TLSPDC this means
 	// using WorkToDoTimeout attribute.
 	// We make sure to get the seconds from
-	// "Timeout" as it is a "TimeDuration" and remote (TLPSDC) only expects value in seconds.
+	// "Timeout" as it is a "TimeDuration" and remote (TLSPDC) only expects value in seconds.
 	if req.Timeout > 0 {
 		seconds := int64(req.Timeout.Seconds())
 		secondsString := strconv.FormatInt(seconds, 10)

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -653,9 +653,12 @@ func (c *Connector) prepareRequest(req *certificate.Request, zone string) (tppRe
 	//    - true: Clear the Disabled attribute, reenable, and then renew the certificate (in this request). Reuse the same CertificateDN, that is also known as a Certificate object.
 	tppReq.Reenable = true
 
-	// If enable timeout is defined by the user in the request, we use it in order
-	// override API's timeout for the CA to finish issuance
-	if req.Timeout != 0 {
+	// If "Timeout" is defined by the user in the request, we use it in order to
+	// override API's timeout for the CA to finish issuance. In TLSPDC this means
+	// using WorkToDoTimeout attribute.
+	// We make sure to get the seconds from
+	// "Timeout" as it is a "TimeDuration" and remote (TLPSDC) only expects value in seconds.
+	if req.Timeout > 0 {
 		seconds := int64(req.Timeout.Seconds())
 		secondsString := strconv.FormatInt(seconds, 10)
 		tppReq.WorkToDoTimeout = secondsString

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -500,7 +500,7 @@ func TestRequestCertificateUserPassword(t *testing.T) {
 			t.Fatalf("err is not nil, err: %s", err)
 		}
 	}
-	DoRequestCertificate(t, tpp)
+	DoRequestCertificate(t, tpp, 0)
 }
 
 func TestRequestCertificateToken(t *testing.T) {
@@ -515,7 +515,24 @@ func TestRequestCertificateToken(t *testing.T) {
 			t.Fatalf("err is not nil, err: %s", err)
 		}
 	}
-	DoRequestCertificate(t, tpp)
+	DoRequestCertificate(t, tpp, 0)
+}
+
+func TestRequestCertificateTokenWithExtendedTimeout(t *testing.T) {
+	t.Skip("Skipping as we cannot make TPP to hold the amount of time we want to properly test this")
+	tpp, err := getTestConnector(ctx.TPPurl, ctx.TPPZone)
+	if err != nil {
+		t.Fatalf("err is not nil, err: %s url: %s", err, expectedURL)
+	}
+
+	if tpp.apiKey == "" {
+		err = tpp.Authenticate(&endpoint.Authentication{AccessToken: ctx.TPPaccessToken})
+		if err != nil {
+			t.Fatalf("err is not nil, err: %s", err)
+		}
+	}
+	timeout, _ := time.ParseDuration("45s")
+	DoRequestCertificate(t, tpp, timeout)
 }
 
 func TestRequestCertificateWithValidityHours(t *testing.T) {
@@ -1106,7 +1123,7 @@ func DoRequestCertificateWithValidityDuration(t *testing.T, tpp *Connector) {
 
 }
 
-func DoRequestCertificate(t *testing.T, tpp *Connector) {
+func DoRequestCertificate(t *testing.T, tpp *Connector, timeout time.Duration) {
 	config, err := tpp.ReadZoneConfiguration()
 	if err != nil {
 		t.Fatalf("err is not nil, err: %s", err)
@@ -1125,6 +1142,9 @@ func DoRequestCertificate(t *testing.T, tpp *Connector) {
 	req.FriendlyName = cn
 	req.CustomFields = []certificate.CustomField{
 		{Name: "custom", Value: "2019-10-10"},
+	}
+	if timeout != 0 {
+		req.Timeout = timeout
 	}
 	err = tpp.GenerateRequest(config, req)
 	if err != nil {

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -84,6 +84,7 @@ type certificateRequest struct {
 	Devices                 []device        `json:",omitempty"`
 	CertificateType         string          `json:",omitempty"`
 	Reenable                bool            `json:",omitempty"`
+	WorkToDoTimeout         string          `json:",omitempty"`
 }
 
 type certificateRetrieveRequest struct {


### PR DESCRIPTION
In order for other integrations to consume and override enrollment timeout. We enable `WorkDoTimeout` in order to override TLSPDC (TPP) default CA timeout (60secs). To be noted that as of now, maximum value is 120 seconds. If greater value is provided (e.g. 180 secs), TPP will automatically take 120 secs.