### PR TITLE
security: CWE-326: Replace DES with AES256 for SSH legacy PEM encryption — VC-53763

### DIFF
--- a/pkg/util/sshKeyGenerator.go
+++ b/pkg/util/sshKeyGenerator.go
@@ -41,7 +41,7 @@ func encodePrivKeyToPEM(privateKey *rsa.PrivateKey, keyPassword string, format .
 	if keyPassword != "" {
 		if format[0] == LegacyPem {
 			privDER := x509.MarshalPKCS1PrivateKey(privateKey)
-			privBlock, err = X509EncryptPEMBlock(rand.Reader, RsaPrivKeyType, privDER, []byte(keyPassword), PEMCipherDES)
+			privBlock, err = X509EncryptPEMBlock(rand.Reader, RsaPrivKeyType, privDER, []byte(keyPassword), PEMCipherAES256)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Summary

Replaces weak single-DES (56-bit) encryption with AES-256 for SSH RSA private keys when using `--format legacy-pem` in `vcert sshenroll`.

## Finding

**CWE-326 / CWE-327**: `encodePrivKeyToPEM()` in `pkg/util/sshKeyGenerator.go` was hard-coded to use `PEMCipherDES` (single 56-bit DES) when encrypting SSH RSA private keys with the `legacy-pem` format. This cipher is cryptographically weak and susceptible to exhaustive key search regardless of passphrase strength.

The vulnerable line at `pkg/util/sshKeyGenerator.go:44` used:
```go
X509EncryptPEMBlock(rand.Reader, RsaPrivKeyType, privDER, []byte(keyPassword), PEMCipherDES)
```

## Remediation

Changed the cipher parameter from `PEMCipherDES` to `PEMCipherAES256` to align with the encryption used in all other legacy-PEM code paths in the codebase (e.g., `pkg/util/utils.go:77,82`).

**Changed file:**
- `pkg/util/sshKeyGenerator.go`: Line 44 - replaced `PEMCipherDES` with `PEMCipherAES256`

## Verification

This is a minimal, single-token change that upgrades the encryption cipher from 56-bit DES to 256-bit AES for password-protected SSH private keys in legacy PEM format, matching the existing security standard used elsewhere in the codebase.

---
*Auto-generated by Project Logos Pattern-C remediation (VC-53763)*