### PR TITLE
security: CWE-1336: Reject TPP tokens containing template delimiters — VC-53761

### DIFF
--- a/pkg/playbook/app/service/tokenService.go
+++ b/pkg/playbook/app/service/tokenService.go
@@ -18,6 +18,7 @@ package service
 
 import (
 	"fmt"
+	"strings"
 
 	"go.uber.org/zap"
 
@@ -104,6 +105,14 @@ func replaceTokensInFile(playbook map[string]interface{}, accessToken string, re
 	}
 
 	credsMap := creds.(map[string]interface{})
+
+	// Reject tokens containing template delimiters to prevent template injection
+	for _, tok := range []string{accessToken, refreshToken} {
+		if strings.Contains(tok, "{{") || strings.Contains(tok, "}}") {
+			return fmt.Errorf("refusing to persist token containing template delimiters")
+		}
+	}
+
 	credsMap["accessToken"] = accessToken
 	credsMap["refreshToken"] = refreshToken
 


### PR DESCRIPTION
## Summary

This PR fixes CWE-1336: TPP token template injection vulnerability in the playbook token persistence logic.

## Finding

**CWE-1336 / CWE-94 - Improper Neutralization of Special Elements Used in a Template Engine**

The `ValidateTPPCredentials()` function writes TPP server's `access_token` and `refresh_token` JSON fields verbatim into the on-disk playbook YAML via `replaceTokensInFile()` and `parser.WritePlaybook()`. Subsequently, `parser.ReadPlaybook()` evaluates the YAML file through `text/template` with an `Env` FuncMap. A malicious TPP server could inject template expressions like `{{Env "NAME"}}` in tokens, causing environment variables on the playbook host to be rendered and potentially exfiltrated back to the attacker on the next run.

**CVSS 8.2** (CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N)

**Root Cause:** `pkg/playbook/app/service/tokenService.go:107-108` stores server-controlled bytes without filtering `{{` or `}}` template delimiters. `pkg/playbook/app/parser/reader.go:137,145` evaluates the full file with `Env`/`Hostname` FuncMap before YAML unmarshaling.

## Remediation

Added validation in `replaceTokensInFile()` to reject any token containing `{{` or `}}` before persisting to the playbook file. Since legitimate TPP tokens are base64url-encoded, template delimiters can never appear in valid tokens.

The fix adds a validation loop that checks both `accessToken` and `refreshToken` for template delimiters and returns an error if found, preventing the injection attack vector.

## Verification

- Modified `pkg/playbook/app/service/tokenService.go` to add delimiter validation
- Added `strings` import for `strings.Contains` check
- Changes are minimal and focused solely on the injection vulnerability