### PR TITLE
[VC-31275] Allow user to configure the User-Agent HTTP header in vcert SDK

### DIFF
--- a/client.go
+++ b/client.go
@@ -78,6 +78,9 @@ func (cfg *Config) newClient(args []interface{}) (connector endpoint.Connector, 
 		return
 	}
 
+	if cfg.UserAgent != nil {
+		connector.SetUserAgent(*cfg.UserAgent)
+	}
 	connector.SetZone(cfg.Zone)
 	connector.SetHTTPClient(cfg.Client)
 

--- a/client_test.go
+++ b/client_test.go
@@ -20,15 +20,25 @@ import (
 	"crypto/tls"
 	"crypto/x509/pkix"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/http/httputil"
 	"os"
+	"regexp"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/go-http-utils/headers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+
 	"github.com/Venafi/vcert/v5/pkg/certificate"
 	"github.com/Venafi/vcert/v5/pkg/endpoint"
+	"github.com/Venafi/vcert/v5/pkg/util"
 )
 
 func init() {
@@ -127,4 +137,324 @@ func TestNewClientWithFileConfig(t *testing.T) {
 	certs, err := c.RetrieveCertificate(req)
 	haltIf(err)
 	print(certs)
+}
+
+// userAgentChecker can be used as an http.Client.Transport (RoundTripper) to
+// check that the User-Agent header is being consistently added to HTTP requests.
+type userAgentChecker struct {
+	t             *testing.T
+	config        Config
+	expectedError error
+}
+
+// newUserAgentChecker creates a userAgentChecker configured for the UserAgent
+// in the supplied Config.
+//
+// It sets up the Client field of the supplied Config so that any HTTP requests
+// will be checked for the expected User-Agent value among the HTTP headers.
+// The in-memory HTTP client used to verify the User-Agent headers will always
+// return a sentinel error.
+// Use `RequireRoundTripError` to check that the expected sentinel error is
+// returned by any method of the connector which is expected to make HTTP
+// requests.
+// The connector should be generated using `vcert.Config.NewClient` or `vcert.NewClient(Config)“
+func newUserAgentChecker(t *testing.T, config *Config) *userAgentChecker {
+	uac := &userAgentChecker{
+		t:             t,
+		config:        *config,
+		expectedError: errors.New("simulated-error"),
+	}
+	config.Client = &http.Client{
+		Transport: uac,
+	}
+	return uac
+}
+
+// RoundTrip implements http.RoundTripper.RoundTrip.
+//
+// It verifies the User-Agent header and dumps the request content as test log
+// messages, to make it easier to inspect the HTTP request headers.
+// It always returns a simulated error and never returns an http.Response.
+func (o *userAgentChecker) RoundTrip(req *http.Request) (*http.Response, error) {
+	reqBytes, err := httputil.DumpRequest(req, true)
+	require.NoError(o.t, err)
+	o.t.Log(string(reqBytes))
+
+	assert.Len(o.t, req.Header.Values(headers.UserAgent), 1,
+		"There must always be one User-Agent header set, "+
+			"to avoid the Go http DefaultClient setting the User-Agent header to Go-HTTP-1.1 by default")
+
+	actualUserAgent := req.Header.Get(headers.UserAgent)
+
+	if o.config.UserAgent == nil {
+		assert.Equal(o.t, util.DefaultUserAgent, actualUserAgent,
+			"User-Agent header should be vcert/v5 when the config.UserAgent field is omitted")
+	} else {
+		assert.Equal(o.t, *o.config.UserAgent, actualUserAgent,
+			"User-Agent header should match config.UserAgent when the field is set")
+	}
+
+	return nil, o.expectedError
+}
+
+// RequireRoundTripError is used to check the error returned by any function
+// that has been instrumented with the NewHTTPClient (above). The instrumented
+// function is therefore expected to generate HTTP requests and where it does,
+// it is expected to return or wrap the error that is always returned by the
+// RoundTripper of this test helper.
+func (o *userAgentChecker) RequireRoundTripError(err error) {
+	require.ErrorContains(o.t, err, o.expectedError.Error(),
+		"The user supplied HTTP client (with simulated-error RoundTripper) should always be used, "+
+			"so the simulated-error should always be returned here. "+
+			"If not, it indicates one of two programming errors: "+
+			"1. the function is calling API endpoints with the wrong HTTP client, or "+
+			"2. the function is ignoring or hiding the error returned in the HTTP response.")
+}
+
+// TestNewClient_UserAgent checks that all connectors are consistent in the way
+// they set the User-Agent header.
+//
+// The desired behavior is that a User-Agent header is always included the
+// requests.
+// If the Config.UserAgent field is nil, the default UserAgent value is used.
+// Else, the supplied UserAgent string is used, even when empty.
+func TestNewClient_UserAgent(t *testing.T) {
+	// These base connector configs will be tested
+	connectorConfigs := []Config{
+		{
+			ConnectorType: endpoint.ConnectorTypeCloud,
+		},
+		{
+			ConnectorType: endpoint.ConnectorTypeTPP,
+			BaseUrl:       "https://tpp.example.local",
+		},
+		{
+			ConnectorType: endpoint.ConnectorTypeFirefly,
+			BaseUrl:       "https://firefly.example.local",
+		},
+	}
+
+	// These methods will be called on every connector.
+	connectorMethods := []struct {
+		name string
+		f    func(c endpoint.Connector, args ...any) error
+	}{
+		{
+			name: "Authenticate",
+			f: func(c endpoint.Connector, args ...any) error {
+				credentials, ok := args[0].(*endpoint.Authentication)
+				if !ok {
+					return fmt.Errorf("unexpected args: %T", args[0])
+				}
+				return c.Authenticate(credentials)
+			},
+		},
+		{
+			name: "Ping",
+			f: func(c endpoint.Connector, _ ...any) error {
+				return c.Ping()
+			},
+		},
+		{
+			name: "ListCertificates",
+			f: func(c endpoint.Connector, args ...any) error {
+				filter, ok := args[0].(endpoint.Filter)
+				if !ok {
+					return fmt.Errorf("unexpected args: %T", args[0])
+				}
+				_, err := c.ListCertificates(filter)
+				return err
+			},
+		},
+		{
+			name: "RequestCertificates",
+			f: func(c endpoint.Connector, args ...any) error {
+				request, ok := args[0].(*certificate.Request)
+				if !ok {
+					return fmt.Errorf("unexpected args: %T", args[0])
+				}
+				_, err := c.RequestCertificate(request)
+				return err
+			},
+		},
+		{
+			name: "SynchronousRequestCertificate",
+			f: func(c endpoint.Connector, args ...any) error {
+				request, ok := args[0].(*certificate.Request)
+				if !ok {
+					return fmt.Errorf("unexpected args: %T", args[0])
+				}
+				_, err := c.SynchronousRequestCertificate(request)
+				return err
+			},
+		},
+	}
+
+	// Methods will be called with all the arguments where test matches `test`.
+	//
+	// If the connector + method only need so be tested with one combination of
+	// argument, then the name can be omitted.
+	// If there are no arguments, each connector + method be called once without
+	// any arguments
+	type methodArguments struct {
+		name string
+		test string
+		args []any
+	}
+	args := []methodArguments{
+		{
+			test: endpoint.ConnectorTypeCloud.String() + ":Authenticate",
+			name: "with-api-key",
+			args: []any{
+				&endpoint.Authentication{
+					APIKey: "fake-key",
+				},
+			},
+		},
+		{
+			test: endpoint.ConnectorTypeCloud.String() + ":Authenticate",
+			name: "with-service-account",
+			args: []any{
+				&endpoint.Authentication{
+					TenantID:       "fake-tenant-id",
+					ExternalIdPJWT: "fake-external-id-pjwt",
+				},
+			},
+		},
+		{
+			test: endpoint.ConnectorTypeTPP.String() + ":Authenticate",
+			args: []any{
+				&endpoint.Authentication{
+					User:     "fake-user",
+					Password: "fake-password",
+				},
+			},
+		},
+		{
+			test: endpoint.ConnectorTypeFirefly.String() + ":Authenticate",
+			args: []any{
+				&endpoint.Authentication{
+					IdentityProvider: &endpoint.OAuthProvider{
+						DeviceURL: "https://device.oauth.example.local",
+					},
+				},
+			},
+		},
+		{
+			test: ":ListCertificates",
+			args: []any{
+				endpoint.Filter{},
+			},
+		},
+		{
+			test: ":RequestCertificates",
+			args: []any{
+				&certificate.Request{},
+			},
+		},
+		{
+			test: ":SynchronousRequestCertificate",
+			args: []any{
+				&certificate.Request{},
+			},
+		},
+	}
+
+	// These User-Agent strings will be tested with every method of every
+	// connector.
+	userAgents := []struct {
+		name  string
+		value *string
+	}{
+		{
+			name:  "override-user-agent",
+			value: ptr.To("fake-user-agent/v9.9.9"),
+		},
+		{
+			name:  "omit-user-agent",
+			value: ptr.To(""),
+		},
+		{
+			name:  "default-user-agent",
+			value: nil,
+		},
+	}
+
+	// These tests will be skipped because the connector does not yet implement
+	// the method.
+	skips := []string{
+		endpoint.ConnectorTypeCloud.String() + ":Ping",
+		endpoint.ConnectorTypeCloud.String() + ":SynchronousRequestCertificate",
+
+		endpoint.ConnectorTypeTPP.String() + ":SynchronousRequestCertificate",
+
+		endpoint.ConnectorTypeFirefly.String() + ":Ping",
+		endpoint.ConnectorTypeFirefly.String() + ":ListCertificates",
+		endpoint.ConnectorTypeFirefly.String() + ":RequestCertificates",
+	}
+
+	for _, config := range connectorConfigs {
+		for _, method := range connectorMethods {
+			name := fmt.Sprintf("%s:%s", config.ConnectorType.String(), method.name)
+			var matchingArgs []methodArguments
+			for _, arg := range args {
+				re := regexp.MustCompile(arg.test)
+				if re.MatchString(name) {
+					matchingArgs = append(matchingArgs, arg)
+				}
+			}
+			if len(matchingArgs) == 0 {
+				matchingArgs = []methodArguments{{}}
+			}
+			for _, arg := range matchingArgs {
+				name := name
+				if arg.name != "" {
+					name = name + ":" + arg.name
+				}
+				for _, userAgent := range userAgents {
+					name := name + ":" + userAgent.name
+					t.Run(
+						name,
+						func(t *testing.T) {
+							for _, skipPrefix := range skips {
+								if strings.HasPrefix(name, skipPrefix) {
+									t.Skip("not supported")
+								}
+							}
+
+							config.UserAgent = userAgent.value
+
+							// The TPP and Cloud connectors both require a zone to be set
+							config.Zone = "fake-zone"
+
+							uaChecker := newUserAgentChecker(t, &config)
+
+							c, err := NewClient(&config, false)
+							require.NoError(t, err,
+								"NewClient with auth argument set to false should have no side effects "+
+									"and should always succeed.")
+
+							// The VaaS connector requires this because before even
+							// attempting to send requests to resource endpoints it
+							// checks the connector.accessToken attribute, and the
+							// only way to set that is to call Authenticate with an
+							// AccessToken credential.
+							if c.GetType() == endpoint.ConnectorTypeCloud {
+								credentials := &endpoint.Authentication{
+									AccessToken: "fake-access-token",
+								}
+								err = c.Authenticate(credentials)
+								require.NoError(t, err,
+									"For the VaaS connector Authenticate with AccessToken simply sets an attribute; "+
+										"it does not trigger any HTTP requests, so there should never be an error.")
+							}
+
+							err = method.f(c, arg.args...)
+							uaChecker.RequireRoundTripError(err)
+						},
+					)
+				}
+			}
+		}
+	}
 }

--- a/config.go
+++ b/config.go
@@ -63,6 +63,11 @@ type Config struct {
 	LogVerbose      bool
 	// http.Client to use durring construction
 	Client *http.Client
+	// UserAgent is the value of the UserAgent header in HTTP requests to Venafi
+	// API endpoints.
+	// If nil, the default is `vcert/v5`.
+	// Further reading: https://www.rfc-editor.org/rfc/rfc9110#field.user-agent
+	UserAgent *string
 }
 
 // LoadConfigFromFile is deprecated. In the future will be rewritten.

--- a/examples/firefly/main.go
+++ b/examples/firefly/main.go
@@ -10,9 +10,16 @@ import (
 	"github.com/Venafi/vcert/v5"
 	"github.com/Venafi/vcert/v5/pkg/certificate"
 	"github.com/Venafi/vcert/v5/pkg/endpoint"
+	"github.com/Venafi/vcert/v5/pkg/util"
+)
+
+const (
+	name    = "example-firefly-certificate-client"
+	version = "v0.0.1"
 )
 
 func main() {
+	userAgent := fmt.Sprintf("%s/%s %s", name, version, util.DefaultUserAgent)
 	fireflyConfig := vcert.Config{
 		ConnectorType: endpoint.ConnectorTypeFirefly,
 		BaseUrl:       os.Getenv("FIREFLY_URL"),
@@ -23,7 +30,8 @@ func main() {
 				TokenURL: os.Getenv("FIREFLY_TOKEN_URL"),
 			},
 		},
-		Zone: os.Getenv("FIREFLY_ZONE"),
+		Zone:      os.Getenv("FIREFLY_ZONE"),
+		UserAgent: &userAgent,
 	}
 
 	trustBundleFilePath := os.Getenv("FIREFLY_TRUST_BUNDLE_PATH")
@@ -39,7 +47,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("error creating client: %s", err.Error())
 	}
