### PR TITLE
Add missing RSA 3072 bit key size

### DIFF
--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -41,7 +41,7 @@ const (
 )
 
 func AllSupportedKeySizes() []int {
-	return []int{1024, DefaultRSAlength, 4096, 8192}
+	return []int{1024, DefaultRSAlength, 3072, 4096, 8192}
 }
 
 //SSH Certificate structures

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -2002,7 +2002,7 @@ func TestReadPolicyConfiguration(t *testing.T) {
 				[]string{"^Utah$"},
 				[]string{"^Salt Lake$"},
 				[]string{"^US$"},
-				[]endpoint.AllowedKeyConfiguration{{certificate.KeyTypeRSA, []int{2048, 4096, 8192}, nil}},
+				[]endpoint.AllowedKeyConfiguration{{certificate.KeyTypeRSA, []int{2048, 3072, 4096, 8192}, nil}},
 				[]string{`^([\p{L}\p{N}-*]+\.)*vfidev\.com$`, `^([\p{L}\p{N}-*]+\.)*vfidev\.net$`, `^([\p{L}\p{N}-*]+\.)*vfide\.org$`},
 				[]string{".*"},
 				[]string{".*"},

--- a/pkg/venafi/tpp/tpp_test.go
+++ b/pkg/venafi/tpp/tpp_test.go
@@ -311,7 +311,7 @@ func TestConvertServerPolicyToInternalPolicy(t *testing.T) {
 	if k.KeyType != certificate.KeyTypeRSA {
 		t.Fatal("invalid key type")
 	}
-	if len(k.KeySizes) != 3 || k.KeySizes[0] != 2048 || k.KeySizes[1] != 4096 || k.KeySizes[2] != 8192 {
+	if len(k.KeySizes) != 4 || k.KeySizes[0] != 2048 || k.KeySizes[1] != 3072 || k.KeySizes[2] != 4096 || k.KeySizes[3] != 8192 {
 		t.Fatal("bad key lengths")
 	}
 
@@ -399,7 +399,7 @@ func TestConvertServerPolicyToInternalPolicy(t *testing.T) {
 	if k.KeyType != certificate.KeyTypeRSA {
 		t.Fatal("invalid key type")
 	}
-	if len(k.KeySizes) != 3 || k.KeySizes[0] != 2048 || k.KeySizes[1] != 4096 || k.KeySizes[2] != 8192 {
+	if len(k.KeySizes) != 4 || k.KeySizes[0] != 2048 || k.KeySizes[1] != 3072 || k.KeySizes[2] != 4096 || k.KeySizes[3] != 8192 {
 		t.Fatal("bad key lengths")
 	}
 	k = p.AllowedKeyConfigurations[1]


### PR DESCRIPTION
This causes the `.ValidateCertificateRequest()` validation function to fail for 3072 bit RSA keys.