### PR TITLE
Set log prefix in main.go instead of endpoint.go

### DIFF
--- a/cmd/vcert/main.go
+++ b/cmd/vcert/main.go
@@ -35,6 +35,10 @@ var (
 	exit   = os.Exit
 )
 
+func init() {
+	log.SetPrefix(UtilityShortName + ": ")
+}
+
 // UtilityName is the full name of the command-line utility
 const UtilityName string = "Venafi Certificate Utility"
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -24,7 +24,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
 	"regexp"
@@ -55,7 +54,6 @@ const (
 )
 
 func init() {
-	log.SetPrefix("vCert: ")
 	LocalIP = getPrimaryNetAddr()
 }
 


### PR DESCRIPTION
vCert sets a log prefix on the global logger in endpoint.go.
This unexpectedly alters the logger when importing vCert.
In order to not modify the global logger when importing vCert as a go library, I moved the `SetPrefix` call to `main.go` which is only used in the vCert binary but when importing vCert as a library.