### PR TITLE
BUG FIX: issue with pickup-id flag and ARN in response when provisioning to AWS

### DIFF
--- a/cmd/vcert/cmdCloudKeystores.go
+++ b/cmd/vcert/cmdCloudKeystores.go
@@ -79,7 +79,7 @@ func doCommandProvisionCloudKeystore(c *cli.Context) error {
 	}
 	switch metadata.CloudKeystoreType {
 	case domain.CloudKeystoreTypeACM:
-		result.ARN = metadata.ARN
+		result.ARN = metadata.CertificateID
 	case domain.CloudKeystoreTypeAKV:
 		result.AzureID = metadata.CertificateID
 		result.AzureName = metadata.CertificateName

--- a/cmd/vcert/utils.go
+++ b/cmd/vcert/utils.go
@@ -621,7 +621,7 @@ func randRunes(n int) string {
 func fillProvisioningRequest(req *domain.ProvisioningRequest, keystore domain.CloudKeystore, cf *commandFlags) (*domain.ProvisioningRequest, *domain.ProvisioningOptions) {
 	req.CertificateID = cleanEmptyStringPointer(cf.certificateID)
 	req.Keystore = &keystore
-	req.PickupID = &(cf.pickupID)
+	req.PickupID = &(cf.provisionPickupID)
 
 	if cf.keystoreCertName == "" {
 		return req, nil

--- a/examples/provisionWithCertificateRequest/main.go
+++ b/examples/provisionWithCertificateRequest/main.go
@@ -89,7 +89,7 @@ func main() {
 
 	// Example to get values from other keystores machine identities metadata
 	if certMetaData.CloudKeystoreType == domain.CloudKeystoreTypeACM {
-		log.Printf("Certificate AWS Metadata ARN:\n%v", certMetaData.ARN)
+		log.Printf("Certificate AWS Metadata ARN:\n%v", certMetaData.CertificateID)
 	}
 	if certMetaData.CloudKeystoreType == domain.CloudKeystoreTypeAKV {
 		log.Printf("Certificate Azure Metadata ID:\n%v", certMetaData.CertificateID)

--- a/examples/provisionWithServiceAccount/main.go
+++ b/examples/provisionWithServiceAccount/main.go
@@ -103,7 +103,7 @@ func main() {
 
 	// Example to get values from other keystores machine identities metadata
 	if certMetaData.CloudKeystoreType == domain.CloudKeystoreTypeACM {
-		log.Printf("Certificate AWS Metadata ARN:\n%v", certMetaData.ARN)
+		log.Printf("Certificate AWS Metadata ARN:\n%v", certMetaData.CertificateID)
 	}
 	if certMetaData.CloudKeystoreType == domain.CloudKeystoreTypeAKV {
 		log.Printf("Certificate Azure Metadata ID:\n%v", certMetaData.CertificateID)

--- a/pkg/domain/provisioning.go
+++ b/pkg/domain/provisioning.go
@@ -17,7 +17,6 @@ type ProvisioningRequest struct {
 
 type ProvisioningMetadata struct {
 	CloudKeystoreType         CloudKeystoreType
-	ARN                       string
 	CertificateID             string
 	CertificateName           string
 	CertificateVersion        string


### PR DESCRIPTION
- fixes bug where wrong pickup-id variable was set. 
- fixes bug for ARN as the value from websocket is not responding with that value. Thus this required update in function provisionToMachineIdentiy to find out before hand the keystore type (if keystore was not provided in request