### PR TITLE
Adds Tests Generated Files to Gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,4 @@ credentials
 vendor
 google_auth.json
 .env
-cov_tpp.out
-cov_vaas.out
-cov_firefly.out
-cov_cmd.out
-cov_playbook.out
+*.out

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,9 @@ credentials
 *.DS_Store
 vendor
 google_auth.json
+.env
+cov_tpp.out
+cov_vaas.out
+cov_firefly.out
+cov_cmd.out
+cov_playbook.out


### PR DESCRIPTION
Whenever we run any of the "make test_" there are coverage files that are generated. We don't need to keep track of those file