### PR TITLE
Fix some mentions to the removed `--idp-jwt` that was renamed to `--external-jwt`

### DIFF
--- a/cmd/vcert/validatorsCloud.go
+++ b/cmd/vcert/validatorsCloud.go
@@ -17,10 +17,10 @@ func validateConnectionFlagsCloud(commandName string) error {
 		emailPresent := flags.email != ""
 
 		if tokenURLPresent && !jwtPresent {
-			return fmt.Errorf("missing jwt for service account authentication. Set the jwt using --idp-jwt flag")
+			return fmt.Errorf("missing jwt for service account authentication. Set the jwt using --external-jwt flag")
 		}
 
-		advice := "Use --token-url/--idp-jwt for authentication or --email for registration"
+		advice := "Use --token-url/--external-jwt for authentication or --email for registration"
 		if !svcAccountPresent && !emailPresent {
 			return fmt.Errorf("missing flags for Venafi Cloud Platform authentication. %s", advice)
 		}


### PR DESCRIPTION
In https://github.com/Venafi/vcert/pull/453, the flag `--idp-jwt` was removed and replaced by `--external-jwt`, but some of the error messages still mention `--idp-jwt`. This PR fixes the error messages.