-
 	request := &certificate.Request{
 		Subject: pkix.Name{
 			CommonName:         "common.name.venafi.example.com",

--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -9,6 +9,12 @@ import (
 
 	"github.com/Venafi/vcert/v5"
 	"github.com/Venafi/vcert/v5/pkg/endpoint"
+	"github.com/Venafi/vcert/v5/pkg/util"
+)
+
+const (
+	name    = "example-auto-certificate-server"
+	version = "v0.0.1"
 )
 
 func main() {
@@ -22,13 +28,15 @@ func main() {
 }
 
 func initConfig() *vcert.Config {
+	userAgent := fmt.Sprintf("%s/%s %s", name, version, util.DefaultUserAgent)
 	conf := &vcert.Config{
 		ConnectorType: endpoint.ConnectorTypeTPP,
 		BaseUrl:       os.Getenv("TPP_URL"),
 		Credentials: &endpoint.Authentication{
 			User:     os.Getenv("TPP_USER"),
 			Password: os.Getenv("TPP_PASSWORD")},
-		Zone: os.Getenv("TPP_ZONE"),
+		Zone:      os.Getenv("TPP_ZONE"),
+		UserAgent: &userAgent,
 	}
 	trustBundleFilePath := os.Getenv("TRUST_BUNDLE_PATH")
 	if trustBundleFilePath != "" {

--- a/examples/simple-cli/main.go
+++ b/examples/simple-cli/main.go
@@ -33,7 +33,13 @@ import (
 	"github.com/Venafi/vcert/v5"
 	"github.com/Venafi/vcert/v5/pkg/certificate"
 	"github.com/Venafi/vcert/v5/pkg/endpoint"
+	"github.com/Venafi/vcert/v5/pkg/util"
 	"github.com/Venafi/vcert/v5/pkg/venafi/tpp"
+)
+
+const (
+	name    = "example-certificate-client"
+	version = "v0.0.1"
 )
 
 func main() {
@@ -49,6 +55,8 @@ func main() {
 	config := tppConfig
 	//config := cloudConfig
 	//config := mockConfig
+	userAgent := fmt.Sprintf("%s/%s %s", name, version, util.DefaultUserAgent)
+	config.UserAgent = &userAgent
 	c, err := vcert.NewClient(config)
 	if err != nil {
 		t.Fatalf("could not connect to endpoint: %s", err)

--- a/examples/tlspc-svc-account/main.go
+++ b/examples/tlspc-svc-account/main.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"crypto/x509/pkix"
+	"fmt"
 	"log"
 	"os"
 
 	"github.com/Venafi/vcert/v5"
 	"github.com/Venafi/vcert/v5/pkg/certificate"
 	"github.com/Venafi/vcert/v5/pkg/endpoint"
+	"github.com/Venafi/vcert/v5/pkg/util"
 )
 
 const (
@@ -17,6 +19,9 @@ const (
 	TlspcJwt      = "TLSPC_JWT"
 
 	envVarNotSet = "environment variable not set: %s"
+
+	name    = "example-tlspc-service-account-client"
+	version = "v0.0.1"
 )
 
 func main() {
@@ -37,6 +42,7 @@ func main() {
 		log.Fatalf(envVarNotSet, TlspcJwt)
 	}
 
+	userAgent := fmt.Sprintf("%s/%s %s", name, version, util.DefaultUserAgent)
 	config := &vcert.Config{
 		ConnectorType: endpoint.ConnectorTypeCloud,
 		BaseUrl:       url,
@@ -45,6 +51,7 @@ func main() {
 			TenantID:       tenantID,
 			ExternalIdPJWT: jwt,
 		},
+		UserAgent: &userAgent,
 	}
 	connector, err := vcert.NewClient(config)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	gopkg.in/ini.v1 v1.51.0
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
+	k8s.io/utils v0.0.0-20240310230437-4693a0247e57
 	software.sslmate.com/src/go-pkcs12 v0.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -366,6 +366,8 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
+k8s.io/utils v0.0.0-20240310230437-4693a0247e57 h1:gbqbevonBh57eILzModw6mrkbwM0gQBEuevE/AaBsHY=
+k8s.io/utils v0.0.0-20240310230437-4693a0247e57/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
 software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -139,6 +139,11 @@ type Connector interface {
 
 	RetrieveSystemVersion() (string, error)
 	WriteLog(req *LogRequest) error
+	// SetUserAgent sets the value of the UserAgent header in HTTP requests to
+	// Venafi API endpoints by this connector.
+	// The default is `vcert/v5`.
+	// Further reading: https://www.rfc-editor.org/rfc/rfc9110#field.user-agent
+	SetUserAgent(userAgent string)
 }
 
 type Filter struct {

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -3,4 +3,7 @@ package util
 const (
 	PathSeparator           = "\\"
 	ApplicationServerTypeID = "784938d1-ef0d-11eb-9461-7bb533ba575b"
+	// DefaultUserAgent is the default value of the UserAgent header in HTTP
+	// requests to Venafi API endpoints.
+	DefaultUserAgent = "vcert/v5"
 )

--- a/pkg/venafi/cloud/cloud.go
+++ b/pkg/venafi/cloud/cloud.go
@@ -331,6 +331,7 @@ func (c *Connector) request(method string, url string, data interface{}, authNot
 		return
 	}
 
+	r.Header.Set(headers.UserAgent, c.userAgent)
 	if c.accessToken != "" {
 		r.Header.Add(headers.Authorization, fmt.Sprintf("%s %s", oauthTokenType, c.accessToken))
 	} else if c.apiKey != "" {

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -32,6 +32,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-http-utils/headers"
 	"golang.org/x/crypto/nacl/box"
 
 	"github.com/Venafi/vcert/v5/pkg/certificate"
@@ -90,12 +91,13 @@ type Connector struct {
 	trust       *x509.CertPool
 	zone        cloudZone
 	client      *http.Client
+	userAgent   string
 }
 
 // NewConnector creates a new Venafi Cloud Connector object used to communicate with Venafi Cloud
 func NewConnector(url string, zone string, verbose bool, trust *x509.CertPool) (*Connector, error) {
 	cZone := cloudZone{zone: zone}
-	c := Connector{verbose: verbose, trust: trust, zone: cZone}
+	c := Connector{verbose: verbose, trust: trust, zone: cZone, userAgent: util.DefaultUserAgent}
 
 	var err error
 	c.baseURL, err = normalizeURL(url)
@@ -112,6 +114,10 @@ func (c *Connector) GetType() endpoint.ConnectorType {
 func (c *Connector) SetZone(z string) {
 	cZone := cloudZone{zone: z}
 	c.zone = cZone
+}
+
+func (c *Connector) SetUserAgent(userAgent string) {
+	c.userAgent = userAgent
 }
 
 func (c *Connector) SetHTTPClient(client *http.Client) {
@@ -876,6 +882,7 @@ func (c *Connector) GetAccessToken(auth *endpoint.Authentication) (*TLSPCAccessT
 		err = fmt.Errorf("%w: %v", verror.VcertError, err)
 		return nil, err
 	}
+	r.Header.Set(headers.UserAgent, c.userAgent)
 	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	httpClient := c.getHTTPClient()

--- a/pkg/venafi/fake/connector.go
+++ b/pkg/venafi/fake/connector.go
@@ -160,6 +160,9 @@ func (c *Connector) GetType() endpoint.ConnectorType {
 func (c *Connector) SetZone(z string) {
 }
 
+func (c *Connector) SetUserAgent(_ string) {
+}
+
 func (c *Connector) Ping() (err error) {
 	return
 }

--- a/pkg/venafi/firefly/connector.go
+++ b/pkg/venafi/firefly/connector.go
@@ -50,6 +50,7 @@ type Connector struct {
 	trust       *x509.CertPool
 	client      *http.Client
 	zone        string // holds the policyName
+	userAgent   string
 }
 
 // NewConnector creates a new Firefly Connector object used to communicate with Firefly
@@ -61,7 +62,7 @@ func NewConnector(url string, zone string, verbose bool, trust *x509.CertPool) (
 			return nil, fmt.Errorf("%w: failed to normalize URL: %v", verror.UserDataError, err)
 		}
 	}
-	return &Connector{baseURL: url, zone: zone, verbose: verbose, trust: trust}, nil
+	return &Connector{baseURL: url, zone: zone, verbose: verbose, trust: trust, userAgent: util.DefaultUserAgent}, nil
 }
 
 // normalizeURL normalizes the base URL used to communicate with Firefly
@@ -73,6 +74,10 @@ func normalizeURL(url string) (normalizedURL string, err error) {
 func (c *Connector) SetZone(zone string) {
 	//for now the zone refers to the policyName
 	c.zone = zone
+}
+
+func (c *Connector) SetUserAgent(userAgent string) {
+	c.userAgent = userAgent
 }
 
 func (c *Connector) GetType() endpoint.ConnectorType {

--- a/pkg/venafi/firefly/firefly.go
+++ b/pkg/venafi/firefly/firefly.go
@@ -30,6 +30,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-http-utils/headers"
+
 	"github.com/Venafi/vcert/v5/pkg/certificate"
 	"github.com/Venafi/vcert/v5/pkg/endpoint"
 	"github.com/Venafi/vcert/v5/pkg/verror"
@@ -131,6 +133,7 @@ func (c *Connector) request(method string, resource urlResource, data interface{
 
 	r, _ := http.NewRequest(method, resourceUrl, payload)
 	r.Close = true
+	r.Header.Set(headers.UserAgent, c.userAgent)
 	if c.accessToken != "" {
 		r.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.accessToken))
 	}

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -48,6 +48,7 @@ type Connector struct {
 	trust       *x509.CertPool
 	zone        string
 	client      *http.Client
+	userAgent   string
 }
 
 func (c *Connector) IsCSRServiceGenerated(req *certificate.Request) (bool, error) {
@@ -64,7 +65,7 @@ func (c *Connector) RetrieveAvailableSSHTemplates() (response []certificate.SshA
 
 // NewConnector creates a new TPP Connector object used to communicate with TPP
 func NewConnector(url string, zone string, verbose bool, trust *x509.CertPool) (*Connector, error) {
-	c := Connector{verbose: verbose, trust: trust, zone: zone}
+	c := Connector{verbose: verbose, trust: trust, zone: zone, userAgent: util.DefaultUserAgent}
 	var err error
 	c.baseURL, err = normalizeURL(url)
 	if err != nil {
@@ -91,6 +92,10 @@ func normalizeURL(url string) (normalizedURL string, err error) {
 
 func (c *Connector) SetZone(z string) {
 	c.zone = z
+}
+
+func (c *Connector) SetUserAgent(userAgent string) {
+	c.userAgent = userAgent
 }
 
 func (c *Connector) GetType() endpoint.ConnectorType {

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -31,6 +31,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-http-utils/headers"
+
 	"github.com/Venafi/vcert/v5/pkg/certificate"
 	"github.com/Venafi/vcert/v5/pkg/endpoint"
 )
@@ -490,6 +492,7 @@ func (c *Connector) request(method string, resource urlResource, data interface{
 
 	r, _ := http.NewRequest(method, url, payload)
 	r.Close = true
+	r.Header.Set(headers.UserAgent, c.userAgent)
 	if c.accessToken != "" {
 		r.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.accessToken))
 	} else if c.apiKey != "" {


### PR DESCRIPTION
**Software like cert-manager can now supply its own User-Agent when it instantiates the vcert.Client.**
> Why? Because if there is a bug in the cert-manager Venafi issuer, which causes it to not back off in the event of a failed API request, the Venafi server administrator can quickly know that cert-manager is the culprit and quickly report the bug so that it be quickly fixed.

**The default User-Agent for `vcert` CLI and for any software importing the vcert/v5 is now: `vcert/v5`.**
> Why? Because right now the vcert CLI and any software that uses the vcert SDK will use the [default `Go-http-client/1.1` User-Agent header](https://github.com/golang/go/blob/db423dde85ad4923c2c4addb1cd96f119c7b6dc6/src/net/http/request.go#L534-L538) and the requests will be indistinguishable from any other Go http client.
The new default header will allow the Venafi administrator to estimate the adoption of vcert v5.

Fixes: https://github.com/Venafi/vcert/issues/437

* https://github.com/Venafi/vcert/issues/437
* VC-31275

## Testing
### `vcert` CLI default
```sh
export HTTPS_PROXY=localhost:8080
go run ./cmd/vcert renew     -k foo --no-prompt -id foo --trust-bundle ~/.mitmproxy/mitmproxy-ca.pem
```

```sh
vCert: 2024/03/27 10:54:54 Warning: --platform not set. Attempting to best-guess platform from connection flags
vCert: 2024/03/27 10:54:54 Detected trust bundle...
vCert: 2024/03/27 10:54:54 You specified a trust bundle.
vCert: 2024/03/27 10:54:55 Unable to connect to Venafi as a Service: vcert error: server error: 401 Unauthorized
vCert: 2024/03/27 10:54:55 Failed to fetch old certificate by id foo: must be autheticated to request a certificate
exit status 1
```

![image](https://github.com/Venafi/vcert/assets/978965/9a171cf2-252f-4ebc-ae56-c8d042d0f72b)

### Examples
I've partially tested the examples, in so far as I ran each example with some fake settings in environment variables and observed that the expected User-Agent header was present in the first failing request.

* firefly
![image](https://github.com/Venafi/vcert/assets/978965/b8bc09da-abbf-4f7e-a0c0-bca5fdab5920)

* server
![image](https://github.com/Venafi/vcert/assets/978965/74f32253-a471-4d19-a510-b8aa3f522c51)

* simple-cli
![image](https://github.com/Venafi/vcert/assets/978965/e0f0d116-ca5a-4559-b0a3-2e1fe1e88960)

* tlspc-svc-account
![image](https://github.com/Venafi/vcert/assets/978965/f9ee5ca4-cc97-4568-b391-3e12b909bc47)
