### PR TITLE
security: CWE-732: Preserve file permissions in backup copies — VC-53765

### DIFF
--- a/pkg/playbook/util/filehelper.go
+++ b/pkg/playbook/util/filehelper.go
@@ -81,7 +81,7 @@ func CopyFile(source string, destination string) error {
 	}
 	defer sourceFile.Close()
 
-	destinationFile, err := os.Create(destination)
+	destinationFile, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, sourceFileStat.Mode().Perm())
 	if err != nil {
 		zap.L().Error("failed to create/truncate file", zap.String("file", destination), zap.Error(err))
 		return err


### PR DESCRIPTION
## Summary

Fixes CWE-732: Backup files created with world-readable permissions instead of preserving source file's restrictive permissions.

## Finding

When `backupFiles: true` is set in playbook installations, the `util.CopyFile()` function creates backup files (e.g., `<keyFile>.bak`) with default permissions (0644), making private keys, PKCS#12 bundles, and JKS files world-readable to any local user.

The root cause is in `pkg/playbook/util/filehelper.go:84` where `os.Create(destination)` uses mode 0666 &^ umask (typically 0644) instead of preserving the source file's 0600 permissions.

## Remediation

Changed `os.Create(destination)` to `os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, sourceFileStat.Mode().Perm())` to preserve the source file's permissions when creating backup copies.

This ensures backup files inherit the same restrictive permissions (0600) as the original private key files.

## Verification

The fix modifies only the file creation mode in `CopyFile()` to preserve source permissions. The `sourceFileStat` variable (obtained at line 65) is now used to extract and apply the source file's permission bits.

Files affected:
- `pkg/playbook/util/filehelper.go`: 1 line changed