### PR TITLE
Fixes lint error issues and golangci deprecated configurations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,8 +4,6 @@ run:
 
 linters:
   disable:
-    - deadcode
-    - varcheck
     - unused
   enable:
     - gosec

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -22,6 +22,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -337,7 +338,7 @@ func (p *Policy) ValidateCertificateRequest(request *certificate.Request) error 
 				}
 			}
 			if !keyValid {
-				return fmt.Errorf(keyError)
+				return errors.New(keyError)
 			}
 		}
 
@@ -361,7 +362,7 @@ func (p *Policy) ValidateCertificateRequest(request *certificate.Request) error 
 
 		if len(p.AllowedKeyConfigurations) > 0 {
 			if !checkKey(request.KeyType, request.KeyLength, request.KeyCurve.String(), p.AllowedKeyConfigurations) {
-				return fmt.Errorf(keyError)
+				return errors.New(keyError)
 			}
 		}
 	}

--- a/pkg/util/pemUtil.go
+++ b/pkg/util/pemUtil.go
@@ -169,7 +169,7 @@ func X509EncryptPEMBlock(rand io.Reader, blockType string, data, password []byte
 	}
 	iv := make([]byte, ciph.blockSize)
 	if _, err := io.ReadFull(rand, iv); err != nil {
-		return nil, fmt.Errorf("x509: cannot generate IV: " + err.Error())
+		return nil, fmt.Errorf("x509: cannot generate IV: %s", err.Error())
 	}
 	// The salt is the first 8 bytes of the initialization vector,
 	// matching the key derivation in DecryptPEMBlock.

--- a/pkg/venafi/cloud/cloudUtil.go
+++ b/pkg/venafi/cloud/cloudUtil.go
@@ -2,6 +2,7 @@ package cloud
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -27,7 +28,7 @@ func parseCertificateInfo(httpStatusCode int, httpStatus string, body []byte) (*
 				for _, e := range respErrors {
 					respError += fmt.Sprintf("Error Code: %d Error: %s\n", e.Code, e.Message)
 				}
-				return nil, fmt.Errorf(respError)
+				return nil, errors.New(respError)
 			}
 		}
 		return nil, fmt.Errorf("unexpected status code on Venafi Cloud certificate search. Status: %s", httpStatus)
@@ -51,7 +52,7 @@ func parseDEKInfo(httpStatusCode int, httpStatus string, body []byte) (*EdgeEncr
 				for _, e := range respErrors {
 					respError += fmt.Sprintf("Error Code: %d Error: %s\n", e.Code, e.Message)
 				}
-				return nil, fmt.Errorf(respError)
+				return nil, errors.New(respError)
 			}
 		}
 		return nil, fmt.Errorf("unexpected status code on VaaS retrieving DEK's info. Status. Status: %s", httpStatus)

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -24,6 +24,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -1045,7 +1046,7 @@ func (c *Connector) getCertificateStatus(requestID string) (certStatus *certific
 		for _, e := range respErrors {
 			respError += fmt.Sprintf("Error Code: %d Error: %s\n", e.Code, e.Message)
 		}
-		return nil, fmt.Errorf(respError)
+		return nil, errors.New(respError)
 	}
 
 	return nil, fmt.Errorf("unexpected status code on Venafi Cloud certificate search. Status: %d", statusCode)
@@ -1297,7 +1298,7 @@ func (c *Connector) getCertificate(certificateId string) (*managedCertificate, e
 				for _, e := range respErrors {
 					respError += fmt.Sprintf("Error Code: %d Error: %s\n", e.Code, e.Message)
 				}
-				return nil, fmt.Errorf(respError)
+				return nil, errors.New(respError)
 			}
 		}
 		return nil, fmt.Errorf("unexpected status code on Venafi Cloud certificate search. Status: %d", statusCode)

--- a/pkg/venafi/cloud/search.go
+++ b/pkg/venafi/cloud/search.go
@@ -18,6 +18,7 @@ package cloud
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"math"
@@ -138,7 +139,7 @@ func ParseCertificateSearchResponse(httpStatusCode int, body []byte) (searchResu
 				for _, e := range respErrors {
 					respError += fmt.Sprintf("Error Code: %d Error: %s\n", e.Code, e.Message)
 				}
-				return nil, fmt.Errorf(respError)
+				return nil, errors.New(respError)
 			}
 		}
 		return nil, fmt.Errorf("unexpected status code on Venafi Cloud certificate search. Status: %d", httpStatusCode)

