### PR TITLE
Add SetAuthentication function to authenticate 'passively'

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -85,6 +85,10 @@ type Connector interface {
 	// SetHTTPClient allows to set custom http.Client to this Connector.
 	SetHTTPClient(client *http.Client)
 	Ping() (err error)
+	// SetAuthentication can be used to set the authentication details for the connector, it does not perform the validation
+	// done by Authenticate. It is useful when you want to set the authentication details without validating them.
+	SetAuthentication(auth *Authentication) (err error)
+	// Authenticate calls SetAuthentication and then validates the authentication details by making a request to the server.
 	// Authenticate is usually called by NewClient and it is not required that you manually call it.
 	Authenticate(auth *Authentication) (err error)
 

--- a/pkg/venafi/cloud/cloud.go
+++ b/pkg/venafi/cloud/cloud.go
@@ -313,7 +313,7 @@ func (c *Connector) getHTTPClient() *http.Client {
 }
 
 func (c *Connector) request(method string, url string, data interface{}, authNotRequired ...bool) (statusCode int, statusText string, body []byte, err error) {
-	if (c.accessToken == "" && c.user == nil) || (c.user != nil && c.user.Company == nil) {
+	if c.accessToken == "" && c.apiKey == "" {
 		if !(len(authNotRequired) == 1 && authNotRequired[0]) {
 			err = fmt.Errorf("%w: must be autheticated to make requests to TLSPC API", verror.VcertError)
 			return

--- a/pkg/venafi/fake/connector.go
+++ b/pkg/venafi/fake/connector.go
@@ -176,6 +176,10 @@ func (c *Connector) Authenticate(auth *endpoint.Authentication) (err error) {
 	return
 }
 
+func (c *Connector) SetAuthentication(auth *endpoint.Authentication) (err error) {
+	return
+}
+
 type fakeRequestID struct {
 	Req *certificate.Request
 	CSR string

--- a/pkg/venafi/firefly/connector.go
+++ b/pkg/venafi/firefly/connector.go
@@ -86,7 +86,20 @@ func (c *Connector) GetType() endpoint.ConnectorType {
 	return endpoint.ConnectorTypeFirefly
 }
 
+// Authenticate authenticates the connector to the Firefly server.
+// In the future, this method will send a request to the Firefly server to validate the authentication.
 func (c *Connector) Authenticate(auth *endpoint.Authentication) error {
+	if err := c.SetAuthentication(auth); err != nil {
+		return err
+	}
+
+	// TODO: use the access token to send a request and validate the authentication.
+
+	return nil
+}
+
+// SetAuthentication sets the authentication details to connect to the Firefly server
+func (c *Connector) SetAuthentication(auth *endpoint.Authentication) error {
 	if auth == nil {
 		msg := "failed to authenticate: no credentials provided"
 		zap.L().Error(msg, fieldPlatform)


### PR DESCRIPTION
When using vcert as a library, being able to create a vcert client without sending a self-check request to the server can help reduce unnecessary API calls.
It gives the caller more control over when the self-checks occur.
Eg. when creating clients dynamically based on cached credentials.
