### PR TITLE
security: CWE-94: Prevent YAML injection via environment variables — VC-53766

### DIFF
--- a/pkg/playbook/app/parser/reader.go
+++ b/pkg/playbook/app/parser/reader.go
@@ -109,6 +109,12 @@ func readFile(location string) ([]byte, error) {
 	return data, nil
 }
 
+func yamlSafeScalar(v string) string {
+	v = strings.ReplaceAll(v, "\r", "")
+	v = strings.ReplaceAll(v, "\n", "")
+	return v
+}
+
 func parseConfigTemplate(b []byte) ([]byte, error) {
 	// Valid functions for the config file template
 	fm := template.FuncMap{
@@ -117,7 +123,7 @@ func parseConfigTemplate(b []byte) ([]byte, error) {
 				e := es[0]
 				value, found := os.LookupEnv(e)
 				if found {
-					return value, nil
+					return yamlSafeScalar(value), nil
 				}
 				return "", fmt.Errorf("environment variable not defined: %s", e)
 			} else if len(es) == 2 {
@@ -125,9 +131,9 @@ func parseConfigTemplate(b []byte) ([]byte, error) {
 				d := es[1]
 				value, found := os.LookupEnv(e)
 				if found {
-					return value, nil
+					return yamlSafeScalar(value), nil
 				} else {
-					return d, nil
+					return yamlSafeScalar(d), nil
 				}
 			} else {
 				return "", fmt.Errorf("unsupported number of inputs provided: %d", len(es))


### PR DESCRIPTION
## Summary

Fix CWE-94 vulnerability that allowed YAML structure injection through unsanitized environment variables in playbook template parsing.

## Finding

**CWE-94 / CWE-74: Improper Control of Generation of Code**  
**CVSS: 7.3 (CVSS:4.0/AV:L/AC:L/AT:P/PR:L/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N)**

The `parseConfigTemplate()` function in `pkg/playbook/app/parser/reader.go` substituted raw environment variable values from `os.LookupEnv()` directly into YAML byte streams before unmarshalling, without YAML-escaping. This allowed an attacker who controls a referenced environment variable to inject newlines, close the enclosing scalar, and append arbitrary YAML structure that could reach `util.ExecuteScript()` → `exec.Command("sh","-c", afterAction)` as the playbook process user.

## Remediation

Added `yamlSafeScalar()` helper function that strips carriage returns (`\r`) and newlines (`\n`) from all values before they are substituted into the YAML template:

- Wrapped all three return paths in the `Env` template function with `yamlSafeScalar()`
- Applied to both environment variable lookups and default values
- Prevents YAML structure injection by neutralizing line break characters

## Verification

Changes limited to `pkg/playbook/app/parser/reader.go`:
- 1 file changed
- 9 insertions, 3 deletions
- No refactoring or unrelated changes

The fix applies minimal sanitization focused solely on preventing YAML structure injection via the `Env` template function.