--- a/pkg/venafi/firefly/connector.go
+++ b/pkg/venafi/firefly/connector.go
@@ -19,6 +19,7 @@ package firefly
 import (
 	"context"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -89,7 +90,7 @@ func (c *Connector) Authenticate(auth *endpoint.Authentication) error {
 	if auth == nil {
 		msg := "failed to authenticate: no credentials provided"
 		zap.L().Error(msg, fieldPlatform)
-		return fmt.Errorf(msg)
+		return errors.New(msg)
 	}
 
 	if auth.AccessToken == "" {
@@ -121,7 +122,7 @@ func (c *Connector) Authorize(auth *endpoint.Authentication) (token *oauth2.Toke
 	if auth == nil {
 		msg := "failed to authenticate: missing credentials"
 		zap.L().Error(msg, fieldPlatform)
-		return nil, fmt.Errorf(msg)
+		return nil, errors.New(msg)
 	}
 
 	successMsg := "successfully authorized to OAuth2 server"
@@ -198,7 +199,7 @@ func (c *Connector) Authorize(auth *endpoint.Authentication) (token *oauth2.Toke
 
 	errMsg := "authorization failed: cannot determine the authorization flow required for the credentials provided"
 	zap.L().Error(errMsg, fieldPlatform)
-	return token, fmt.Errorf(errMsg)
+	return token, errors.New(errMsg)
 }
 
 // SynchronousRequestCertificate It's not supported yet in VaaS

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -113,7 +113,7 @@ func (c *Connector) Ping() (err error) {
 		return
 	}
 	if statusCode != http.StatusOK {
-		err = fmt.Errorf(status)
+		err = errors.New(status)
 	}
 	return
 }
@@ -847,7 +847,7 @@ func (c *Connector) ResetCertificate(req *certificate.Request, restart bool) (er
 		}
 
 		if strings.HasSuffix(decodedResetResponse.Error, "does not exist or you do not have sufficient rights to the object.") {
-			return &ErrCertNotFound{fmt.Errorf(decodedResetResponse.Error)}
+			return &ErrCertNotFound{errors.New(decodedResetResponse.Error)}
 		}
 
 		return fmt.Errorf("while resetting: %s", decodedResetResponse.Error)
@@ -890,7 +890,7 @@ func (c *Connector) GetPolicy(name string) (*policy.PolicySpecification, error) 
 	}
 
 	if checkPolicyResponse.Error != "" {
-		return nil, fmt.Errorf(checkPolicyResponse.Error)
+		return nil, errors.New(checkPolicyResponse.Error)
 	}
 
 	log.Println("Building policy")
@@ -972,7 +972,7 @@ func PolicyExist(policyName string, c *Connector) (bool, error) {
 	} else if (response.Error != "") && (response.Result == 400) {
 		return false, nil
 	} else {
-		return false, fmt.Errorf(response.Error)
+		return false, errors.New(response.Error)
 	}
 
 }
@@ -1994,7 +1994,7 @@ func createPolicyAttribute(c *Connector, at string, av []string, n string, l boo
 	}
 
 	if response.Error != "" {
-		err = fmt.Errorf(response.Error)
+		err = errors.New(response.Error)
 		return statusCode, statusText, body, err
 	}
 
@@ -2158,7 +2158,7 @@ func resetTPPAttribute(c *Connector, at, zone string) error {
 	}
 
 	if response.Error != "" {
-		err = fmt.Errorf(response.Error)
+		err = errors.New(response.Error)
 		return err
 	}
 

--- a/pkg/venafi/tpp/sshCertUtils.go
+++ b/pkg/venafi/tpp/sshCertUtils.go
@@ -18,6 +18,7 @@ package tpp
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -319,7 +320,7 @@ func GetAvailableSshTemplates(c *Connector) ([]certificate.SshAvaliableTemplate,
 		}
 	case http.StatusNotFound:
 		// Return NotFound as this API method is unavailable in SSH Protect versions prior 21.4.0
-		return nil, fmt.Errorf(status)
+		return nil, errors.New(status)
 	default:
 		return nil, fmt.Errorf("error while retriving avaliable SSH templates, error body:%s, status:%s and status code:%v", string(body), status, statusCode)
 	}


### PR DESCRIPTION
- Fixes warning from GolangCI-Lint that states that configurations: "deadcode" and "varcheck" are deprecated and deactivated. Removes from GolangCI Lint configuration accordingly.
- Fixes following lint rules:
  - SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
  - printf: non-constant format string in call to fmt.Errorf (govet)

