### PR TITLE
[FIX] Ensure that the accessToken is set back to the original

### DIFF
--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -281,6 +281,10 @@ func (c *Connector) RevokeAccessToken(auth *endpoint.Authentication) (err error)
 	}
 
 	if auth.AccessToken != "" {
+		// Take a copy of any existing c.accessToken
+		// and Restore after our Revoke for any existing calls
+		origToken := c.accessToken
+		defer func(){ c.accessToken = origToken}
 		c.accessToken = auth.AccessToken
 		statusCode, statusText, _, err := c.request("GET", urlResource(urlResourceRevokeAccessToken), nil)
 		if err != nil {

--- a/pkg/venafi/tpp/connector_test.go
+++ b/pkg/venafi/tpp/connector_test.go
@@ -412,6 +412,21 @@ func TestBadAuthorizeToTPP(t *testing.T) {
 	}
 }
 
+func TestRevokeAccessToken(t *testing.T){
+	tpp, err := getTestConnector(ctx.TPPurl, ctx.TPPZone)
+	if err != nil {
+		t.Fatalf("err is not nil, err: %s url: %s", err, expectedURL)
+	}
+
+	err = tpp.Authenticate(&endpoint.Authentication{AccessToken: ctx.TPPaccessToken})
+	if err != nil {
+		t.Fatalf("err is not nil, err: %s", err)
+	}
+	tpp.RevokeAccessToken(&endpoint.Authentication{AccessToken: "RandomAccessToken"})
+	// Ensure that our own access token is set back!
+	assert.Equal(t, tpp.accessToken, ctx.TPPaccessToken)
+}
+
 func TestReadConfigData(t *testing.T) {
 	tpp, err := getTestConnector(ctx.TPPurl, ctx.TPPZone)
 	if err != nil {


### PR DESCRIPTION
… (or whatever it was set too, before Revoking any other AccessTokens.

While the intended behaviour is that the `RevokeAccessToken` API Call uses the Access Token we want to Revoke, we also don't want to remove any valid access tokens we may already have setup within the vCert Client.