### PR TITLE
Fix error wrapping to preserve network error types

### DIFF
--- a/pkg/venafi/cloud/cloud.go
+++ b/pkg/venafi/cloud/cloud.go
@@ -343,7 +343,7 @@ func (c *Connector) request(method string, url string, data interface{}, authNot
 
 	r, err := http.NewRequest(method, url, payload)
 	if err != nil {
-		err = fmt.Errorf("%w: %v", verror.VcertError, err)
+		err = fmt.Errorf("%w: %w", verror.VcertError, err)
 		return
 	}
 
@@ -366,7 +366,7 @@ func (c *Connector) request(method string, url string, data interface{}, authNot
 
 	res, err := httpClient.Do(r)
 	if err != nil {
-		err = fmt.Errorf("%w: %v", verror.ServerUnavailableError, err)
+		err = fmt.Errorf("%w: %w", verror.ServerUnavailableError, err)
 		return
 	}
 	statusCode = res.StatusCode
@@ -375,7 +375,7 @@ func (c *Connector) request(method string, url string, data interface{}, authNot
 	defer res.Body.Close()
 	body, err = io.ReadAll(res.Body)
 	if err != nil {
-		err = fmt.Errorf("%w: %v", verror.ServerError, err)
+		err = fmt.Errorf("%w: %w", verror.ServerError, err)
 	}
 
 	if c.verbose {

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -712,7 +712,7 @@ func (c *Connector) ImportCertificate(req *certificate.ImportRequest) (*certific
 	url := c.getURL(urlResourceCertificates)
 	statusCode, status, body, err := c.request("POST", url, request)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", verror.ServerTemporaryUnavailableError, err)
+		return nil, fmt.Errorf("%w: %w", verror.ServerTemporaryUnavailableError, err)
 	}
 	var r importResponse
 	switch statusCode {
@@ -1001,7 +1001,7 @@ func (c *Connector) GetAccessToken(auth *endpoint.Authentication) (*TLSPCAccessT
 
 	r, err := http.NewRequest(http.MethodPost, url, strings.NewReader(body.Encode()))
 	if err != nil {
-		err = fmt.Errorf("%w: %v", verror.VcertError, err)
+		err = fmt.Errorf("%w: %w", verror.VcertError, err)
 		return nil, err
 	}
 	r.Header.Set(headers.UserAgent, c.userAgent)
@@ -1010,7 +1010,7 @@ func (c *Connector) GetAccessToken(auth *endpoint.Authentication) (*TLSPCAccessT
 	httpClient := c.getHTTPClient()
 	resp, err := httpClient.Do(r)
 	if err != nil {
-		err = fmt.Errorf("%w: %v", verror.ServerUnavailableError, err)
+		err = fmt.Errorf("%w: %w", verror.ServerUnavailableError, err)
 		return nil, err
 	}
 
@@ -1020,7 +1020,7 @@ func (c *Connector) GetAccessToken(auth *endpoint.Authentication) (*TLSPCAccessT
 	defer resp.Body.Close()
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		err = fmt.Errorf("%w: %v", verror.ServerError, err)
+		err = fmt.Errorf("%w: %w", verror.ServerError, err)
 		return nil, err
 	}
 

--- a/pkg/venafi/ngts/cloud.go
+++ b/pkg/venafi/ngts/cloud.go
@@ -348,7 +348,7 @@ func (c *Connector) request(method string, url string, data interface{}, authNot
 
 	r, err := http.NewRequest(method, url, payload)
 	if err != nil {
-		err = fmt.Errorf("%w: %v", verror.VcertError, err)
+		err = fmt.Errorf("%w: %w", verror.VcertError, err)
 		return
 	}
 
@@ -371,7 +371,7 @@ func (c *Connector) request(method string, url string, data interface{}, authNot
 
 	res, err := httpClient.Do(r)
 	if err != nil {
-		err = fmt.Errorf("%w: %v", verror.ServerUnavailableError, err)
+		err = fmt.Errorf("%w: %w", verror.ServerUnavailableError, err)
 		return
 	}
 	statusCode = res.StatusCode
@@ -380,7 +380,7 @@ func (c *Connector) request(method string, url string, data interface{}, authNot
 	defer res.Body.Close()
 	body, err = io.ReadAll(res.Body)
 	if err != nil {
-		err = fmt.Errorf("%w: %v", verror.ServerError, err)
+		err = fmt.Errorf("%w: %w", verror.ServerError, err)
 	}
 
 	if c.verbose {

--- a/pkg/venafi/ngts/connector.go
+++ b/pkg/venafi/ngts/connector.go
@@ -853,7 +853,7 @@ func (c *Connector) ImportCertificate(req *certificate.ImportRequest) (*certific
 	url := c.getURL(urlResourceCertificates)
 	statusCode, status, body, err := c.request("POST", url, request)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", verror.ServerTemporaryUnavailableError, err)
+		return nil, fmt.Errorf("%w: %w", verror.ServerTemporaryUnavailableError, err)
 	}
 	var r importResponse
 	switch statusCode {
@@ -1135,7 +1135,7 @@ func (c *Connector) GetAccessToken(auth *endpoint.Authentication) (*AccessTokenR
 
 	r, err := http.NewRequest(http.MethodPost, url, strings.NewReader(body.Encode()))
 	if err != nil {
-		err = fmt.Errorf("%w: %v", verror.VcertError, err)
+		err = fmt.Errorf("%w: %w", verror.VcertError, err)
 		return nil, err
 	}
 	r.Header.Set(headers.UserAgent, c.userAgent)
@@ -1145,7 +1145,7 @@ func (c *Connector) GetAccessToken(auth *endpoint.Authentication) (*AccessTokenR
 	httpClient := c.getHTTPClient()
 	resp, err := httpClient.Do(r)
 	if err != nil {
-		err = fmt.Errorf("%w: %v", verror.ServerUnavailableError, err)
+		err = fmt.Errorf("%w: %w", verror.ServerUnavailableError, err)
 		return nil, err
 	}
 
@@ -1155,7 +1155,7 @@ func (c *Connector) GetAccessToken(auth *endpoint.Authentication) (*AccessTokenR
 	defer resp.Body.Close()
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		err = fmt.Errorf("%w: %v", verror.ServerError, err)
+		err = fmt.Errorf("%w: %w", verror.ServerError, err)
 		return nil, err
 	}
 


### PR DESCRIPTION
## Problem

We aren't able to distinguish the error type (e.g., `*url.Error` or `*net.OpError`) when VCert returns an error during authentication. That's because the err format strings use `%v` instead of `%w`.

## Solution

Very straightforward:

```diff
-err = fmt.Errorf("%w: %v", verror.ServerUnavailableError, err)
+err = fmt.Errorf("%w: %w", verror.ServerUnavailableError, err)
```

Fixes #664