### PR TITLE
fix: VC-55689 render certificate validity as ISO-8601 day form

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -28,6 +28,35 @@ func ConvertSecondsToTime(t int64) time.Time {
 	return time.Unix(0, t*int64(time.Second))
 }
 
+// FormatValidityPeriodISO8601 renders a certificate validity duration as an ISO-8601 period
+// string for CyberArk Certificate Manager, SaaS (VaaS) and NGTS certificate requests.
+//
+// Whole days are emitted in day form ("P<days>D"); a sub-day remainder is appended as a time
+// component ("P<days>DT<h>H<m>M<s>S"); a purely sub-day duration keeps the time-only form
+// ("PT<h>H<m>M<s>S"). The duration is truncated to whole seconds. A non-positive duration
+// yields an empty string so the caller omits the field and the server applies its default.
+//
+// The day component is required for third-party CA connectors such as ZTPKI, which honor the
+// requested validity only when the period carries days — an hours-only period like
+// "PT2160H0M0S" is silently ignored and the CA falls back to the issuing-template default
+// (VC-55689). The built-in CA honors either form, so day form is safe for all backends.
+func FormatValidityPeriodISO8601(d time.Duration) string {
+	d = d.Truncate(time.Second)
+	if d <= 0 {
+		return ""
+	}
+	days := int64(d / (24 * time.Hour))
+	remainder := d % (24 * time.Hour)
+	switch {
+	case days == 0:
+		return "PT" + strings.ToUpper(remainder.String())
+	case remainder == 0:
+		return fmt.Sprintf("P%dD", days)
+	default:
+		return fmt.Sprintf("P%dDT%s", days, strings.ToUpper(remainder.String()))
+	}
+}
+
 func GetJsonAsString(i interface{}) (s string) {
 	byte, _ := json.MarshalIndent(i, "", "  ")
 	s = string(byte)

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -1,0 +1,51 @@
+package util
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFormatValidityPeriodISO8601(t *testing.T) {
+	day := 24 * time.Hour
+	cases := []struct {
+		name string
+		in   time.Duration
+		want string
+	}{
+		// Whole days -> day form (the VC-55689 fix: ZTPKI honors P<days>D, not PT<hours>H).
+		{"1 day", 1 * day, "P1D"},
+		{"30 days (terraform valid_days=30)", 30 * day, "P30D"},
+		{"90 days", 90 * day, "P90D"},
+		{"365 days", 365 * day, "P365D"},
+		{"397 days", 397 * day, "P397D"},
+		{"1 day via hours", 24 * time.Hour, "P1D"},
+		{"30 days via hours (valid_days*24)", 720 * time.Hour, "P30D"},
+
+		// Sub-day only -> time-only form (unchanged from previous behavior; built-in honors it).
+		{"12 hours", 12 * time.Hour, "PT12H0M0S"},
+		{"90 minutes", 90 * time.Minute, "PT1H30M0S"},
+		{"30 seconds", 30 * time.Second, "PT30S"},
+
+		// Days + sub-day remainder -> combined form (day component honored by ZTPKI).
+		{"1 day 12 hours", day + 12*time.Hour, "P1DT12H0M0S"},
+		{"1 day 1 hour", day + 1*time.Hour, "P1DT1H0M0S"},
+		{"30 days 30 minutes", 30*day + 30*time.Minute, "P30DT30M0S"},
+		{"1 day 2 hours 3 minutes 4 seconds", day + 2*time.Hour + 3*time.Minute + 4*time.Second, "P1DT2H3M4S"},
+
+		// Truncated to whole seconds.
+		{"30 days + sub-second", 30*day + 999*time.Millisecond, "P30D"},
+		{"500ms", 500 * time.Millisecond, ""},
+
+		// Non-positive -> empty (field omitted, server default applies).
+		{"zero", 0, ""},
+		{"negative", -5 * time.Hour, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := FormatValidityPeriodISO8601(c.in)
+			if got != c.want {
+				t.Errorf("FormatValidityPeriodISO8601(%s) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -1113,7 +1113,9 @@ func (c *Connector) getCloudRequest(req *certificate.Request) (*certificateReque
 	}
 
 	if validityDuration != nil {
-		cloudReq.ValidityPeriod = "PT" + strings.ToUpper((*validityDuration).Truncate(time.Second).String())
+		// Day form ("P<days>D") — third-party CAs such as ZTPKI ignore an hours-only period
+		// ("PT<hours>H") and fall back to the template default (VC-55689).
+		cloudReq.ValidityPeriod = util.FormatValidityPeriodISO8601(*validityDuration)
 	}
 
 	if req.Tags != nil && len(req.Tags) > 0 {

--- a/pkg/venafi/cloud/connector_test.go
+++ b/pkg/venafi/cloud/connector_test.go
@@ -2667,4 +2667,12 @@ func TestGetCloudRequest(t *testing.T) {
 		assert.NotNil(t, cloudReq)
 		assert.Equal(t, tags, cloudReq.Tags)
 	})
+	t.Run("validity hours rendered as ISO-8601 day form (VC-55689)", func(t *testing.T) {
+		req.ValidityHours = 720 //nolint:staticcheck // deprecated field; the terraform provider sets valid_days*24
+		cloudReq, _ := conn.getCloudRequest(&req)
+		req.ValidityHours = 0 //nolint:staticcheck
+		assert.NotNil(t, cloudReq)
+		// ZTPKI honors day form ("P30D"), not hours form ("PT720H0M0S") — see VC-55689.
+		assert.Equal(t, "P30D", cloudReq.ValidityPeriod)
+	})
 }

--- a/pkg/venafi/ngts/connector.go
+++ b/pkg/venafi/ngts/connector.go
@@ -1312,7 +1312,9 @@ func (c *Connector) getCloudRequest(req *certificate.Request) (*certificateReque
 	}
 
 	if validityDuration != nil {
-		cloudReq.ValidityPeriod = "PT" + strings.ToUpper((*validityDuration).Truncate(time.Second).String())
+		// Day form ("P<days>D") — third-party CAs such as ZTPKI ignore an hours-only period
+		// ("PT<hours>H") and fall back to the template default (VC-55689).
+		cloudReq.ValidityPeriod = util.FormatValidityPeriodISO8601(*validityDuration)
 	}
 
 	if req.Tags != nil && len(req.Tags) > 0 {

--- a/pkg/venafi/ngts/connector_test.go
+++ b/pkg/venafi/ngts/connector_test.go
@@ -3064,6 +3064,14 @@ func TestGetCloudRequest(t *testing.T) {
 		assert.NotNil(t, cloudReq)
 		assert.Equal(t, tags, cloudReq.Tags)
 	})
+	t.Run("validity hours rendered as ISO-8601 day form (VC-55689)", func(t *testing.T) {
+		req.ValidityHours = 720 //nolint:staticcheck // deprecated field; the terraform provider sets valid_days*24
+		cloudReq, _ := conn.getCloudRequest(&req)
+		req.ValidityHours = 0 //nolint:staticcheck
+		assert.NotNil(t, cloudReq)
+		// ZTPKI honors day form ("P30D"), not hours form ("PT720H0M0S") — see VC-55689.
+		assert.Equal(t, "P30D", cloudReq.ValidityPeriod)
+	})
 }
 
 func TestCalculateBackoffWithJitter(t *testing.T) {


### PR DESCRIPTION
VaaS and NGTS connectors serialized the requested validity as an hours-only ISO-8601 period (PT<hours>H0M0S). Third-party CAs such as ZTPKI silently ignore an hours-only period and fall back to the issuing-template default, so the requested validity had no effect.

Add util.FormatValidityPeriodISO8601, which emits day form (P<days>D) for whole days and uses a time component only for sub-day remainders; call it from both connectors' getCloudRequest. The built-in CA honors either form, so day form is safe for all backends.

Verified end-to-end against ZTPKI on both platforms (dev251): issued validity now tracks the request instead of the template default.