### PR TITLE
Fixes test pipeline issue tpp

### DIFF
--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -2863,6 +2863,9 @@ func TestSetPolicyValuesAndValidate(t *testing.T) {
 func TestCreateSshCertServiceGeneratedKP(t *testing.T) {
 
 	tpp, err := getTestConnector(ctx.TPPurl, ctx.TPPZone)
+	if err != nil {
+		t.Fatalf("err is not nil, err: %s", err)
+	}
 
 	duration := 4
 
@@ -2927,6 +2930,10 @@ func TestCreateSshCertServiceGeneratedKP(t *testing.T) {
 func TestCreateSshCertLocalGeneratedKP(t *testing.T) {
 
 	tpp, err := getTestConnector(ctx.TPPurl, ctx.TPPZone)
+
+	if err != nil {
+		t.Fatalf("err is not nil, err: %s", err)
+	}
 
 	duration := 4
 

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -1827,6 +1827,11 @@ func TestRenewCertRestoringValues(t *testing.T) {
 	req.FetchPrivateKey = true
 	req.KeyPassword = os.Getenv("TPP_PASSWORD")
 
+	req.Timeout = time.Second * 30 // explicitly setting this value here
+	// to make sure we only wait for certificate issuance for 30 seconds because
+	// setting it before the RequestCertificate function, will override
+	// workToDoTimeout to only wait to 30 seconds
+
 	pcc, err := tpp.RetrieveCertificate(req)
 	if err != nil {
 		t.Fatal(err)
@@ -1846,11 +1851,11 @@ func TestRenewCertRestoringValues(t *testing.T) {
 	renewReq := certificate.RenewalRequest{
 		CertificateDN: req.PickupID,
 	}
-	pickupdID, err := tpp.RenewCertificate(&renewReq)
+	pickupID, err := tpp.RenewCertificate(&renewReq)
 	if err != nil {
 		t.Fatal(err)
 	}
-	req = &certificate.Request{PickupID: pickupdID, Timeout: 30 * time.Second}
+	req = &certificate.Request{PickupID: pickupID, Timeout: 30 * time.Second}
 	pcc, err = tpp.RetrieveCertificate(req)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -1814,7 +1814,6 @@ func TestRenewCertRestoringValues(t *testing.T) {
 	req.KeyType = certificate.KeyTypeECDSA
 	req.KeyCurve = certificate.EllipticCurveP521
 	req.CsrOrigin = certificate.ServiceGeneratedCSR
-	req.Timeout = time.Second * 10
 	err = tpp.GenerateRequest(&endpoint.ZoneConfiguration{}, req)
 	if err != nil {
 		t.Fatalf("err is not nil, err: %s", err)
@@ -2288,7 +2287,6 @@ func TestEnrollWithLocation(t *testing.T) {
 
 	req := certificate.Request{}
 	req.Subject.CommonName = cn
-	req.Timeout = time.Second * 10
 	req.Location = &certificate.Location{
 		Instance:   "instance",
 		Workload:   workload,
@@ -2305,7 +2303,6 @@ func TestEnrollWithLocation(t *testing.T) {
 	}
 	req = certificate.Request{}
 	req.Subject.CommonName = cn
-	req.Timeout = time.Second * 10
 	req.Location = &certificate.Location{
 		Instance:   "instance",
 		Workload:   workload,
@@ -2322,7 +2319,6 @@ func TestEnrollWithLocation(t *testing.T) {
 	}
 	req = certificate.Request{}
 	req.Subject.CommonName = cn
-	req.Timeout = time.Second * 10
 	req.Location = &certificate.Location{
 		Instance:   "instance",
 		Workload:   workload,
@@ -2880,7 +2876,6 @@ func TestCreateSshCertServiceGeneratedKP(t *testing.T) {
 	req.ValidityPeriod = fmt.Sprint(duration, "h")
 	req.Template = os.Getenv("TPP_SSH_CA")
 	req.SourceAddresses = []string{"test.com"}
-	req.Timeout = time.Second * 10
 
 	respData, err := tpp.RequestSSHCertificate(req)
 
@@ -2959,7 +2954,6 @@ func TestCreateSshCertLocalGeneratedKP(t *testing.T) {
 	req.ValidityPeriod = fmt.Sprint(duration, "h")
 	req.Template = os.Getenv("TPP_SSH_CA")
 	req.SourceAddresses = []string{"test.com"}
-	req.Timeout = time.Second * 10
 
 	sPubKey := string(pub)
 

--- a/pkg/venafi/tpp/sshCertUtils.go
+++ b/pkg/venafi/tpp/sshCertUtils.go
@@ -57,7 +57,7 @@ func RequestSshCertificate(c *Connector, req *certificate.SshCertRequest) (*cert
 	response, err := parseSshCertOperationResponse(statusCode, status, body)
 
 	if err != nil {
-		if &response != nil && response.Response.ErrorMessage != "" && c.verbose {
+		if response.Response.ErrorMessage != "" && c.verbose {
 			log.Println(util.GetJsonAsString(response.Response))
 		}
 		return nil, err

--- a/pkg/venafi/tpp/sshCertUtils.go
+++ b/pkg/venafi/tpp/sshCertUtils.go
@@ -46,7 +46,9 @@ func RequestSshCertificate(c *Connector, req *certificate.SshCertRequest) (*cert
 	}
 
 	//TODO: Maybe, there is a better way to set the timeout.
-	c.client.Timeout = time.Duration(req.Timeout) * time.Second
+	if req.Timeout > 0 {
+		c.client.Timeout = req.Timeout * time.Second
+	}
 	statusCode, status, body, err := c.request("POST", urlResourceSshCertReq, sshCertReq)
 	if err != nil {
 		return nil, err
@@ -55,7 +57,7 @@ func RequestSshCertificate(c *Connector, req *certificate.SshCertRequest) (*cert
 	response, err := parseSshCertOperationResponse(statusCode, status, body)
 
 	if err != nil {
-		if response.Response.ErrorMessage != "" && c.verbose {
+		if &response != nil && response.Response.ErrorMessage != "" && c.verbose {
 			log.Println(util.GetJsonAsString(response.Response))
 		}
 		return nil, err


### PR DESCRIPTION
Since when we introduced the `workToDoTimeout` attribute to be set for TPP request in VCert, we have had some sporadic issues in tests with the following error:
```
[2024-11-21T09:44:32.149Z]     connector_test.go:2304: Unexpected status code on TPP Certificate Request.
[2024-11-21T09:44:32.149Z]          Status:
[2024-11-21T09:44:32.149Z]          202 Accepted. 
[2024-11-21T09:44:32.149Z]          Body:
[2024-11-21T09:44:32.149Z]         {
    "CertificateDN": "\\VED\\Policy\\<redacted>\\redacted.example.com",
    "Devices": [
        {
            "Applications": [
                {
                    "DN": "\\VED\\Policy\\<redacted>\\instance\\workload-17redacted55"
                }
            ],
            "DN": "\\VED\\Policy\\redacted\\instance"
        }
    ],
    "Error": "Certificate processing took longer than WorkToDoTimeout. Call certificates\/retrieve to get the certificate data",
    "Guid": "{c2XXXXXX-c7XX-4cXX-XXXX-1XXXXXXXXXX7}"
}
```

These tests had a very short timeout of 10 seconds set, which, in case TPP took longer that, our pipeline would fail.

This PR address that issue as well as some minor fixes