### PR TITLE
Enables direct supply of a valid accessToken via the playbook for VCP…

### DIFF
--- a/pkg/playbook/app/domain/error.go
+++ b/pkg/playbook/app/domain/error.go
@@ -84,6 +84,10 @@ var (
 	ErrNoClientId = fmt.Errorf("no cliendId defined. Firefly platform requires a clientId to request OAuth2 token")
 	// ErrNoIdentityProviderURL is thrown when platform is Firefly and no config.credentials.tokenURL is defined to request an OAuth2 Token
 	ErrNoIdentityProviderURL = fmt.Errorf("no tokenURL defined in credentials. tokenURL is required to request OAuth2 token")
-	// ErrNoExternalJWT is thrown when platform is TLSPC/VAAS/VCP, a tokenURL has been passed but no config.credentials.externalJWT is set
-	ErrNoExternalJWT = fmt.Errorf("no externalJWT defined in credentials. externalJWT is required to request an access token from VCP")
+	// ErrNoExternalJWT is thrown when platform is TLSPC/VAAS/VCP, a tokenURL has been passed but no config.credentials.ExternalJWT is set
+	ErrNoExternalJWT = fmt.Errorf("no externalJWT defined in credentials. externalJWT and tokenURL are both required to request an access token from VCP")
+	// ErrNoVaaSTokenURL is thrown when platform is TLSPC/VAAS/VCP, an externaJWT has been provided, but no config.credentials.TokenURL has been passed
+	ErrNoVCPTokenURL = fmt.Errorf("no tokenURL defined in credentials. tokenURL and externalJWT are both required to request an access token from VCP when using an externalJWT")
+	// ErrAmbiguousVCPCreds is thrown when platform is TLSPC/VAAS/VCP, and more than one type (apiKey, accessToken, or externalJWT) was provided
+	ErrAmbiguousVCPCreds = fmt.Errorf("unable to disambiguate multiple VCP credentials. Only ONE of apiKey, accessToken, or tokenURL WITH externalJWT should be defined")
 )

--- a/pkg/venafi/cloud/cloud.go
+++ b/pkg/venafi/cloud/cloud.go
@@ -528,6 +528,8 @@ func parseCertificateTemplateResult(httpStatusCode int, httpStatus string, body 
 		return parseCertificateTemplateData(body)
 	case http.StatusBadRequest:
 		return nil, verror.ZoneNotFoundError
+	case http.StatusUnauthorized:
+		return nil, verror.UnauthorizedError
 	default:
 		respErrors, err := parseResponseErrors(body)
 		if err != nil {

--- a/pkg/verror/errors.go
+++ b/pkg/verror/errors.go
@@ -12,6 +12,7 @@ var (
 	PolicyValidationError           = fmt.Errorf("%w: policy doesn't match request", VcertError)
 	CertificateCheckError           = fmt.Errorf("%w: request doesn't match certificate", UserDataError)
 	AuthError                       = fmt.Errorf("%w: auth error", UserDataError)
+	UnauthorizedError               = fmt.Errorf("%w: unauthorized or expired access credentials", ServerError)
 	ZoneNotFoundError               = fmt.Errorf("%w: zone not found", UserDataError)
 	ApplicationNotFoundError        = fmt.Errorf("%w: application not found", UserDataError)
 	// certificate search errors


### PR DESCRIPTION
…. also Improves errors on expired access token. (Previously this error was unhandled and failed at parsing an empty response body with an unexpected end of json error.  

Finally, improves playbook validation for VCP credentials, and prevents more than one kind of credential to be set. Like highlander, there can now only be one!  This should keep us from having to make a (wrong) prioritization decision about which credential should be used when multiple are provided.