### PR TITLE
fix(cloud-connector): Adds certificate ID

### DIFF
--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -372,6 +372,8 @@ func (c *Connector) RetrieveCertificate(req *certificate.Request) (*certificate.
 				return nil, err
 			}
 			err = req.CheckCertificate(certificates.Certificate)
+			// Add certificate id to the request
+			req.CertID = certificateId
 			return certificates, err
 		} else if statusCode == http.StatusConflict { // Http Status Code 409 means the certificate has not been signed by the ca yet.
 			return nil, endpoint.ErrCertificatePending{CertificateID: req.PickupID}


### PR DESCRIPTION
Adds certificate ID to certificate request object on cloud connector certificateRetrieve function when not requesting the private key