### PR TITLE
Only call DEK endpoints if the CSR is a ServiceGeneratedCSR

### DIFF
--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -272,7 +272,7 @@ func (c *Connector) RequestCertificate(req *certificate.Request) (requestID stri
 }
 
 // RetrieveCertificate retrieves the certificate for the specified ID
-func (c *Connector) RetrieveCertificate(req *certificate.Request) (certificates *certificate.PEMCollection, err error) {
+func (c *Connector) RetrieveCertificate(req *certificate.Request) (*certificate.PEMCollection, error) {
 	if !c.isAuthenticated() {
 		return nil, fmt.Errorf("must be autheticated to request a certificate")
 	}
@@ -344,22 +344,26 @@ func (c *Connector) RetrieveCertificate(req *certificate.Request) (certificates 
 		certificateId = req.CertID
 	}
 
+	// Download the private key and certificate in case the certificate is service generated
+	if req.CsrOrigin == certificate.ServiceGeneratedCSR || req.FetchPrivateKey {
+		var dekInfo *EdgeEncryptionKey
+		var currentId string
+		var err error
+		if req.CertID != "" {
+			dekInfo, err = getDekInfo(c, req.CertID)
+			currentId = req.CertID
+		} else if certificateId != "" {
+			dekInfo, err = getDekInfo(c, certificateId)
+			currentId = certificateId
+		}
+		if err == nil && dekInfo.Key != "" {
+			req.CertID = currentId
+			return retrieveServiceGeneratedCertData(c, req, dekInfo)
+		}
+	}
+
 	url := c.getURL(urlResourceCertificateRetrievePem)
 	url = fmt.Sprintf(url, certificateId)
-
-	var dekInfo *EdgeEncryptionKey
-	var currentId string
-	if req.CertID != "" {
-		dekInfo, err = getDekInfo(c, req.CertID)
-		currentId = req.CertID
-	} else if certificateId != "" {
-		dekInfo, err = getDekInfo(c, certificateId)
-		currentId = certificateId
-	}
-	if err == nil && dekInfo.Key != "" {
-		req.CertID = currentId
-		return retrieveServiceGeneratedCertData(c, req, dekInfo)
-	}
 
 	switch {
 	case req.CertID != "":
@@ -384,7 +388,7 @@ func (c *Connector) RetrieveCertificate(req *certificate.Request) (certificates 
 			return nil, err
 		}
 		if statusCode == http.StatusOK {
-			certificates, err = newPEMCollectionFromResponse(body, req.ChainOption)
+			certificates, err := newPEMCollectionFromResponse(body, req.ChainOption)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -346,20 +346,20 @@ func (c *Connector) RetrieveCertificate(req *certificate.Request) (*certificate.
 
 	// Download the private key and certificate in case the certificate is service generated
 	if req.CsrOrigin == certificate.ServiceGeneratedCSR || req.FetchPrivateKey {
-		var dekInfo *EdgeEncryptionKey
 		var currentId string
-		var err error
 		if req.CertID != "" {
-			dekInfo, err = getDekInfo(c, req.CertID)
 			currentId = req.CertID
 		} else if certificateId != "" {
-			dekInfo, err = getDekInfo(c, certificateId)
 			currentId = certificateId
 		}
-		if err == nil && dekInfo.Key != "" {
-			req.CertID = currentId
-			return retrieveServiceGeneratedCertData(c, req, dekInfo)
+
+		dekInfo, err := getDekInfo(c, currentId)
+		if err != nil {
+			return nil, err
 		}
+
+		req.CertID = currentId
+		return retrieveServiceGeneratedCertData(c, req, dekInfo)
 	}
 
 	url := c.getURL(urlResourceCertificateRetrievePem)


### PR DESCRIPTION
For the VaaS integration, vcert unconditionally calls the DEK API endpoints.
Similarly to the TPP implementation, we can only call the DEK API calls when a ServiceGeneratedCSR is requested.
This reduces the number of API requests made by vcert.

See the TPP equivalent of this check: https://github.com/Venafi/vcert/blob/21228d0e0de959feddf95acb7d7a22402e2edd23/pkg/venafi/tpp/connector.go#L1359-L1365